### PR TITLE
More agressive choice mapping

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -64,9 +64,6 @@ function elementTypeContainsTypeName(elementType, typeName) {
     if (t.code == typeName
         || t.profile == `http://hl7.org/fhir/StructureDefinition/${typeName}`
         || (t.code == 'Reference' && t.targetProfile == `http://hl7.org/fhir/StructureDefinition/${typeName}`)) {
-      // Add a special marker so we know this choice type is being used.  Later, if we find choices that have
-      // a selected SHR choice, we know to profile out the unselected choices
-      t._shrSelected = true;
       return true;
     }
   }

--- a/lib/export.js
+++ b/lib/export.js
@@ -478,7 +478,7 @@ class FHIRExporter {
     }
 
     this.processFieldToFieldCardinality(map, rule, profile, ss, df);
-    this.processFieldToFieldType(def, rule, profile, ss, df);
+    this.processFieldToFieldType(map, def, rule, profile, ss, df);
 
     if (dfIsNew && Object.keys(df).length > 2) {
       profile.differential.element.push(df);
@@ -772,9 +772,9 @@ class FHIRExporter {
     }
   }
 
-  processFieldToFieldType(def, rule, profile, snapshotEl, differentialEl) {
+  processFieldToFieldType(map, def, rule, profile, snapshotEl, differentialEl) {
     const sourceValue = this.findValueByPath(rule.sourcePath, def);
-    const matchedPaths = this.processValueToFieldType(rule.sourcePath, sourceValue, profile, snapshotEl, differentialEl);
+    const matchedPaths = this.processValueToFieldType(map, rule.sourcePath, sourceValue, profile, snapshotEl, differentialEl);
     if (!(snapshotEl.type.length == 1 && snapshotEl.type[0].code == 'BackboneElement')) {
       if (matchedPaths) {
         for (const mp of matchedPaths) {
@@ -827,7 +827,7 @@ class FHIRExporter {
     return allowedTargetTypes;
   }
 
-  processValueToFieldType(sourcePath, sourceValue, profile, snapshotEl, differentialEl) {
+  processValueToFieldType(map, sourcePath, sourceValue, profile, snapshotEl, differentialEl) {
     const clonedPath = sourcePath.map(p => p.clone());
     const sourceIdentifier = sourceValue.effectiveIdentifier;
     const targetTypes = snapshotEl.type;
@@ -857,58 +857,90 @@ class FHIRExporter {
       return [clonedPath];
     }
 
+    const matchedPaths = [];
+
     // Check if the source field has a mapping to a FHIR profile.  If so, and it matches target, apply the profile to the target
     const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
     if (typeof sourceMap !== 'undefined') {
-      let match = false;
+      let matchedType;
+      const profileURL = common.fhirURL(sourceMap.identifier);
       const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
       const allowableTargetProfiles = allowableTargetTypes.map(t => `http://hl7.org/fhir/StructureDefinition/${t}`);
       for (const t of targetTypes) {
-        if (allowableTargetTypes.includes(t.code)) {
-          match = true;
-          t.profile = common.fhirURL(sourceMap.identifier);
-          this.markSelectedOptionsInChoice(targetTypes, [t]);
-          break;
-        } else if (allowableTargetProfiles.includes(t.profile)) {
-          match = true;
-          t.profile = common.fhirURL(sourceMap.identifier);
-          this.markSelectedOptionsInChoice(targetTypes, [t]);
+        if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(t.profile)) {
+          matchedType = t;
+          // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
+          if (!this.optionIsSelected(t)) {
+            t.profile = profileURL;
+            this.markSelectedOptionsInChoice(targetTypes, [t]);
+          }
           break;
         } else if (t.code == 'Reference' && allowableTargetProfiles.includes(t.targetProfile)) {
-          match = true;
-          t.targetProfile = common.fhirURL(sourceMap.identifier);
-          this.markSelectedOptionsInChoice(targetTypes, [t]);
+          matchedType = t;
+          // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
+          if (!this.optionIsSelected(t)) {
+            t.targetProfile = profileURL;
+            this.markSelectedOptionsInChoice(targetTypes, [t]);
+          }
           break;
         }
       }
-      if (match) {
-        // We modified the types, so we need to apply the differential
-        differentialEl.type = snapshotEl.type;
-        this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false);
-        return [clonedPath];
+
+      if (typeof matchedType !== 'undefined') {
+        // We got a match!
+        // Check to see if this is trying to map a different element than the one that was previously mapped.
+        const mappedProfile = typeof matchedType.profile !== 'undefined' ? matchedType.profile : matchedType.targetProfile;
+        if (profileURL != mappedProfile) {
+          // It's trying to map a different element than the one that was previously mapped.  Conflict!
+          logger.warn('Trying to map %s to %s, but %s was previously mapped to it', profileURL, matchedType.code, mappedProfile);
+        } else {
+          // We successfully mapped the type, so we need to apply the differential and constraints
+          differentialEl.type = snapshotEl.type;
+          this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false);
+          matchedPaths.push(clonedPath);
+        }
+      } else {
+        const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
+        if (allowedConvertedTypes.length > 0) {
+          this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
+          this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl);
+          matchedPaths.push(clonedPath);
+        }
       }
-      const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
-      if (allowedConvertedTypes.length > 0) {
-        this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
-        this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl);
-        return [clonedPath];
-      }
-      // It didn't have a match, so keep going to see if we can map on value instead
-      // TODO: Determine if this really is the right approach (to fall through and keep going)
     }
 
-    // If we got here, we still don't have a match, so now try the source's Value
+    // If we have a match for each type (in this case, 1 each), then we can return the match now
+    if (matchedPaths.length == targetTypes.length) {
+      return matchedPaths;
+    }
+
+    // If we still don't have a match, or if we have a match but the target is a choice, try to map the source's Value
     const sourceEl = this._specs.dataElements.findByIdentifier(sourceIdentifier);
     if (sourceEl && sourceEl.value) {
+      // If the element has any unmapped required fields, then it's not appropriate to map the value
+      if (matchedPaths.length > 0) {
+        // Loop through the fields, looking for required fields
+        for (const field of sourceEl.fields) {
+          if (field.effectiveCard.min != 0) {
+            // It's required so check to see if it is mapped or not.
+            const fullPath = [...clonedPath, field.identifier];
+            if (!map.rulesFilter.withSourcePath(fullPath).hasRules) {
+              // No mapping rules exist for this required field, so it's not appropriate to map the value
+              return matchedPaths.length > 0 ? matchedPaths : undefined;
+            }
+          }
+        }
+      }
+
+      // It's potentially appropriate to map the value
       if (sourceEl.value instanceof mdls.IdentifiableValue) {
         const mergedValue = this.mergeConstraintsToChild(sourceValue, sourceEl.value, true);
         const newPath = [...clonedPath, mergedValue.effectiveIdentifier];
-        return this.processValueToFieldType(newPath, mergedValue, profile, snapshotEl, differentialEl);
+        const valMatchedPaths = this.processValueToFieldType(map, newPath, mergedValue, profile, snapshotEl, differentialEl);
+        if (typeof valMatchedPaths !== 'undefined') {
+          matchedPaths.push(...valMatchedPaths);
+        }
       } else if (sourceEl.value instanceof mdls.ChoiceValue) {
-        // TODO: Rather than returning on the first match, we really *should* be trying to map as many of the
-        // fields in the choice as we can.  This limitation also causes us to report more unmatched paths than
-        // are really the case.
-        const matchedPaths = [];
         for (const opt of sourceEl.value.aggregateOptions) {
           if (opt instanceof mdls.IdentifiableValue) {
             // First merge the choicevalue onto the option value (TODO: Will this work right w/ aggregate options?)
@@ -916,7 +948,7 @@ class FHIRExporter {
             // Then merge the sourceValue onto the merged option value
             mergedValue = this.mergeConstraintsToChild(sourceValue, mergedValue);
             const newPath = [...clonedPath, mergedValue.effectiveIdentifier];
-            const optMatchedPaths = this.processValueToFieldType(newPath, mergedValue, profile, snapshotEl, differentialEl);
+            const optMatchedPaths = this.processValueToFieldType(map, newPath, mergedValue, profile, snapshotEl, differentialEl);
             if (optMatchedPaths) {
               let loggedWarning = false; // Only need to log the warning once per choice
               for (const omp of optMatchedPaths) {
@@ -932,14 +964,10 @@ class FHIRExporter {
             }
           }
         }
-        if (matchedPaths.length > 0) {
-          return matchedPaths;
-        }
       }
     }
 
-    // No match at all
-    return undefined;
+    return matchedPaths.length > 0 ? matchedPaths : undefined;
   }
 
   markSelectedOptionsInChoice(allTypes, selectedTypes) {
@@ -949,6 +977,10 @@ class FHIRExporter {
         t._shrSelected = true;
       }
     }
+  }
+
+  optionIsSelected(option) {
+    return option._shrSelected === true;
   }
 
   getTypeHierarchy(fhirType) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
When mapping against choices, try to map to as many as possible by attempting to map the source's value as well.  For example, in MedicationPrescription, mapping to medication[x] should map the Medication element *and* the CodeableConcept (which is the Medication's value).  Prior to this it only mapped the Medication and then stopped.