### PR TITLE
Fix QA detection of fixed codes + Performance Tweak

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2407,12 +2407,6 @@ class FHIRExporter {
 
     if (typeof codeEl === 'undefined' || (codeEl.min == 0 && codeEl.max == '0')) {
       // No need for mapping or constraints when it's profiled out
-    } else if (this.elementTypeNotChanged(profile, codeEl)) {
-      if (!def._isAbstract) {
-        logger.warn('No mapping to \'%s\'. This property is core to the target resource and usually should be mapped. ERROR_CODE:03005', path);
-      } else {
-        logger.info('Abstract Class: No mapping to \'%s\'. This property is core to the target resource and usually should be mapped.', path);
-      }
     } else if (this.elementTypeUnconstrainedCode(profile, codeEl)) {
       // Allow this for "base" classes
       if (!profile.id.endsWith(`-${profile.type}`)) {
@@ -2436,7 +2430,7 @@ class FHIRExporter {
       // Find the corresponding element in the profile
       const pEl = profile.snapshot.element.find(e => e.path == el.path);
       // If it's not constrained, we need to check if any of the types are codish or quantities
-      if (this.codeNotConstrained(pEl, rEl)) {
+      if (this.codeNotConstrained(profile, pEl, rEl)) {
         const root = el.path.slice(0, -3); // e.g., root of Observation.value[x] is Observation.value
         // As we iterate through, if we find codish or quantity types, we need to check if perhaps they
         // are constrained in a slice.  For example, if value[x] had a CodeableConcept choice, we
@@ -2459,7 +2453,7 @@ class FHIRExporter {
           if (i >= 0) {
             // This element matches an unconstrained path, so check if it's still unconstrained
             const rEl2 = this.getOriginalElement(pEl2) || rEl;
-            if (! this.codeNotConstrained(pEl2, rEl2)) {
+            if (! this.codeNotConstrained(profile, pEl2, rEl2)) {
               // Remove the path from the unconstrained code paths!
               unconstrainedCodePaths.splice(i, 1);
             }
@@ -2470,7 +2464,7 @@ class FHIRExporter {
       }
     }
     // It's not a choice, so just do the direct check
-    return this.elementTypeIsCodishOrQuantity(el) && this.codeNotConstrained(el, rEl);
+    return this.elementTypeIsCodishOrQuantity(el) && this.codeNotConstrained(profile, el, rEl);
   }
 
   elementTypeIsCodishOrQuantity(el) {
@@ -2481,16 +2475,42 @@ class FHIRExporter {
     return typeCode && ['code', 'Coding', 'CodeableConcept', 'Quantity'].indexOf(typeCode) >= 0;
   }
 
-  codeNotConstrained(el, rEl) {
-    return simpleJSONEqual(el.binding, rEl.binding) &&
-           simpleJSONEqual(el.fixedCode, rEl.fixedCode) &&
-           simpleJSONEqual(el.fixedCoding, rEl.fixedCoding) &&
-           simpleJSONEqual(el.fixedCodeableConcept, rEl.fixedCodeableConcept) &&
-           simpleJSONEqual(el.fixedQuantity, rEl.fixedQuantity) &&
-           simpleJSONEqual(el.patternCode, rEl.patternCode) &&
-           simpleJSONEqual(el.patternCoding, rEl.patternCoding) &&
-           simpleJSONEqual(el.patternCodeableConcept, rEl.patternCodeableConcept) &&
-           simpleJSONEqual(el.patternQuantity, rEl.patternQuantity);
+  codeNotConstrained(profile, el, rEl) {
+    let rootNotConstrained = rEl && simpleJSONEqual(el.binding, rEl.binding) &&
+      simpleJSONEqual(el.fixedCode, rEl.fixedCode) &&
+      simpleJSONEqual(el.fixedCoding, rEl.fixedCoding) &&
+      simpleJSONEqual(el.fixedCodeableConcept, rEl.fixedCodeableConcept) &&
+      simpleJSONEqual(el.fixedQuantity, rEl.fixedQuantity) &&
+      simpleJSONEqual(el.patternCode, rEl.patternCode) &&
+      simpleJSONEqual(el.patternCoding, rEl.patternCoding) &&
+      simpleJSONEqual(el.patternCodeableConcept, rEl.patternCodeableConcept) &&
+      simpleJSONEqual(el.patternQuantity, rEl.patternQuantity);
+    if (rootNotConstrained) {
+      // Now we need to check for possible constraints on the nested elements (e.g., fixed code and system)
+      if (el.type && el.type.some(t => t.code === 'Coding' || t.code === 'Quantity')) {
+        const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, el, null, false);
+        if (systemEl && systemEl.fixedUri) {
+          const rSystemEl = this.getOriginalElement(systemEl);
+          if (!rSystemEl || systemEl.fixedUri !== rSystemEl.fixedUri) {
+            return false;
+          }
+        }
+        if (codeEl && codeEl.fixedCode) {
+          const rCodeEl = this.getOriginalElement(codeEl);
+          if (!rCodeEl || codeEl.fixedCode !== rCodeEl.fixedCode) {
+            return false;
+          }
+        }
+      }
+      if (el.type && el.type.some(t => t.code === 'CodeableConcept')) {
+        const codings = profile.snapshot.element.filter(pEl => pEl.id.startsWith(el.id) && pEl.path === `${el.path}.coding`);
+        const noneConstrained = codings.every(cEl => this.codeNotConstrained(profile, cEl, this.getOriginalElement(cEl)));
+        if (!noneConstrained) {
+          return false;
+        }
+      }
+    }
+    return rootNotConstrained;
   }
 
   // NOTE: This function only called if REPORT_PROFILE_INDICATORS is set to true

--- a/lib/export.js
+++ b/lib/export.js
@@ -40,7 +40,7 @@ class FHIRExporter {
     this._codeSystemExporter = new CodeSystemExporter(this._specs, this._fhir, configuration);
     this._valueSetExporter = new ValueSetExporter(this._specs, this._fhir, configuration);
     this._extensionExporter = new ExtensionExporter(this, this._specs, this._fhir, TARGET, configuration);
-    this._profiles = [];
+    this._profilesMap = new Map();
     if (REPORT_PROFILE_INDICATORS) {
       this._profileIndicators = new Map();
     }
@@ -117,7 +117,7 @@ class FHIRExporter {
     }
 
     return {
-      profiles: this._profiles.filter(p => common.isCustomProfile(p)),
+      profiles: Array.from(this._profilesMap.values()).filter(p => common.isCustomProfile(p)),
       extensions: this._extensionExporter.extensions,
       valueSets: this._valueSetExporter.valueSets,
       codeSystems: this._codeSystemExporter.codeSystems,
@@ -186,7 +186,7 @@ class FHIRExporter {
       }
 
       // Add it to the profiles now so if we get a recursive lookup, we find this instance
-      this._profiles.push(profile);
+      this._profilesMap.set(profile.id, profile);
 
       this.processMappingRules(map, profile);
       this.addExtensions(map, profile);
@@ -258,13 +258,13 @@ class FHIRExporter {
       // Check if this is a "no-diff" profile.
       if (profile.differential.element.length <= 1) {
         // This is a "no-diff" profile.  Substitute it with the original resource!
-        // First, find the index of the original so we can replace it in the array
-        const i = this._profiles.findIndex(p => p === profile);
+        // First, remember the original id
+        const originalId = profile.id;
         // Now re-set the profile to the original resource
         profile = common.cloneJSON(def);
         // Set a flag so we can easily identify these "no-diff" profiles
         profile._noDiffProfile = profileID;
-        this._profiles[i] = profile;
+        this._profilesMap.set(originalId, profile);
       } else {
         // Perform additional QA
         this.additionalQA(profile);
@@ -2045,7 +2045,7 @@ class FHIRExporter {
   }
 
   lookupProfile(identifier, createIfNeeded=true, warnIfProfileIsProcessing=false) {
-    let p = this._profiles.find(p => p.id == common.fhirID(identifier));
+    let p = this._profilesMap.get(common.fhirID(identifier));
     if (typeof p === 'undefined' && createIfNeeded) {
       const mapping = this._specs.maps.findByTargetAndIdentifier(TARGET, identifier);
       if (typeof mapping !== 'undefined') {
@@ -2065,7 +2065,7 @@ class FHIRExporter {
 
   lookupStructureDefinition(id, warnIfStructureDefinitionIsProcessing=false) {
     // First check profiles
-    const profile = this._profiles.find(p => p.id == id);
+    const profile = this._profilesMap.get(id);
     if (typeof profile !== 'undefined') {
       if (warnIfStructureDefinitionIsProcessing && this._processTracker.isActive(id)) {
         logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(id));


### PR DESCRIPTION
This PR addresses two issues:

1. The QA code was not finding fixed codes that were directly on a Coding's code and system elements.  This is now fixed (see #66).
2. Performance was suffering due to inefficient profile lookups.  This is now fixed by storing profiles in a Map.