### PR TITLE
Support Expanded Choice Value Mappings

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -479,6 +479,12 @@ class FHIRExporter {
       this.unrollContentReference(profile, ss);
     }
 
+    const sourceValue = this.findValueByPath(rule.sourcePath, def);
+    if (typeof sourceValue === 'undefined') {
+      // This only happens in cases where a base class defined a mapping, but the subclass
+      // constrained out that path so it no longer exists.  So... we can safely ignore it!
+      return;
+    }
     this.processFieldToFieldCardinality(map, rule, profile, ss, df);
     this.processFieldToFieldType(map, def, rule, profile, ss, df);
 
@@ -788,18 +794,21 @@ class FHIRExporter {
     }
     if (typeof matchedPaths === 'undefined') {
       // collect some info for an AWESOME error message
-      const value = this._specs.dataElements.findByIdentifier(sourceValue.effectiveIdentifier).value;
-      let valueStr = '';
-      if (value instanceof mdls.IdentifiableValue) {
-        valueStr = value.identifier.fqn;
-      } else if (value) {
-        valueStr = value.toString();
+      let sourceString = sourceValue.effectiveIdentifier;
+      if (!sourceValue.effectiveIdentifier.isPrimitive) {
+        const value = this._specs.dataElements.findByIdentifier(sourceValue.effectiveIdentifier).value;
+        if (value instanceof mdls.IdentifiableValue) {
+          sourceString += `[Value: ${value.identifier.fqn}]`;
+        } else if (value) {
+          sourceString += `[Value: ${value.toString()}]`;
+        }
       }
+
       const sMapsTo = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceValue.effectiveIdentifier);
       if (sMapsTo) {
-        valueStr += ` (mapped to ${sMapsTo.targetItem})`;
+        sourceString += ` (mapped to ${sMapsTo.targetItem})`;
       }
-      logger.error('Mismatched types. Cannot map %s to %s.', valueStr, typesToString(snapshotEl.type));
+      logger.error('Mismatched types. Cannot map %s to %s.', sourceString, typesToString(snapshotEl.type));
     }
     return;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
When a mapping uses the special "Value" word in its path, and that value is actually a choice, the expander will now expand that into a new mapping rule per choice option.

One result is that we now have to handle the case that if a subclass constrains out some choices, we need to ignore any inherited mappings that might still refer to those choices.