### PR TITLE
Turn OFF Unmapped Path Tracking

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -10,6 +10,11 @@ const {exportIG} = require('./ig');
 const TARGET = 'FHIR_STU_3';
 const ENTRY_ID = new mdls.Identifier('shr.base', 'Entry');
 
+// The following two constants toggle advanced developer features, usually not needed
+// or wanted (since they cause performance degradation).
+const TRACK_UNMAPPED_PATHS = false;
+const REPORT_PROFILE_INDICATORS = false;
+
 var rootLogger = bunyan.createLogger({name: 'shr-fhir-export'});
 var logger = rootLogger;
 function setLogger(bunyanLogger) {
@@ -36,8 +41,12 @@ class FHIRExporter {
     this._valueSetExporter = new ValueSetExporter(this._specs, this._fhir);
     this._extensionExporter = new ExtensionExporter(this, this._specs, this._fhir, TARGET);
     this._profiles = [];
-    this._profileIndicators = new Map();
-    this._unmappedPaths = new Map();
+    if (REPORT_PROFILE_INDICATORS) {
+      this._profileIndicators = new Map();
+    }
+    if (TRACK_UNMAPPED_PATHS) {
+      this._unmappedPaths = new Map();
+    }
   }
 
   export() {
@@ -65,35 +74,35 @@ class FHIRExporter {
       this.mappingToProfile(map);
     }
 
-    // Log out the unmapped paths
-    // First build a reverse map where the unmapped fields are the key.  This allows us to consolidate
-    // all the unmapped fields that probably derive from the same baseclass.
-    const reverseMap = new Map();
-    for (const [key, value] of this._unmappedPaths) {
-      const text = unmappedPathTreeAsText(value);
-      if (text === '') {
-        continue;
-      } else if (!reverseMap.has(text)) {
-        reverseMap.set(text, []);
+    if (TRACK_UNMAPPED_PATHS) {
+      // Log out the unmapped paths
+      // First build a reverse map where the unmapped fields are the key.  This allows us to consolidate
+      // all the unmapped fields that probably derive from the same baseclass.
+      const reverseMap = new Map();
+      for (const [key, value] of this._unmappedPaths) {
+        const text = unmappedPathTreeAsText(value);
+        if (text === '') {
+          continue;
+        } else if (!reverseMap.has(text)) {
+          reverseMap.set(text, []);
+        }
+        reverseMap.get(text).push(key);
       }
-      reverseMap.get(text).push(key);
-    }
-    for (const [text, elements] of reverseMap) {
-      logger.debug('Unmapped fields in [ %s ]:\n%s', elements.join(', '), text);
+      for (const [text, elements] of reverseMap) {
+        logger.info('Unmapped fields in [ %s ]:\n%s', elements.join(', '), text);
+      }
     }
 
-    /*
-    // A file showing profiles that have fixed values -- useful for trying to guess the profile, as in the FHIR Scorecard.
-    console.log('--------------- PROFILE INDICATORS ------------------');
-    const indicatorJSON = {};
-    for (const [, p] of this._profileIndicators) {
-      if (p.hasFixedValues) {
-        indicatorJSON[p.profileURL] = p.toJSON();
+    if (REPORT_PROFILE_INDICATORS) {
+      // A file showing profiles that have fixed values -- useful for trying to guess the profile, as in the FHIR Scorecard.
+      const indicatorJSON = {};
+      for (const [, p] of this._profileIndicators) {
+        if (p.hasFixedValues) {
+          indicatorJSON[p.profileURL] = p.toJSON();
+        }
       }
+      logger.info('Profile Indicators JSON:', JSON.stringify(indicatorJSON, null, 2));
     }
-    console.log(JSON.stringify(indicatorJSON, null, 2));
-    console.log('-----------------------------------------------------');
-    */
 
     return {
       profiles: this._profiles,
@@ -115,7 +124,9 @@ class FHIRExporter {
 
       const profileID = common.fhirID(map.identifier);
       const profileURL = common.fhirURL(map.identifier);
-      this._profileIndicators.set(profileID, new ProfileIndicators(profileURL, map.targetItem));
+      if (REPORT_PROFILE_INDICATORS) {
+        this._profileIndicators.set(profileID, new ProfileIndicators(profileURL, map.targetItem));
+      }
 
       const def = this._fhir.find(map.targetItem);
       if (typeof def === 'undefined') {
@@ -156,7 +167,9 @@ class FHIRExporter {
         isModifier : rootSS.isModifier,
         isSummary : rootSS.isSummary
       }] };
-      this._unmappedPaths.set(map.identifier.fqn, this.buildUnmappedPathsTree(map.identifier));
+      if (TRACK_UNMAPPED_PATHS) {
+        this._unmappedPaths.set(map.identifier.fqn, this.buildUnmappedPathsTree(map.identifier));
+      }
       this.processMappingRules(map, profile);
       this.addExtensions(map, profile);
       if (map.targetItem == 'Basic') {
@@ -231,6 +244,7 @@ class FHIRExporter {
     }
   }
 
+  // NOTE: This function only called if TRACK_UNMAPPED_PATHS is set to true
   buildUnmappedPathsTree(identifier, lineage = new Map()) {
     const tree = new Map();
     lineage.set(identifier.fqn, true);
@@ -244,6 +258,7 @@ class FHIRExporter {
     return tree;
   }
 
+  // NOTE: This function only called if TRACK_UNMAPPED_PATHS is set to true
   addFieldToUnmappedPathsTree(field, tree, lineage) {
     if (field instanceof mdls.IdentifiableValue) {
       if (field.identifier instanceof mdls.TBD) {
@@ -263,6 +278,7 @@ class FHIRExporter {
     }
   }
 
+  // NOTE: This function only called if TRACK_UNMAPPED_PATHS is set to true
   removeMappedPath(def, sourcePath) {
     let map = this._unmappedPaths.get(def.identifier.fqn);
     for (let i=0; i < sourcePath.length; i++) {
@@ -318,7 +334,9 @@ class FHIRExporter {
       ssEl.patternCodeableConcept = dfEl.patternCodeableConcept = {
         coding: [ { system: 'http://standardhealthrecord.org/fhir/basic-resource-type', code: profile.id }]
       };
-      this.addFixedValueIndicator(profile, ssEl.path, ssEl.patternCodeableConcept);
+      if (REPORT_PROFILE_INDICATORS) {
+        this.addFixedValueIndicator(profile, ssEl.path, ssEl.patternCodeableConcept);
+      }
     }
   }
 
@@ -557,7 +575,9 @@ class FHIRExporter {
       // affect cardinality? Do we need a way in the mapping grammar to place extensions at certain points?
       logger.info('Deep path mapped to extension, but extension placed at root level.');
     }
-    this.removeMappedPath(def, rule.sourcePath);
+    if (TRACK_UNMAPPED_PATHS) {
+      this.removeMappedPath(def, rule.sourcePath);
+    }
     this.addExtension(def, profile, rule.sourcePath, rule.target);
   }
 
@@ -939,7 +959,7 @@ class FHIRExporter {
   processFieldToFieldType(map, def, rule, profile, snapshotEl, differentialEl) {
     const sourceValue = this.findValueByPath(rule.sourcePath, def);
     const matchedPaths = this.processValueToFieldType(map, rule.sourcePath, sourceValue, profile, snapshotEl, differentialEl);
-    if (!(snapshotEl.type.length == 1 && snapshotEl.type[0].code == 'BackboneElement')) {
+    if (TRACK_UNMAPPED_PATHS && !(snapshotEl.type.length == 1 && snapshotEl.type[0].code == 'BackboneElement')) {
       if (matchedPaths) {
         for (const mp of matchedPaths) {
           this.removeMappedPath(def, mp);
@@ -1569,7 +1589,9 @@ class FHIRExporter {
 
     // If we made it this far, we can set the fixed value
     snapshotEl[property] = differentialEl[property] = value;
-    this.addFixedValueIndicator(profile, snapshotEl.path, value);
+    if (REPORT_PROFILE_INDICATORS) {
+      this.addFixedValueIndicator(profile, snapshotEl.path, value);
+    }
   }
 
   applyOwnBooleanConstraints(sourceValue, profile, snapshotEl, differentialEl) {
@@ -1586,7 +1608,9 @@ class FHIRExporter {
         return;
       }
       snapshotEl.fixedBoolean = differentialEl.fixedBoolean = value;
-      this.addFixedValueIndicator(profile, snapshotEl.path, value);
+      if (REPORT_PROFILE_INDICATORS) {
+        this.addFixedValueIndicator(profile, snapshotEl.path, value);
+      }
       if (boolConstraints.length > 1) {
         logger.error('Found more than one boolean to fix on %s. This should never happen and is probably a bug in the tool.', snapshotEl.id);
       }
@@ -1632,7 +1656,9 @@ class FHIRExporter {
       if (field instanceof mdls.IdentifiableValue) {
         if (!map.rules.some(r => r.sourcePath && r.sourcePath.length > 0 && r.sourcePath[0].equals(field.identifier))) {
           this.addExtension(def, profile, [field.identifier]);
-          this.removeMappedPath(def, [field.identifier]);
+          if (TRACK_UNMAPPED_PATHS) {
+            this.removeMappedPath(def, [field.identifier]);
+          }
         }
         // TODO: Should also dive into elements that are mapped and check if their sub-fields are mapped (recursively)
       } else {
@@ -2127,6 +2153,7 @@ class FHIRExporter {
            simpleJSONEqual(el.patternQuantity, rEl.patternQuantity);
   }
 
+  // NOTE: This function only called if REPORT_PROFILE_INDICATORS is set to true
   addFixedValueIndicator(profile, path, value) {
     if (this._profileIndicators.has(profile.id)) {
       this._profileIndicators.get(profile.id).addFixedValue(path, value);
@@ -2341,6 +2368,7 @@ function typesToString(types) {
   return `[${ts.join(', ')}]`;
 }
 
+// NOTE: This function only called if TRACK_UNMAPPED_PATHS is set to true
 function unmappedPathTreeAsText(tree, currentPrefix) {
   let text = '';
   for (let [key, value] of tree) {
@@ -2375,6 +2403,7 @@ function allowedBindingStrengthChange(originalStrength, newStrength) {
   }
 }
 
+// NOTE: This class only used if REPORT_PROFILE_INDICATORS is set to true
 class ProfileIndicators {
   constructor(profileURL, profileOn) {
     this._profileURL = profileURL;
@@ -2399,6 +2428,7 @@ class ProfileIndicators {
   }
 }
 
+// NOTE: This class only used if REPORT_PROFILE_INDICATORS is set to true
 class ProfileFixedValueIndicator {
   constructor(path, value) {
     this._path = path;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Previously, the export code always tracked unmapped paths -- although it only showed the results in debug output.  Since this is an advanced developer feature, and can create significant performance issues, it should be OFF by default.  The same approach was also applied to reporting profile indicators.