### PR TITLE
Fix bugs when few mappings provided

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1288,7 +1288,10 @@ class FHIRExporter {
     if (!profile.snapshot.element.some(e => e.id == (`${snapshotEl.id}.id`))) {
       this.unrollElement(shrPath[0], profile, snapshotEl);
     }
-    const isSimple = profile.snapshot.element.find(e => e.id.startsWith(`${snapshotEl.id}.value`)).max == '1';
+    // If it's a simple extension, it will have a value element that is not zeroed out
+    // If it's not an extension, or the value element is zeroed out, we need to dig deeper
+    const valueEl = profile.snapshot.element.find(e => e.id.startsWith(`${snapshotEl.id}.value`));
+    const isSimple = typeof valueEl !== 'undefined' && valueEl.max == '1';
     let el;
     if (isSimple) {
       // There's really only one place to find it: the value element
@@ -1721,6 +1724,11 @@ class FHIRExporter {
       if (typeof mapping !== 'undefined') {
         // Warning -- there CAN be a circular dependency here -- so watch out!  I warned you...
         p = this.mappingToProfile(mapping);
+      } else {
+        // This must be an Element that has no mapping provided, so... map to Basic
+        const basicMapping = new mdls.ElementMapping(identifier, TARGET, 'Basic');
+        this._specs.maps.add(basicMapping);
+        p = this.mappingToProfile(basicMapping);
       }
     }
     return p;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
In cases where there are very few mappings, we end up with lots of profiles on Basic and lots of extensions.  This use case exposed some crashes that are fixed here.