### PR TITLE
No diff profiles

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -146,6 +146,34 @@ function isCustomProfile(profile) {
   return typeof profile._noDiffProfile === 'undefined';
 }
 
+class ProcessTracker {
+  constructor() {
+    this._map = {};
+  }
+
+  start(...ids) {
+    for (let id of ids) {
+      if (!this._map[id]) {
+        this._map[id] = 0;
+      }
+      this._map[id] = this._map[id] + 1;
+    }
+  }
+
+  stop(...ids) {
+    for (let id of ids) {
+      this._map[id] = this._map[id] - 1;
+      if (this._map[id] === 0) {
+        delete(this._map[id]);
+      }
+    }
+  }
+
+  isActive(id) {
+    return this._map[id] && this._map[id] > 0;
+  }
+}
+
 class FHIRExportError extends Error {
   constructor(message = 'FHIR export error') {
     super(message);
@@ -154,4 +182,4 @@ class FHIRExportError extends Error {
   }
 }
 
-module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, todayString, isCustomProfile};
+module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, todayString, isCustomProfile, ProcessTracker};

--- a/lib/common.js
+++ b/lib/common.js
@@ -142,6 +142,10 @@ function todayString() {
   return (new Date()).toISOString().split('T')[0];
 }
 
+function isCustomProfile(profile) {
+  return typeof profile._noDiffProfile === 'undefined';
+}
+
 class FHIRExportError extends Error {
   constructor(message = 'FHIR export error') {
     super(message);
@@ -150,4 +154,4 @@ class FHIRExportError extends Error {
   }
 }
 
-module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, todayString};
+module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, todayString, isCustomProfile};

--- a/lib/export.js
+++ b/lib/export.js
@@ -1428,9 +1428,9 @@ class FHIRExporter {
   }
 
   applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl) {
-    [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
     const vsConstraints = sourceValue.constraintsFilter.own.valueSet.constraints;
     if (vsConstraints.length > 0) {
+      [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
       const vsConstraint = vsConstraints[0];
       const vsURI = vsConstraint.valueSet;
       if (vsURI.startsWith('urn:tbd')) {
@@ -1570,9 +1570,9 @@ class FHIRExporter {
   }
 
   applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl) {
-    [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
     const codeConstraints = sourceValue.constraintsFilter.own.code.constraints;
     if (codeConstraints.length > 0) {
+      [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
       this.fixCodeOnElement(sourceValue.identifier, profile, snapshotEl, differentialEl, codeConstraints[0].code);
       if (codeConstraints.length > 1) {
         logger.error('Found more than one code to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13031', snapshotEl.id);
@@ -1823,9 +1823,9 @@ class FHIRExporter {
   }
 
   applyOwnBooleanConstraints(sourceValue, profile, snapshotEl, differentialEl) {
-    [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
     const boolConstraints = sourceValue.constraintsFilter.own.boolean.constraints;
     if (boolConstraints.length > 0) {
+      [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
       const value = boolConstraints[0].value;
       if (typeof snapshotEl.fixedBoolean !== 'undefined') {
         if (snapshotEl.fixedBoolean == value) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -48,6 +48,13 @@ class FHIRExporter {
       this._unmappedPaths = new Map();
     }
     this._config = configuration;
+    this._processTracker = new common.ProcessTracker();
+  }
+
+  // The process tracker is used to keep track of what profiles are currently being processed.  This allows us to
+  // check for possible issues when looking up and using a profile that is currently mid-process.
+  get processTracker() {
+    return this._processTracker;
   }
 
   export() {
@@ -75,7 +82,7 @@ class FHIRExporter {
       try {
         this.mappingToProfile(map);
       } catch (e) {
-        logger.error('Unexpected error processing mapping to FHIR. ERROR_CODE:???', e);
+        logger.error('Unexpected error processing mapping to FHIR. ERROR_CODE:13049', e);
       }
     }
 
@@ -122,6 +129,7 @@ class FHIRExporter {
     const lastLogger = logger;
     logger = rootLogger.child({ shrId: map.identifier.fqn, target: map.targetItem });
     logger.debug('Start mapping element');
+    this._processTracker.start(map.identifier.fqn, common.fhirID(map.identifier));
     try {
       // We need to enhance the map so some implicit things are made explicit for easier processing
       const originalMap = map;
@@ -257,6 +265,7 @@ class FHIRExporter {
       this._profiles.push(profile);
       return profile;
     } finally {
+      this._processTracker.stop(map.identifier.fqn, common.fhirID(map.identifier));
       // Close out the logging for this mapping
       logger.debug('Done mapping element');
       logger = lastLogger;
@@ -578,7 +587,7 @@ class FHIRExporter {
           }
         }
       } catch (e) {
-        logger.error('Unexpected error processing mapping rule. ERROR_CODE:???', e);
+        logger.error('Unexpected error processing mapping rule. ERROR_CODE:13050', e);
       } finally {
         logger.debug('Done mapping rule');
         logger = lastLogger;
@@ -753,17 +762,17 @@ class FHIRExporter {
     if (identifier instanceof mdls.Identifier) {
       if (snapshotEl.type.length == 1 && snapshotEl.type[0].code == 'Extension') {
         // Lookup the extension
-        sdToUnroll = this._extensionExporter.lookupExtension(identifier);
+        sdToUnroll = this._extensionExporter.lookupExtension(identifier, true, true);
       } else {
         // Look up the profile
-        sdToUnroll = this.lookupProfile(identifier);
+        sdToUnroll = this.lookupProfile(identifier, true, true);
         if (typeof sdToUnroll === 'undefined') {
           logger.error('Cannot unroll %s at %s: invalid SHR element. ERROR_CODE:13010', identifier.fqn, snapshotEl.id);
           return;
         }
       }
     } else {
-      sdToUnroll = this.lookupStructureDefinition(identifier);
+      sdToUnroll = this.lookupStructureDefinition(identifier, true);
     }
 
     if (typeof sdToUnroll === 'undefined') {
@@ -799,10 +808,10 @@ class FHIRExporter {
     let sdToAdd;
     if (snapshotEl.type.length == 1 && snapshotEl.type[0].code == 'Extension') {
       // Lookup the extension
-      sdToAdd = this._extensionExporter.lookupExtension(sourceIdentifier);
+      sdToAdd = this._extensionExporter.lookupExtension(sourceIdentifier, true, true);
     } else {
       // Look up the profile (TODO: Support for primitives?)
-      sdToAdd = this.lookupProfile(sourceIdentifier);
+      sdToAdd = this.lookupProfile(sourceIdentifier, true, true);
       if (typeof sdToAdd === 'undefined') {
         logger.error('Cannot make choice element explicit at %s. Invalid SHR identifier: %s. ERROR_CODE:13012', snapshotEl.id, sourceIdentifier.fqn);
         return;
@@ -1122,7 +1131,7 @@ class FHIRExporter {
     const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
     if (typeof sourceMap !== 'undefined') {
       let matchedType;
-      const sourceProfile = this.lookupProfile(sourceMap.identifier, true);
+      const sourceProfile = this.lookupProfile(sourceMap.identifier, true, true);
       const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
       const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
       const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL, false));
@@ -1893,7 +1902,7 @@ class FHIRExporter {
               this.removeMappedPath(def, [field.identifier]);
             }
           } catch (e) {
-            logger.error('Unexpected error adding extension. ERROR_CODE:???', e);
+            logger.error('Unexpected error adding extension. ERROR_CODE:13051', e);
           } finally {
             logger.debug('Done mapping extension');
             logger = lastLogger;
@@ -2028,7 +2037,7 @@ class FHIRExporter {
     }
   }
 
-  lookupProfile(identifier, createIfNeeded=true) {
+  lookupProfile(identifier, createIfNeeded=true, warnIfProfileIsProcessing=false) {
     let p = this._profiles.find(p => p.id == common.fhirID(identifier));
     if (typeof p === 'undefined' && createIfNeeded) {
       const mapping = this._specs.maps.findByTargetAndIdentifier(TARGET, identifier);
@@ -2041,18 +2050,26 @@ class FHIRExporter {
         this._specs.maps.add(basicMapping);
         p = this.mappingToProfile(basicMapping);
       }
+    } else if (warnIfProfileIsProcessing && this._processTracker.isActive(identifier)) {
+      logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(identifier));
     }
     return p;
   }
 
-  lookupStructureDefinition(id) {
+  lookupStructureDefinition(id, warnIfStructureDefinitionIsProcessing=false) {
     // First check profiles
     const profile = this._profiles.find(p => p.id == id);
     if (typeof profile !== 'undefined') {
+      if (warnIfStructureDefinitionIsProcessing && this._processTracker.isActive(id)) {
+        logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(id));
+      }
       return profile;
     }
     const ext = this._extensionExporter.extensions.find(e => e.id == id);
     if (typeof ext !== 'undefined') {
+      if (warnIfStructureDefinitionIsProcessing && this._extensionExporter.processTracker.isActive(id)) {
+        logger.warn('Using extension that is currently in the middle of processing: %s.  ERROR_CODE:13055', common.fhirID(id));
+      }
       return ext;
     }
     return this._fhir.find(id);
@@ -2083,7 +2100,7 @@ class FHIRExporter {
         return;
       }
       const type = parentEl.type[0].code;
-      const sd = this.lookupStructureDefinition(type);
+      const sd = this.lookupStructureDefinition(type, true);
       // Before we unroll it, check to be sure the sub-element exists (otherwise we needlessly unroll it)
       if (sd.snapshot.element.some(e => e.path == `${sd.type}.${parts[i]}`)) {
         this.unrollElement(type, profile, parentEl);

--- a/lib/export.js
+++ b/lib/export.js
@@ -184,6 +184,10 @@ class FHIRExporter {
       if (TRACK_UNMAPPED_PATHS) {
         this._unmappedPaths.set(map.identifier.fqn, this.buildUnmappedPathsTree(map.identifier));
       }
+
+      // Add it to the profiles now so if we get a recursive lookup, we find this instance
+      this._profiles.push(profile);
+
       this.processMappingRules(map, profile);
       this.addExtensions(map, profile);
       if (map.targetItem == 'Basic') {
@@ -254,15 +258,18 @@ class FHIRExporter {
       // Check if this is a "no-diff" profile.
       if (profile.differential.element.length <= 1) {
         // This is a "no-diff" profile.  Substitute it with the original resource!
+        // First, find the index of the original so we can replace it in the array
+        const i = this._profiles.findIndex(p => p === profile);
+        // Now re-set the profile to the original resource
         profile = common.cloneJSON(def);
         // Set a flag so we can easily identify these "no-diff" profiles
         profile._noDiffProfile = profileID;
+        this._profiles[i] = profile;
       } else {
         // Perform additional QA
         this.additionalQA(profile);
       }
 
-      this._profiles.push(profile);
       return profile;
     } finally {
       this._processTracker.stop(map.identifier.fqn, common.fhirID(map.identifier));

--- a/lib/export.js
+++ b/lib/export.js
@@ -110,7 +110,7 @@ class FHIRExporter {
     }
 
     return {
-      profiles: this._profiles,
+      profiles: this._profiles.filter(p => common.isCustomProfile(p)),
       extensions: this._extensionExporter.extensions,
       valueSets: this._valueSetExporter.valueSets,
       codeSystems: this._codeSystemExporter.codeSystems,
@@ -138,7 +138,7 @@ class FHIRExporter {
         logger.error('Invalid FHIR target: %s. ERROR_CODE:13001', map.targetItem);
         return;
       }
-      const profile = common.cloneJSON(def);
+      let profile = common.cloneJSON(def);
       delete(profile.meta);
       delete(profile.extension);
       delete(profile.version);
@@ -243,8 +243,16 @@ class FHIRExporter {
       }
       profile.differential.element = fixedDifferentials;
 
-      // Perform additional QA
-      this.additionalQA(profile);
+      // Check if this is a "no-diff" profile.
+      if (profile.differential.element.length <= 1) {
+        // This is a "no-diff" profile.  Substitute it with the original resource!
+        profile = common.cloneJSON(def);
+        // Set a flag so we can easily identify these "no-diff" profiles
+        profile._noDiffProfile = profileID;
+      } else {
+        // Perform additional QA
+        this.additionalQA(profile);
+      }
 
       this._profiles.push(profile);
       return profile;
@@ -802,7 +810,8 @@ class FHIRExporter {
     }
 
     // Check to be sure we don't already have one
-    const baseId = `${snapshotEl.id.replace('[x]', sdToAdd.type)}:${common.fhirID(sourceIdentifier)}`;
+    const sliceName = sdToAdd.id;
+    const baseId = `${snapshotEl.id.replace('[x]', sdToAdd.type)}:${sliceName}`;
     const existing = profile.snapshot.element.find(e => e.id == baseId);
     if (existing) {
       return existing;
@@ -813,15 +822,22 @@ class FHIRExporter {
     common.addSlicingToBaseElement(snapshotEl, differentialEl, 'type', '$this');
 
     // Build the new choice element
+    const newType = { code: sdToAdd.type };
+    if (sdToAdd.type === 'Reference') {
+      newType.targetProfile = sdToAdd.url;
+    }
+    if (sdToAdd.type === 'Extension' || common.isCustomProfile(sdToAdd)) {
+      newType.profile = sdToAdd.url;
+    }
     const choiceEl = {
       id: baseId,
       path: snapshotEl.path.replace('[x]', sdToAdd.type),
-      sliceName: common.fhirID(sourceIdentifier),
+      sliceName,
       short: snapshotEl.short,
       definition: snapshotEl.definition,
       min: snapshotEl.min,
       max: snapshotEl.max,
-      type: [{ code: sdToAdd.type, profile: sdToAdd.url }],
+      type: [newType],
       isSummary: snapshotEl.isSummary
     };
 
@@ -1106,7 +1122,7 @@ class FHIRExporter {
     const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
     if (typeof sourceMap !== 'undefined') {
       let matchedType;
-      const profileURL = common.fhirURL(sourceMap.identifier, this._config.fhirURL);
+      const sourceProfile = this.lookupProfile(sourceMap.identifier, true);
       const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
       const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
       const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL, false));
@@ -1116,7 +1132,9 @@ class FHIRExporter {
           // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
           // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
           if (!this.optionIsSelected(t) || basedOnTargetProfiles.includes(t.profile)) {
-            t.profile = profileURL;
+            if (common.isCustomProfile(sourceProfile)) {
+              t.profile = sourceProfile.url;
+            }
             this.markSelectedOptionsInChoice(targetTypes, [t]);
           }
           break;
@@ -1125,7 +1143,7 @@ class FHIRExporter {
           // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
           // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
           if (!this.optionIsSelected(t) || basedOnTargetProfiles.includes(t.targetProfile)) {
-            t.targetProfile = profileURL;
+            t.targetProfile = sourceProfile.url;
             this.markSelectedOptionsInChoice(targetTypes, [t]);
           }
           break;
@@ -1136,12 +1154,14 @@ class FHIRExporter {
         // We got a match!
         // Check to see if this is trying to map a different element than the one that was previously mapped.
         const mappedProfile = typeof matchedType.profile !== 'undefined' ? matchedType.profile : matchedType.targetProfile;
-        if (profileURL != mappedProfile) {
+        if (typeof mappedProfile !== 'undefined' && mappedProfile != sourceProfile.url) {
           // It's trying to map a different element than the one that was previously mapped.  Conflict!
-          logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', profileURL, matchedType.code, mappedProfile);
+          logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
         } else {
           // We successfully mapped the type, so we need to apply the differential and constraints
-          differentialEl.type = snapshotEl.type;
+          if (typeof mappedProfile !== 'undefined') {
+            differentialEl.type = snapshotEl.type;
+          }
           this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false);
           matchedPaths.push(clonedPath);
         }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -20,21 +20,31 @@ class ExtensionExporter {
     this._target = target;
     this._config = configuration;
     this._extensionsMap = new Map();
+    this._processTracker = new common.ProcessTracker();
+  }
+
+  // The process tracker is used to keep track of what profiles are currently being processed.  This allows us to
+  // check for possible issues when looking up and using a profile that is currently mid-process.
+  get processTracker() {
+    return this._processTracker;
   }
 
   get extensions() {
     return Array.from(this._extensionsMap.values());
   }
 
-  lookupExtension(identifier) {
-    const ext = this._extensionsMap.get(identifier.fqn);
-    if (ext) {
-      return ext;
+  lookupExtension(identifier, createIfNeeded=true, warnIfExtensionIsProcessing=false) {
+    let ext = this._extensionsMap.get(identifier.fqn);
+    if (typeof ext === 'undefined' && createIfNeeded) {
+      ext = this.createExtension(identifier);
+    } else if (warnIfExtensionIsProcessing && this._processTracker.isActive(identifier)) {
+      logger.warn('Using extension that is currently in the middle of processing: %s. ERROR_CODE:13055', common.fhirID(identifier, 'extension'));
     }
-    return this.createExtension(identifier);
+    return ext;
   }
 
   createExtension(identifier) {
+    this._processTracker.start(identifier.fqn, common.fhirID(identifier, 'extension'));
     let def = this._specs.dataElements.findByIdentifier(identifier);
     if (typeof def === 'undefined' && identifier.isPrimitive) {
       // We can cheat by creating a definition to represent the primitive value
@@ -74,7 +84,7 @@ class ExtensionExporter {
     // Now add all the snapshot and differential elements.  Since the extension is in the map by
     // reference, we shouldn't need to set it in the map again after.
     this.pushDefExtensionElements(ext, baseId, '', def);
-
+    this._processTracker.stop(identifier.fqn), common.fhirID(identifier, 'extension');
     return ext;
   }
 
@@ -155,7 +165,7 @@ class ExtensionExporter {
         } else if (field instanceof mdls.TBD) {
           continue;
         } else {
-          console.error('Unsupported field value type: ', field.constructor.name);
+          logger.error('Unsupported field value type: %s. ERROR_CODE:13052', field.constructor.name);
         }
       }
       this.pushExtensionURLElement(extension, baseId, def);
@@ -343,7 +353,7 @@ class ExtensionExporter {
       const typeObj = { code: type };
       // Set the profile or targetProfile if appropriate
       if (! value.identifier.isPrimitive) {
-        const profile = this._profileExporter.lookupProfile(value.identifier);
+        const profile = this._profileExporter.lookupProfile(value.identifier, true, true);
         if (type == 'Reference') {
           typeObj.targetProfile = profile.url;
         } else if (common.isCustomProfile(profile)) {
@@ -462,7 +472,7 @@ class ExtensionExporter {
           }
         }
       } else {
-        console.error(`Unsupported value type: ${opt.constructor.name}`);
+        logger.error('Unsupported value type: %s. ERROR_CODE:13053', opt.constructor.name);
         return false;
       }
     }
@@ -481,7 +491,7 @@ class ExtensionExporter {
         }
         const code = VALUE_SUPPORTED_TYPES.indexOf(map.targetItem) >= 0 ? map.targetItem : 'Reference';
         const typeObj = { code };
-        const profile = this._profileExporter.lookupProfile(map.identifier);
+        const profile = this._profileExporter.lookupProfile(map.identifier, true, true);
         if (code == 'Reference') {
           return { code: code, targetProfile: profile.url };
         } else if (common.isCustomProfile(profile)) {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -340,13 +340,17 @@ class ExtensionExporter {
         }
       }
     } else if (value && value instanceof mdls.IdentifiableValue) {
-      if (value.identifier.isPrimitive) {
-        ssValue.type.push({ code: type });
-      } else if (type == 'Reference') {
-        ssValue.type.push({ code: type, targetProfile: common.fhirURL(value.identifier, this._config.fhirURL, false) });
-      } else {
-        ssValue.type.push({ code: type, profile: common.fhirURL(value.identifier, this._config.fhirURL, false) });
+      const typeObj = { code: type };
+      // Set the profile or targetProfile if appropriate
+      if (! value.identifier.isPrimitive) {
+        const profile = this._profileExporter.lookupProfile(value.identifier);
+        if (type == 'Reference') {
+          typeObj.targetProfile = profile.url;
+        } else if (common.isCustomProfile(profile)) {
+          typeObj.profile = profile.url;
+        }
       }
+      ssValue.type.push(typeObj);
     } else {
       ssValue.type.push({ code: type});
     }
@@ -476,11 +480,14 @@ class ExtensionExporter {
           return;
         }
         const code = VALUE_SUPPORTED_TYPES.indexOf(map.targetItem) >= 0 ? map.targetItem : 'Reference';
+        const typeObj = { code };
+        const profile = this._profileExporter.lookupProfile(map.identifier);
         if (code == 'Reference') {
-          return { code: code, targetProfile: common.fhirURL(map.identifier, this._config.fhirURL) };
-        } else {
-          return { code: code, profile: common.fhirURL(map.identifier, this._config.fhirURL) };
+          return { code: code, targetProfile: profile.url };
+        } else if (common.isCustomProfile(profile)) {
+          return { code: code, profile: profile.url };
         }
+        return typeObj;
       }
     }
   }

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -3,9 +3,9 @@ const fs = require('fs-extra');
 const common = require('./common');
 
 function exportIG(fhirResults, outDir, configuration = [], specPath) {
-  
+
   const config = configuration;
-  
+
   // Copy the static parts of the IG
   fs.copySync(path.join(__dirname, 'ig_files'), outDir);
 
@@ -28,14 +28,14 @@ function exportIG(fhirResults, outDir, configuration = [], specPath) {
 
   const igIndexHtmlPath = path.join(outDir, 'pages','index.html');
   const igIndexHtml = fs.readFileSync(igIndexHtmlPath, 'utf8');
-  const igIndexContentPath = path.join(specPath, config.igIndexContent); 
+  const igIndexContentPath = path.join(specPath, config.igIndexContent);
   var igIndexContent;
   try {
     igIndexContent = fs.readFileSync(igIndexContentPath, 'utf8');
   } catch (error) {
     igIndexContent =
 `<p> This is a ${config.projectName} FHIR implementation guide. </p>`;
-    fs.writeFileSync(igIndexContentPath, igIndexContent, 'utf8');    
+    fs.writeFileSync(igIndexContentPath, igIndexContent, 'utf8');
   }
 
   fs.writeFileSync(igIndexHtmlPath, igIndexHtml.replace("<igIndexContent-go-here>", igIndexContent), 'utf8');
@@ -55,9 +55,10 @@ function exportIG(fhirResults, outDir, configuration = [], specPath) {
   // 3. Add it to the IG XML file
   // 4. Add it to the corresponding HTML listing file
   // 5. Create the mapping xhtml file (profiles only)
+  fhirResults.profiles.sort(byID);
   const sdPath = path.join(outDir, 'resources', 'StructureDefinition');
   fs.ensureDirSync(sdPath);
-  for (const profile of fhirResults.profiles.sort()) {
+  for (const profile of fhirResults.profiles) {
     fs.writeFileSync(path.join(sdPath, `${profile.id}.json`), JSON.stringify(profile, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${profile.id}`] = {
       'base': `StructureDefinition-${profile.id}.html`
@@ -113,7 +114,8 @@ ${match[1]}
   };
   fs.copySync(patchPath, sdPath, { filter: filterFunc });
 
-  for (const extension of fhirResults.extensions.sort()) {
+  fhirResults.extensions.sort(byID);
+  for (const extension of fhirResults.extensions) {
     fs.writeFileSync(path.join(sdPath, `${extension.id}.json`), JSON.stringify(extension, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${extension.id}`] = {
       'base': `StructureDefinition-${extension.id}.html`
@@ -141,9 +143,10 @@ ${match[1]}
     fs.writeFileSync(mapPath, '', 'utf8');
   }
 
+  fhirResults.valueSets.sort(byID);
   const vsPath = path.join(outDir, 'resources', 'ValueSet');
   fs.ensureDirSync(vsPath);
-  for (const valueSet of fhirResults.valueSets.sort()) {
+  for (const valueSet of fhirResults.valueSets) {
     fs.writeFileSync(path.join(vsPath, `${valueSet.id}.json`), JSON.stringify(valueSet, null, 2), 'utf8');
     igControl.resources[`ValueSet/${valueSet.id}`] = {
       'base': `ValueSet-${valueSet.id}.html`
@@ -169,9 +172,10 @@ ${match[1]}
     `);
   }
 
+  fhirResults.codeSystems.sort(byID);
   const csPath = path.join(outDir, 'resources', 'CodeSystem');
   fs.ensureDirSync(csPath);
-  for (const codeSystem of fhirResults.codeSystems.sort()) {
+  for (const codeSystem of fhirResults.codeSystems) {
     fs.writeFileSync(path.join(csPath, `${codeSystem.id}.json`), JSON.stringify(codeSystem, null, 2), 'utf8');
     igControl.resources[`CodeSystem/${codeSystem.id}`] = {
       'base': `CodeSystem-${codeSystem.id}.html`
@@ -206,13 +210,13 @@ ${match[1]}
   fs.writeFileSync(igXmlPath, igXml.replace('<resources-go-here/>', xmlResources.join(''))
                                    .replace(/<project-name-go-here>/g, config.projectName)
                                    .replace("<ig-url-go-here>", config.fhirURL), 'utf8');
-  
+
   // Rewrite the updated Profiles HTML file
   const profilesHtmlPath = path.join(outDir, 'pages', 'profiles.html');
   const profilesHtml = fs.readFileSync(profilesHtmlPath, 'utf8');
   fs.writeFileSync(profilesHtmlPath, profilesHtml.replace('<resources-go-here/>', htmlProfiles.join(''))
                                                  .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
-  
+
   // Rewrite the updated Extensions HTML file
   const extensionsHtmlPath = path.join(outDir, 'pages', 'extensions.html');
   const extensionsHtml = fs.readFileSync(extensionsHtmlPath, 'utf8');
@@ -240,6 +244,15 @@ function getNamespaceFromID(id, trimLastTerm=false) {
   const endIndex = trimLastTerm ? parts.length-2 : parts.length-1;
   const nsParts = parts.slice(1, endIndex).map(p => p.charAt(0).toUpperCase() + p.slice(1));
   return nsParts.join(' ');
+}
+
+function byID(a, b) {
+  if (a.id < b.id) {
+    return -1;
+  } else if (a.id > b.id) {
+    return 1;
+  }
+  return 0;
 }
 
 module.exports = {exportIG};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The primary purpose of this pull request is to _not_ create profiles for SHR elements that map cleanly to FHIR (e.g., there are no additional constraints or changes to the original FHIR type).  The SHR element `Coding` is a good example.  Since it doesn't constrain anything in FHIR `Coding`, an SHR profile for `Coding` is _not_ produced -- and all other elements that refer to `Coding` will use the FHIR `Coding` instead of a specific SHR `Coding`.

This implementation introduces more possibility for recursive profile definition -- so new logging capabilities have also been added to detect this situation when it might adversely affect the results.

This also introduces a few bug fixes, most notably being a bug that caused many elements in the profiles to be "unrolled" (i.e. expanded) when that was not at all necessary.