### PR TITLE
Fix crash w/ fixed mapping rules

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -444,7 +444,10 @@ class FHIRExporter {
             for (; j < map.rules.length; j++) {
               const sliceRule = map.rules[j];
               // First check if this is a child of the slice path.  If not, stop looking and break.
-              if (sliceRule.sourcePath.length <= rule.sourcePath.length) {
+              if (typeof sliceRule.sourcePath === 'undefined') {
+                // pass through rules like "fix related.type to #has-member"
+                continue;
+              } else if (sliceRule.sourcePath.length <= rule.sourcePath.length) {
                 break;
               } else if (!rule.sourcePath.every((p, pIdx) => p.equals(sliceRule.sourcePath[pIdx]))) {
                 break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The mapping enhancement code had one loop that assumed rules had a `sourcePath`.  Since this isn't true for _fixed_ mapping rules, there was a crash.

For example, this fixed mapping rule in the `Observation` mapping:
```
fix related.type to #has-member
```
caused this crash:
```
[23:32:54.983Z] ERROR shr:  (module=shr-fhir-export)
    Unexpected error processing mapping to FHIR. ERROR_CODE:13049 TypeError: Cannot read property 'length' of undefined
        at FHIRExporter.enhanceMap (C:\Users\mkramer\Documents\GitHub\shr-cli-5_3_2\node_modules\shr-fhir-export\lib\export.js:447:39)
        at FHIRExporter.mappingToProfile (C:\Users\mkramer\Documents\GitHub\shr-cli-5_3_2\node_modules\shr-fhir-export\lib\export.js:136:18)
        at FHIRExporter.export (C:\Users\mkramer\Documents\GitHub\shr-cli-5_3_2\node_modules\shr-fhir-export\lib\export.js:83:14)
        at Object.exportToFHIR (C:\Users\mkramer\Documents\GitHub\shr-cli-5_3_2\node_modules\shr-fhir-export\lib\export.js:33:25)
        at Object.<anonymous> (C:\Users\mkramer\Documents\GitHub\shr-cli-5_3_2\app.js:97:29)
        at Module._compile (module.js:570:32)
        at Object.Module._extensions..js (module.js:579:10)
        at Module.load (module.js:487:32)
        at tryModuleLoad (module.js:446:12)
        at Function.Module._load (module.js:438:3)
```

This PR addresses that, fixing #74.