### PR TITLE
Implemented sanity checking for conflicting versions of shr-models

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2805,4 +2805,4 @@ class Stack {
   }
 }
 
-module.exports = {exportToFHIR, FHIRExporter, exportIG, setLogger, TARGET, isTargetBasedOn};
+module.exports = {exportToFHIR, FHIRExporter, exportIG, setLogger, TARGET, isTargetBasedOn, MODELS_INFO: mdls.MODELS_INFO};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",
@@ -19,12 +19,11 @@
   "dependencies": {
     "bunyan": "^1.8.9",
     "fs-extra": "^2.0.0",
-    "shr-models": "^5.1.0"
+    "shr-models": "^5.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
-    "mocha": "^3.2.0",
-    "shr-test-helpers": "^5.0.1"
+    "mocha": "^3.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,16 +894,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.1.0.tgz#3f9ef0e7ba929ea440fd07f2f31f905866ac4e03"
-
-shr-test-helpers@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.0.1.tgz#72abffcf26606fd5d88f731e3c3d4833210f9d1e"
-  dependencies:
-    bunyan "^1.8.9"
-    shr-models "^5.1.0"
+shr-models@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.0.tgz#3dba6f113f65a16250de2012f6e4d4bbf692e0ed"
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Added sanity checking support for different versions of `shr-models`. Note that although `shr-fhir-export` lists `shr-test-helpers` as a dev dependency, it doesn't actually use it, so the dependency has been dropped.