### PR TITLE
Improves readability for specific error messages

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1030,7 +1030,7 @@ class FHIRExporter {
         if (value instanceof mdls.IdentifiableValue) {
           sourceString += `[Value: ${value.identifier.fqn}]`;
         } else if (value) {
-          sourceString += `[Value: ${value.toString()}]`;
+          sourceString += `[Value: ${value.toLoggerString()}]`;
         }
       }
 


### PR DESCRIPTION
reference: https://github.com/standardhealth/shr-models/pull/17

This is a more readable option for choice values in errors (in response to feedback from Mark).

Turns:

> [19:25:20.965Z] ERROR shr: No cardinality found for field: ChoiceValue<IdentifiableValue<shr.core.CodeableConcept>|RefValue<shr.core.Range>|IdentifiableValue<shr.core.Quantity>>. ERROR_CODE:12004 (module=shr-expand, shrId=shr.careplan.ResultTargeted)


into:

> [19:19:23.316Z] ERROR shr: No cardinality found for field Choice(CodeableConcept, Range, Quantity) in ResultTargeted. ERROR_CODE:12004 (module=shr-expand, shrId=shr.careplan.ResultTargeted)


(with the addition of some base class tracking improvements by @cmoesel).