### PR TITLE
Includes Type Bug Fixes

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2764,14 +2764,11 @@ function setCardinalityOnFHIRElements(card, snapshotEl, differentialEl, skipIfEq
       if (typeof differentialEl._originalProperties === 'undefined') {
         differentialEl._originalProperties = originalProperties;
       }
-      if (snapshotEl.min !== differentialEl._originalProperties.min) {
+      if (snapshotEl.min !== differentialEl._originalProperties.min || snapshotEl.max !== differentialEl._originalProperties.max) {
         differentialEl.min = snapshotEl.min;
-      } else {
-        delete(differentialEl.min);
-      }
-      if (snapshotEl.max !== differentialEl._originalProperties.max) {
         differentialEl.max = snapshotEl.max;
       } else {
+        delete(differentialEl.min);
         delete(differentialEl.max);
       }
     }

--- a/lib/export.js
+++ b/lib/export.js
@@ -399,10 +399,9 @@ class FHIRExporter {
     // itself, as shr-expand doesn't know how to deal with it.  This is why we do it automagically here instead.
     // In the future we should determine what is the approved way to reference an includetype in a path.
     // The following block of code does the expansion as noted above:
-    const newRules = [];
     const def = this._specs.dataElements.findByIdentifier(map.identifier);
-    for (const rule of map.rules) {
-      newRules.push(rule);
+    for (let i=0; i < map.rules.length; i++) {
+      const rule = map.rules[i];
       if (!(rule instanceof mdls.FieldMappingRule)) {
         continue;
       }
@@ -424,6 +423,8 @@ class FHIRExporter {
           // necessary.  For example, if PanelMembers.Observations includes 1..1 BRAC1Variant and 1..1 BRAC2Variant,
           // then we know the array it maps two must have at least a lower cardinality of 2 (1 + 1 = 2).
           let minCard = 0;
+          // We need to keep track of the index where to insert extra includes type elements (if applicable)
+          let includesInsertIdx;
           const includesTypeRules = [];
           for (const incl of includes) {
             if (incl.path.length > 0) {
@@ -438,10 +439,30 @@ class FHIRExporter {
             }
             // Create and store a new rule, but remove "slice strategy" from the commands since it only applies to parent
             includesTypeRules.push(new mdls.FieldMappingRule(newSourcePath, new FieldTarget(t.target, t.commands.filter(c => c.key != 'slice strategy')).toRuleTarget()));
+            // Copy, update, and add specific child rules within the slice
+            let j=i+1;
+            for (; j < map.rules.length; j++) {
+              const sliceRule = map.rules[j];
+              // First check if this is a child of the slice path.  If not, stop looking and break.
+              if (sliceRule.sourcePath.length <= rule.sourcePath.length) {
+                break;
+              } else if (!rule.sourcePath.every((p, pIdx) => p.equals(sliceRule.sourcePath[pIdx]))) {
+                break;
+              }
+              // It's a match -- so it's a child of the slice path
+              // Substitute the original identifier in the path with the includesType identifier instead
+              const newSliceSourcePath = sliceRule.sourcePath.slice();
+              newSliceSourcePath[rule.sourcePath.length-1] = incl.isA;
+              includesTypeRules.push(new mdls.FieldMappingRule(newSliceSourcePath, sliceRule.target));
+            }
+            // We're at the end of the original rules defining the slices, so this is where we'll
+            // eventually need to insert the new rules.
+            includesInsertIdx = j;
           }
+
           // When we slice on something that has IncludesType constraints, the intention is not to make the base
           // type a slice.  Only the includes types should be slices.  So, *remove* the slice commands from the base.
-          newRules[newRules.length-1] = new mdls.FieldMappingRule(rule.sourcePath, t.target);
+          map.rules[i] = new mdls.FieldMappingRule(rule.sourcePath, t.target);
           // Now we modify the cardinality of what we're slicing (if necessary) to ensure the slices all fit
           if (minCard > 0) {
             let cardTarget = t.target;
@@ -455,19 +476,18 @@ class FHIRExporter {
             let fhirCard = getFHIRElementCardinality(ss);
             if (fhirCard.min < minCard) {
               // Insert the new CardinalityMappingRule above the base rule so it is applied first
-              newRules.splice(newRules.length-1, 0, new mdls.CardinalityMappingRule(cardTarget, new mdls.Cardinality(minCard, fhirCard.max)));
+              map.rules.splice(i, 0, new mdls.CardinalityMappingRule(cardTarget, new mdls.Cardinality(minCard, fhirCard.max)));
             }
           }
           // Now add the new rules we just created based on the includes types!
-          newRules.push(...includesTypeRules);
+          map.rules.splice(includesInsertIdx, 0, ...includesTypeRules);
         } else {
           // The strategy says to slice on includes, but there are none, so modify the rule to remove slicing commands.
           // We don't want to slice on something that has no slices defined!
-          newRules[newRules.length-1] = new mdls.FieldMappingRule(rule.sourcePath, t.target);
+          map.rules[i] = new mdls.FieldMappingRule(rule.sourcePath, t.target);
         }
       }
     }
-    map.rules = newRules;
 
     const sliceOnMap = new Map();
     const sliceAtMap = new Map();
@@ -2188,6 +2208,7 @@ class FHIRExporter {
     }
     if (elements.length > 1) {
       if (fieldTarget.hasInSliceCommand()) {
+        // It's in a slice, so try to find the element in the specific slice
         const [/*match*/,/*path*/,sliceName] = /(.*)\s*\[(.*)\]/.exec(fieldTarget.findInSliceCommand());
         element = elements.find(s => {
           return profile.snapshot.element.some(e => s.id.startsWith(e.id) && e.sliceName == sliceName);
@@ -2197,8 +2218,16 @@ class FHIRExporter {
           element = elements[0];
         }
       } else {
-        logger.error('Target resolves to multiple elements but is not sliced. ERROR_CODE:13044');
-        element = elements[0];
+        // It's not in a slice, so try to find the non-sliced path (for constraints on the base elements)
+        const nonSlices = elements.filter(s => {
+          return ! profile.snapshot.element.some(e => s.id.startsWith(e.id) && typeof e.sliceName !== 'undefined');
+        });
+        if (nonSlices.length === 1) {
+          element = nonSlices[0];
+        } else {
+          logger.error('Target resolves to multiple elements but is not sliced. ERROR_CODE:13044');
+          element = elements[0];
+        }
       }
     } else {
       element = elements[0];
@@ -2305,10 +2334,17 @@ class FHIRExporter {
           for (const itc of value.constraintsFilter.includesType.constraints) {
             if (itc.path.length == 0 && itc.isA.equals(identifier)) {
               // It did resolve from an includes type, so return a value referencing the includes type instead!
+              // Remove any of the direct type-ish constraints and card constraints since we're setting type & card
+              const constraintsToCopy = value.constraints.filter(c => {
+                return c.path.length === 0
+                  && !(c instanceof mdls.IncludesTypeConstraint)
+                  && !(c instanceof mdls.TypeConstraint)
+                  && !(c instanceof mdls.CardConstraint);
+              });
               if (value instanceof mdls.RefValue) {
-                value = new mdls.RefValue(itc.isA).withCard(itc.card).withConstraints(value.constraints);
+                value = new mdls.RefValue(itc.isA).withCard(itc.card).withConstraints(constraintsToCopy);
               } else {
-                value = new mdls.IdentifiableValue(itc.isA).withCard(itc.card).withConstraints(value.constraints);
+                value = new mdls.IdentifiableValue(itc.isA).withCard(itc.card).withConstraints(constraintsToCopy);
               }
               // Apply special marker used only in FHIR Exporter.  There is probably a more elegant way, but the
               // alternative right now seems to require a ton of code

--- a/lib/export.js
+++ b/lib/export.js
@@ -2176,30 +2176,44 @@ class FHIRExporter {
         sliceName = `gen-${elements.length+1}`;
       }
 
-      // Now add the section for the slice!
-      const sliceSection = profile.snapshot.element.filter(e => {
+      // Now add the snapshot and differential sections for the slice!
+      const ssSection = profile.snapshot.element.filter(e => {
         return e.id == baseElement.id || e.id.startsWith(`${baseElement.id}.`);
-      }).map(e => {
+      });
+      const sliceMapper = (e) => {
         const element = common.cloneJSON(e);
         element.id = element.id.replace(baseElement.id, `${baseElement.id}:${sliceName}`);
         return element;
-      });
-      const sliceSectionDf = { id: sliceSection[0].id, path: sliceSection[0].path, sliceName: sliceName };
+      };
+      const ssSliceSection = ssSection.map(sliceMapper);
+
+      // If there were existing differentials, we want to copy them over too
+      const dfSliceSection = ssSection.filter(e => common.getDifferentialElementById(profile, e.id, false))
+        .map(e => common.getDifferentialElementById(profile, e.id, false))
+        .map(sliceMapper);
+      // If there weren't existing differentials, at least add the base slice differential
+      if (dfSliceSection.length === 0 || dfSliceSection[0].id != ssSliceSection[0].id) {
+        dfSliceSection.splice(0, 0, { id: ssSliceSection[0].id, path: ssSliceSection[0].path, sliceName: sliceName });
+      }
+
       // The base slice section element has slicing (from the copy), but we don't need to repeat that
-      delete(sliceSection[0].slicing);
-      sliceSection[0].sliceName = sliceName;
+      delete(ssSliceSection[0].slicing);
+      delete(dfSliceSection[0].slicing);
+      ssSliceSection[0].sliceName = dfSliceSection[0].sliceName = sliceName;
+
       // If a sliceCard was passed in, set it
       if (typeof sliceCard !== 'undefined') {
-        setCardinalityOnFHIRElements(sliceCard, sliceSection[0], sliceSectionDf, true);
+        setCardinalityOnFHIRElements(sliceCard, ssSliceSection[0], dfSliceSection[0], true);
       }
-      // Add the differential w/ the sliceName
-      profile.differential.element.push(sliceSectionDf);
+
+      // Add the differentials
+      profile.differential.element.push(...dfSliceSection);
 
       // Find the insertion point, which should be at the end of any current slices
       let i = profile.snapshot.element.findIndex(e => e == baseElement) + 1;
       for ( ; i < profile.snapshot.element.length && profile.snapshot.element[i].path.startsWith(baseElement.path); i++);
       // Insert the section
-      profile.snapshot.element.splice(i, 0, ...sliceSection);
+      profile.snapshot.element.splice(i, 0, ...ssSliceSection);
     }
 
     if (fieldTarget.hasSliceOnCommand()) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -2297,8 +2297,23 @@ class FHIRExporter {
 
   // Given an identifier and a list of values, it will return the matching value, with all constraints aggregrated onto it
   findValueByIdentifier(identifier, values) {
-    for (const value of values) {
+    for (let value of values) {
       if (value instanceof mdls.IdentifiableValue && value.possibleIdentifiers.some(pid => pid.equals(identifier))) {
+        if (!identifier.equals(value.identifier) && !identifier.equals(value.effectiveIdentifier)) {
+          for (const itc of value.constraintsFilter.includesType.constraints) {
+            if (itc.path.length == 0 && itc.isA.equals(identifier)) {
+              if (value instanceof mdls.RefValue) {
+                value = new mdls.RefValue(itc.isA).withCard(itc.card).withConstraints(value.constraints);
+              } else {
+                value = new mdls.IdentifiableValue(itc.isA).withCard(itc.card).withConstraints(value.constraints);
+              }
+              // Apply special marker used only in FHIR Exporter.  There is probably a more elegant way, but the
+              // alternative right now seems to require a ton of code
+              value._derivedFromIncludesTypeConstraint = true;
+              break;
+            }
+          }
+        }
         return value;
       } else if (value instanceof mdls.ChoiceValue) {
         // First check to see if there is a type constraint to make this a single value type

--- a/lib/export.js
+++ b/lib/export.js
@@ -655,16 +655,16 @@ class FHIRExporter {
       return;
     }
 
-    // If this sourceValue came from an includesType, and there was a "slice at" command,
-    // then the includeType cardinality needs to be set at the base of the slice.
+    // If this sourceValue came from an includesType, then the includeType cardinality needs
+    // to be set at the base of the slice.
     const fieldTarget = FieldTarget.parse(rule.target);
-    let sliceAtCard;
-    if (sourceValue._derivedFromIncludesTypeConstraint && fieldTarget.hasSliceAtCommand()) {
-      sliceAtCard = sourceValue.card;
+    let sliceCard;
+    if (sourceValue._derivedFromIncludesTypeConstraint) {
+      sliceCard = sourceValue.card;
     }
 
 
-    let ss = this.getSnapshotElementForFieldTarget(profile, fieldTarget, sliceAtCard);
+    let ss = this.getSnapshotElementForFieldTarget(profile, fieldTarget, sliceCard);
     if (typeof ss === 'undefined' && fieldTarget.target.endsWith('[x]')) {
       // In some cases (like FHIR VitalSigns profiles), the value[x] is removed and replaced w/ instance (e.g., valueQuantity)
       // TODO: Support when sourceValue is a choice
@@ -675,7 +675,7 @@ class FHIRExporter {
         if (typeof map !== 'undefined') {
           const newTarget = fieldTarget.target.replace(/\[x\]$/, common.capitalize(map.targetItem));
           const newFieldTarget = new FieldTarget(newTarget, fieldTarget.commands, fieldTarget.comments);
-          ss = this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sliceAtCard);
+          ss = this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sliceCard);
         }
       }
     }
@@ -698,7 +698,7 @@ class FHIRExporter {
       this.unrollContentReference(profile, ss);
     }
 
-    if (typeof sliceAtCard === 'undefined') {
+    if (typeof sliceCard === 'undefined') {
       this.processFieldToFieldCardinality(map, rule, profile, ss, df);
     }
     this.processFieldToFieldType(map, def, rule, profile, ss, df);
@@ -2082,7 +2082,7 @@ class FHIRExporter {
     return this._fhir.find(id);
   }
 
-  getSnapshotElementForFieldTarget(profile, fieldTarget, sliceAtCard) {
+  getSnapshotElementForFieldTarget(profile, fieldTarget, sliceCard) {
     // First handle the case where we're referencing an option in a choice (TODO: Support drilling into options)
     let choice;
     let parts = [profile.type, ...fieldTarget.target.split('.')];
@@ -2168,9 +2168,9 @@ class FHIRExporter {
       // The base slice section element has slicing (from the copy), but we don't need to repeat that
       delete(sliceSection[0].slicing);
       sliceSection[0].sliceName = sliceName;
-      // If a sliceAtCard was passed in, set it
-      if (typeof sliceAtCard !== 'undefined') {
-        setCardinalityOnFHIRElements(sliceAtCard, sliceSection[0], sliceSectionDf, true);
+      // If a sliceCard was passed in, set it
+      if (typeof sliceCard !== 'undefined') {
+        setCardinalityOnFHIRElements(sliceCard, sliceSection[0], sliceSectionDf, true);
       }
       // Add the differential w/ the sliceName
       profile.differential.element.push(sliceSectionDf);
@@ -2299,9 +2299,12 @@ class FHIRExporter {
   findValueByIdentifier(identifier, values) {
     for (let value of values) {
       if (value instanceof mdls.IdentifiableValue && value.possibleIdentifiers.some(pid => pid.equals(identifier))) {
+        // If the identifier isn't the value's direct identifier or effective identifier, it's
+        // probably from an includes type.  Check for that case.
         if (!identifier.equals(value.identifier) && !identifier.equals(value.effectiveIdentifier)) {
           for (const itc of value.constraintsFilter.includesType.constraints) {
             if (itc.path.length == 0 && itc.isA.equals(identifier)) {
+              // It did resolve from an includes type, so return a value referencing the includes type instead!
               if (value instanceof mdls.RefValue) {
                 value = new mdls.RefValue(itc.isA).withCard(itc.card).withConstraints(value.constraints);
               } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",
@@ -28,6 +28,6 @@
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.2.1"
+    "shr-models": "^5.2.2"
   }
 }


### PR DESCRIPTION
This PR addresses #72 by fixing several bugs around how "include types" constraints are processed, particularly in regard to cardinalities and applying profile references.  To fix all the bugs, it must be paired with the PR standardhealth/shr-models#18.

In addition, the full solution to the reported error also requires changes to some definitions.  In particular, for any element that is based on `Observation` and has _required_ (e.g., `1..1`) "includes types" constraints on `Components.ObservationComponent`, then `Component` must also be constrained to `1..1`.  For example, in the `BloodPressure` element, this:
```
Components.ObservationComponent
includes 1..1 	SystolicPressure
includes 1..1 	DiastolicPressure
```
should be changed to:
```
1..1 Components
Components.ObservationComponent
includes 1..1 	SystolicPressure
includes 1..1 	DiastolicPressure
```
Without that change, `Components` is still `0..1`, so the `SystolicPressure` and `DiastolicPressure` aren't _really_ required.  On the FHIR side, however, the mapping results in them being required, so the cardinalities don't match and they cause an error.  As noted above, this type of issue is solved by constraining `Components` to `1..1`.