### PR TITLE
Support more fixed types

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -42,25 +42,28 @@ function getFHIRElementByID(elements, id) {
   return elements.find(e => e.id == id);
 }
 
-var idCounter = 1;
+var sliceIDCounters = new Map();
 
-function addSlicingToBaseElement(snapshotEl, differentialEl, discType, discPath) {
+function addSlicingToBaseElement(structureDef, snapshotEl, differentialEl, discType, discPath) {
   if (typeof snapshotEl.slicing !== 'undefined') {
     // A slicing already exists, so just add the missing discriminator
     if (!snapshotEl.slicing.discriminator.some(d => d.type == discType && d.path == discPath)) {
       snapshotEl.slicing.discriminator.push({ type: discType, path: discPath });
     }
   } else {
-    snapshotEl.slicing = createSlicingObject(discType, discPath);
+    snapshotEl.slicing = createSlicingObject(structureDef, discType, discPath);
   }
   if (typeof differentialEl !== 'undefined' && differentialEl != null) {
     differentialEl.slicing = snapshotEl.slicing;
   }
 }
 
-function createSlicingObject(discType, discPath) {
+function createSlicingObject(structureDef, discType, discPath) {
+  if (!sliceIDCounters.has(structureDef.id)) {
+    sliceIDCounters.set(structureDef.id, { count: 1});
+  }
   const slicing = {
-    id : (idCounter++).toString(),
+    id : `${sliceIDCounters.get(structureDef.id).count++}`,
     discriminator : [{
       type: discType,
       path: discPath

--- a/lib/common.js
+++ b/lib/common.js
@@ -146,7 +146,7 @@ function todayString() {
 }
 
 function isCustomProfile(profile) {
-  return typeof profile._noDiffProfile === 'undefined';
+  return profile._shr;
 }
 
 class ProcessTracker {

--- a/lib/export.js
+++ b/lib/export.js
@@ -224,7 +224,7 @@ class FHIRExporter {
         if (profile.differential.element.filter(e => e.path == `${profile.type}.${extType}`).length > 0) {
           // Apparently we only need to modify the snapshot (based on published IGs and examples)
           const ssEl = common.getSnapshotElement(profile, extType);
-          common.addSlicingToBaseElement(ssEl, null, 'value', 'url');
+          common.addSlicingToBaseElement(profile, ssEl, null, 'value', 'url');
         }
       }
 
@@ -865,7 +865,7 @@ class FHIRExporter {
 
     // Slice the choice and add an explicit reference (e.g. value[x] --> valueCodeableConcept)
     // See: https://chat.fhir.org/#narrow/stream/implementers/subject/StructureDefinition.20with.20slice.20on.20choice)
-    common.addSlicingToBaseElement(snapshotEl, differentialEl, 'type', '$this');
+    common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'type', '$this');
 
     // Build the new choice element
     const newType = { code: sdToAdd.type };
@@ -1774,15 +1774,15 @@ class FHIRExporter {
       // Need to set the slicing up on the base element
       switch (sourceValue.identifier.fqn) {
       case 'code':
-        common.addSlicingToBaseElement(snapshotEl, differentialEl, 'value', '$this');
+        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', '$this');
         break;
       case 'shr.core.Coding':
       case 'shr.core.Quantity':
-        common.addSlicingToBaseElement(snapshotEl, differentialEl, 'value', 'system');
-        common.addSlicingToBaseElement(snapshotEl, differentialEl, 'value', 'code');
+        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'system');
+        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'code');
         break;
       case 'shr.core.CodeableConcept':
-        common.addSlicingToBaseElement(snapshotEl, differentialEl, 'value', 'coding');
+        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'coding');
         break;
       default:
         logger.error('Can\'t fix code on %s because source value isn\'t code-like. This should never happen and is probably a bug in the tool. ERROR_CODE:13032', snapshotEl.id);
@@ -1926,7 +1926,7 @@ class FHIRExporter {
       }
 
       const baseCodingDf = common.getDifferentialElementById(profile, baseCoding.id, true);
-      common.addSlicingToBaseElement(baseCoding, baseCodingDf, 'value', 'path');
+      common.addSlicingToBaseElement(profile, baseCoding, baseCodingDf, 'value', 'path');
       const sliceName = `Fixed_${code.code}`;
       const sliceEl = {
         id: `${baseCoding.id}:${sliceName}`,
@@ -2308,7 +2308,7 @@ class FHIRExporter {
 
       // Apply the discriminator to the base element in the snapshot and the differential
       const discType = fieldTarget.hasSliceOnTypeCommand() ? fieldTarget.findSliceOnTypeCommand().value : 'value';
-      common.addSlicingToBaseElement(baseElement, null, discType, fieldTarget.findSliceOnCommand().value);
+      common.addSlicingToBaseElement(profile, baseElement, null, discType, fieldTarget.findSliceOnCommand().value);
       let df = common.getDifferentialElementById(profile, baseElement.id);
       if (typeof df === 'undefined') {
         df = { id: baseElement.id, path: baseElement.path };

--- a/lib/export.js
+++ b/lib/export.js
@@ -936,10 +936,24 @@ class FHIRExporter {
       };
     }
 
-    // TODO: Don't allow 'fix value[x].boolean to 'hello'
-    // TODO: Don't allow multiple fixings on a single element if its upper card is 1
+    // If the path is something like value[x].boolean, get the intended type
+    let targetType;
+    const parts = target.split('.');
+    if (parts.length > 1 && parts[parts.length-2].endsWith('[x]')) {
+      targetType = parts[parts.length-1];
+    }
 
-    // Guess the type based on the value
+    // A function to find the type in the SS based on the allowable and or target types
+    const getType = (ss, allowableTypes) => {
+      if (targetType && allowableTypes.indexOf(targetType) === -1) {
+        return; // if the target is not allowable for the passed in value, it's a type mismatch
+      }
+      return ss.type.find(t => {
+        return allowableTypes.indexOf(t.code) >= 0;
+      });
+    };
+
+    // Guess the type based on the value (e.g., #bar is a code, 12 is an integer, etc)
 
     // Fixed codes (and fallback to URIs with a # character)
     const codeRE = /^(\w+:\/?\/?[^\s]+)?#[^\s]+$/; // regex that matches http://foo#bar or #bar
@@ -948,9 +962,7 @@ class FHIRExporter {
       if (fixedValue[0] !== '#') {
         allowableTypes.push('uri');
       }
-      const type = ss.type.find(t => {
-        return allowableTypes.indexOf(t.code) >= 0;
-      });
+      const type = getType(ss, allowableTypes);
       if (typeof type != 'undefined') {
         if (type.code === 'uri') {
           this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
@@ -970,7 +982,7 @@ class FHIRExporter {
     // Fixed booleans
     const booleanRE = /^(true|false)$/; // regex that matches true or false
     if (booleanRE.test(fixedValue)) {
-      const type = ss.type.find(t => t.code == 'boolean');
+      const type = getType(ss, ['boolean']);
       if (typeof type != 'undefined') {
         this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue === 'true', type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
@@ -987,9 +999,9 @@ class FHIRExporter {
     const stringRE = /^(('(.*)')|("(.*)"))$/; // regex that matches 'hello' or "hello"
     const matches = fixedValue.match(stringRE);
     if (matches && matches.length > 0) {
-      const stringValue = fixedValue[0] === `'` ? matches[3] : matches[5];
-      const type = ss.type.find(t => t.code == 'string');
+      const type = getType(ss, ['string']);
       if (typeof type != 'undefined') {
+        const stringValue = fixedValue[0] === `'` ? matches[3] : matches[5];
         this.fixPrimitiveValueOnElement(profile, ss, df, stringValue, type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
           profile.differential.element.push(df);
@@ -1025,9 +1037,7 @@ class FHIRExporter {
           allowableTypes.push('date', 'dateTime');
         }
       }
-      const type = ss.type.find(t => {
-        return allowableTypes.indexOf(t.code) >= 0;
-      });
+      const type = getType(ss, allowableTypes);
       if (typeof type !== 'undefined') {
         if (type.code === 'date' || type.code === 'dateTime') {
           this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
@@ -1047,9 +1057,7 @@ class FHIRExporter {
     const dateRE = /^-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/; // regex from FHIR spec
     if (dateRE.test(fixedValue)) {
       const allowableTypes = fixedValue.indexOf('T') >= 0 ? ['dateTime', 'instant'] : ['date', 'dateTime'];
-      const type = ss.type.find(t => {
-        return allowableTypes.indexOf(t.code) >= 0;
-      });
+      const type = getType(ss, allowableTypes);
       if (typeof type != 'undefined') {
         this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
@@ -1064,7 +1072,7 @@ class FHIRExporter {
     // Fixed times
     const timeRE = /^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?$/; // regex from FHIR spec
     if (timeRE.test(fixedValue)) {
-      const type = ss.type.find(t => t.code == 'time');
+      const type = getType(ss, ['time']);
       if (typeof type != 'undefined') {
         this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
@@ -1079,7 +1087,7 @@ class FHIRExporter {
     // Fixed URIs
     const uriRE = /^\w+:\/?\/?[^\s]+$/; // regex that matches http://google.com or urn:1.2.3.4.5
     if (uriRE.test(fixedValue)) {
-      const type = ss.type.find(t => t.code == 'uri');
+      const type = getType(ss, ['uri']);
       if (typeof type != 'undefined') {
         this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
@@ -2033,6 +2041,10 @@ class FHIRExporter {
       return;
     }
     snapshotEl[property] = differentialEl[property] = value;
+    // If max cardinality is 1, then remove all other types from the choice
+    if (snapshotEl.max === '1') {
+      snapshotEl.type = differentialEl.type = snapshotEl.type.filter(t => t.code === typeCode);
+    }
     if (REPORT_PROFILE_INDICATORS) {
       this.addFixedValueIndicator(profile, snapshotEl.path, value);
     }

--- a/lib/export.js
+++ b/lib/export.js
@@ -830,21 +830,27 @@ class FHIRExporter {
     profile.snapshot.element = [...ssList.slice(0, unrolledIdx + 1), ...unrolled, ...ssList.slice(unrolledIdx + 1)];
   }
 
-  addExplicitChoiceElement(sourceIdentifier, profile, snapshotEl, differentialEl) {
+  addExplicitChoiceElement(identifier, profile, snapshotEl, differentialEl) {
     if (!snapshotEl.path.endsWith('[x]')) {
       logger.error('Cannot make choice element explicit since it is not a choice ([x]): %s. ERROR_CODE:13011', snapshotEl.id);
-      return;
+      return [];
     }
     let sdToAdd;
-    if (snapshotEl.type.length == 1 && snapshotEl.type[0].code == 'Extension') {
+    if (typeof identifier === 'string') {
+      sdToAdd = this.lookupStructureDefinition(identifier, true);
+      if (typeof sdToAdd === 'undefined') {
+        logger.error('Cannot make choice element explicit at %s. Invalid identifier: %s. ERROR_CODE:13???', snapshotEl.id, identifier);
+        return [];
+      }
+    } else if (snapshotEl.type.length == 1 && snapshotEl.type[0].code == 'Extension') {
       // Lookup the extension
-      sdToAdd = this._extensionExporter.lookupExtension(sourceIdentifier, true, true);
+      sdToAdd = this._extensionExporter.lookupExtension(identifier, true, true);
     } else {
       // Look up the profile (TODO: Support for primitives?)
-      sdToAdd = this.lookupProfile(sourceIdentifier, true, true);
+      sdToAdd = this.lookupProfile(identifier, true, true);
       if (typeof sdToAdd === 'undefined') {
-        logger.error('Cannot make choice element explicit at %s. Invalid SHR identifier: %s. ERROR_CODE:13012', snapshotEl.id, sourceIdentifier.fqn);
-        return;
+        logger.error('Cannot make choice element explicit at %s. Invalid SHR identifier: %s. ERROR_CODE:13012', snapshotEl.id, identifier.fqn);
+        return [];
       }
     }
 
@@ -853,7 +859,8 @@ class FHIRExporter {
     const baseId = `${snapshotEl.id.replace('[x]', sdToAdd.type)}:${sliceName}`;
     const existing = profile.snapshot.element.find(e => e.id == baseId);
     if (existing) {
-      return existing;
+      const dfExisting = common.getDifferentialElementById(profile, existing.id, true);
+      return [existing, dfExisting];
     }
 
     // Slice the choice and add an explicit reference (e.g. value[x] --> valueCodeableConcept)
@@ -868,7 +875,7 @@ class FHIRExporter {
     if (sdToAdd.type === 'Extension' || common.isCustomProfile(sdToAdd)) {
       newType.profile = sdToAdd.url;
     }
-    const choiceEl = {
+    const ssChoiceEl = {
       id: baseId,
       path: snapshotEl.path.replace('[x]', sdToAdd.type),
       sliceName,
@@ -882,9 +889,20 @@ class FHIRExporter {
 
     // Insert the explicit element into the snapshot
     let start = profile.snapshot.element.findIndex(e => e.id == snapshotEl.id) + 1;
-    profile.snapshot.element.splice(start, 0, choiceEl);
+    profile.snapshot.element.splice(start, 0, ssChoiceEl);
 
-    return choiceEl;
+    // Find or create the corresponding differential
+    let dfChoiceEl = common.getDifferentialElementById(profile, ssChoiceEl.id);
+    if (typeof dfChoiceEl === 'undefined') {
+      dfChoiceEl = {
+        id: ssChoiceEl.id,
+        path: ssChoiceEl.path,
+        type: ssChoiceEl.type
+      };
+      profile.differential.element.push(dfChoiceEl);
+    }
+
+    return [ssChoiceEl, dfChoiceEl];
   }
 
   processCardinalityMappingRule(map, rule, profile) {
@@ -1451,16 +1469,7 @@ class FHIRExporter {
     // If it is a choice, we actually want to make the specific choice explicit and apply constraints there
     if (snapshotEl.path.endsWith('[x]')) {
       // Swap out the snapshot and differential variables with the new ones
-      snapshotEl = this.addExplicitChoiceElement(sourceValue.effectiveIdentifier, profile, snapshotEl, differentialEl);
-      differentialEl = common.getDifferentialElementById(profile, snapshotEl.id);
-      if (typeof differentialEl === 'undefined') {
-        differentialEl = {
-          id: snapshotEl.id,
-          path: snapshotEl.path,
-          type: snapshotEl.type
-        };
-        profile.differential.element.push(differentialEl);
-      }
+      [snapshotEl, differentialEl] = this.addExplicitChoiceElement(sourceValue.effectiveIdentifier, profile, snapshotEl, differentialEl);
     }
 
     // First handle own constraints
@@ -1793,6 +1802,10 @@ class FHIRExporter {
       codeType = identifier.fqn;
     } else {
       codeType = identifier;
+    }
+
+    if (snapshotEl.path.endsWith('[x]')) {
+      [snapshotEl, differentialEl] = this.addExplicitChoiceElement(identifier, profile, snapshotEl, differentialEl);
     }
 
     // Different behavior based on code type
@@ -2246,7 +2259,16 @@ class FHIRExporter {
       }
       // The path doesn't exist.  We may need to unroll a nested data type in the path's parent
       const parentEl = profile.snapshot.element.find(e => e.path == parts.slice(0, i).join('.'));
-      if (typeof parentEl === 'undefined' || !Array.isArray(parentEl.type) || parentEl.type.length != 1) {
+      if (typeof parentEl !== 'undefined' && parentEl.path.endsWith('[x]') && parentEl.type.some(t => t.code === parts[i])) {
+        // The target path references a type in a choice (e.g., value[x].Quantity), so we need to make an explicit
+        // choice element for that type, and then update the path to reference it
+        const parentDfEl = common.getDifferentialElementById(profile, parentEl.id, true);
+        const [ssEl] = this.addExplicitChoiceElement(parts[i], profile, parentEl, parentDfEl);
+        // Clone the target with the new path and try again
+        const newTarget = fieldTarget.target.replace(`${parts[i-1]}.${parts[i]}`, ssEl.path.split('.').pop());
+        const newFieldTarget = new FieldTarget(newTarget, fieldTarget.commands, fieldTarget.comments);
+        return this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sliceCard);
+      } else if (typeof parentEl === 'undefined' || !Array.isArray(parentEl.type) || parentEl.type.length != 1) {
         // The parent isn't a drillable element
         return;
       } else if (typeof parentEl.type[0].code === 'undefined' || parentEl.type[0].code == 'Reference') {

--- a/lib/export.js
+++ b/lib/export.js
@@ -943,14 +943,26 @@ class FHIRExporter {
       targetType = parts[parts.length-1];
     }
 
-    // A function to find the type in the SS based on the allowable and or target types
-    const getType = (ss, allowableTypes) => {
-      if (targetType && allowableTypes.indexOf(targetType) === -1) {
-        return; // if the target is not allowable for the passed in value, it's a type mismatch
+    // A function to fix the code or print out a relevant error if it's not the right type
+    const fixIt = (profile, ss, df, value, ...allowableTypes) => {
+      let type;
+      if (typeof targetType === 'undefined' || allowableTypes.indexOf(targetType) !== -1) {
+        type = ss.type.find(t => {
+          return allowableTypes.indexOf(t.code) >= 0;
+        });
       }
-      return ss.type.find(t => {
-        return allowableTypes.indexOf(t.code) >= 0;
-      });
+      // If value is a function, it means it should be called w/ type to resolve to the real value
+      if (typeof value === 'function') {
+        value = value(type);
+      }
+      if (typeof type != 'undefined') {
+        this.fixValueOnElement(profile, ss, df, value, type.code);
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not one of: %s. ERROR_CODE:13056', target, fixedValue, target, allowableTypes.join(', '));
+      }
     };
 
     // Guess the type based on the value (e.g., #bar is a code, 12 is an integer, etc)
@@ -962,35 +974,21 @@ class FHIRExporter {
       if (fixedValue[0] !== '#') {
         allowableTypes.push('uri');
       }
-      const type = getType(ss, allowableTypes);
-      if (typeof type != 'undefined') {
-        if (type.code === 'uri') {
-          this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
-        } else {
+      const value = (type) => {
+        if (type && type.code !== 'uri') {
           const parts = fixedValue.split('#', 2);
-          this.fixCodeOnElement(type.code, profile, ss, df, new mdls.Concept(parts[0], parts[1]));
+          return new mdls.Concept(parts[0], parts[1]);
         }
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not a code, Coding, or CodeableConcept. ERROR_CODE:13???', target, fixedValue, target);
-      }
+        return fixedValue;
+      };
+      fixIt(profile, ss, df, value, ...allowableTypes);
       return;
     }
 
     // Fixed booleans
     const booleanRE = /^(true|false)$/; // regex that matches true or false
     if (booleanRE.test(fixedValue)) {
-      const type = getType(ss, ['boolean']);
-      if (typeof type != 'undefined') {
-        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue === 'true', type.code);
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not a boolean. ERROR_CODE:13???', target, fixedValue, target);
-      }
+      fixIt(profile, ss, df, fixedValue === 'true', 'boolean');
       return;
     }
 
@@ -998,17 +996,8 @@ class FHIRExporter {
     // NOTE that the grammar right now chokes if you try to fix to a string with a space in it
     const stringRE = /^(('(.*)')|("(.*)"))$/; // regex that matches 'hello' or "hello"
     const matches = fixedValue.match(stringRE);
-    if (matches && matches.length > 0) {
-      const type = getType(ss, ['string']);
-      if (typeof type != 'undefined') {
-        const stringValue = fixedValue[0] === `'` ? matches[3] : matches[5];
-        this.fixPrimitiveValueOnElement(profile, ss, df, stringValue, type.code);
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not a string. ERROR_CODE:13???', target, fixedValue, target);
-      }
+    if (matches) {
+      fixIt(profile, ss, df, fixedValue[0] === `'` ? matches[3] : matches[5], 'string');
       return;
     }
 
@@ -1037,19 +1026,8 @@ class FHIRExporter {
           allowableTypes.push('date', 'dateTime');
         }
       }
-      const type = getType(ss, allowableTypes);
-      if (typeof type !== 'undefined') {
-        if (type.code === 'date' || type.code === 'dateTime') {
-          this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
-        } else {
-          this.fixPrimitiveValueOnElement(profile, ss, df, numValue, type.code);
-        }
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not one of: %s. ERROR_CODE:13???', target, fixedValue, target, allowableTypes.join(', '));
-      }
+      const value = (type) => type && ! type.code.startsWith('date') ? numValue : fixedValue;
+      fixIt(profile, ss, df, value, ...allowableTypes);
       return;
     }
 
@@ -1057,50 +1035,26 @@ class FHIRExporter {
     const dateRE = /^-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/; // regex from FHIR spec
     if (dateRE.test(fixedValue)) {
       const allowableTypes = fixedValue.indexOf('T') >= 0 ? ['dateTime', 'instant'] : ['date', 'dateTime'];
-      const type = getType(ss, allowableTypes);
-      if (typeof type != 'undefined') {
-        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not one of: %s. ERROR_CODE:13???', target, fixedValue, target, allowableTypes.join(', '));
-      }
+      fixIt(profile, ss, df, fixedValue, ...allowableTypes);
       return;
     }
 
     // Fixed times
     const timeRE = /^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?$/; // regex from FHIR spec
     if (timeRE.test(fixedValue)) {
-      const type = getType(ss, ['time']);
-      if (typeof type != 'undefined') {
-        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not a time. ERROR_CODE:13???', target, fixedValue, target);
-      }
+      fixIt(profile, ss, df, fixedValue, 'time');
       return;
     }
 
     // Fixed URIs
     const uriRE = /^\w+:\/?\/?[^\s]+$/; // regex that matches http://google.com or urn:1.2.3.4.5
     if (uriRE.test(fixedValue)) {
-      const type = getType(ss, ['uri']);
-      if (typeof type != 'undefined') {
-        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not a URI. ERROR_CODE:13???', target, fixedValue, target);
-      }
+      fixIt(profile, ss, df, fixedValue, 'uri');
       return;
     }
 
     // If we got this far, it's a currently unsupported use case
-    logger.error('Could not fix %s to %s; failed to detect compatible type for value %s. ERROR_CODE:13???', target, fixedValue, fixedValue);
+    logger.error('Could not fix %s to %s; failed to detect compatible type for value %s. ERROR_CODE:13057', target, fixedValue, fixedValue);
   }
 
   processFieldToFieldCardinality(map, rule, profile, snapshotEl, differentialEl) {
@@ -2017,17 +1971,22 @@ class FHIRExporter {
     if (boolConstraints.length > 0) {
       [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
       const boolValue = boolConstraints[0].value;
-      this.fixPrimitiveValueOnElement(profile, snapshotEl, differentialEl, boolValue, 'boolean');
+      this.fixValueOnElement(profile, snapshotEl, differentialEl, boolValue, 'boolean');
       if (boolConstraints.length > 1) {
         logger.error('Found more than one boolean to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13036', snapshotEl.id);
       }
     }
   }
 
-  fixPrimitiveValueOnElement(profile, snapshotEl, differentialEl, value, typeCode) {
+  fixValueOnElement(profile, snapshotEl, differentialEl, value, typeCode) {
     if (! snapshotEl.type.some(t => t.code === typeCode)) {
       // This can't be fixed to the value, as it's not the right type
-      logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13???', snapshotEl.path, value, typeCode);
+      logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13058', snapshotEl.path, value, typeCode);
+      return;
+    }
+    // Codes require special handling, so outsource to the code-specific function if needed
+    if (['code', 'Coding', 'CodeableConcept'].indexOf(typeCode) !== -1) {
+      this.fixCodeOnElement(typeCode, profile, snapshotEl, differentialEl, value);
       return;
     }
     const property = `fixed${common.capitalize(typeCode)}`;
@@ -2037,7 +1996,7 @@ class FHIRExporter {
         return;
       }
       // Found another non-matching fixed value.  Put on the brakes.
-      logger.error('Cannot fix %s to %s since it is already fixed to %s. ERROR_CODE:13???', snapshotEl.path, value, snapshotEl[property]);
+      logger.error('Cannot fix %s to %s since it is already fixed to %s. ERROR_CODE:13059', snapshotEl.path, value, snapshotEl[property]);
       return;
     }
     snapshotEl[property] = differentialEl[property] = value;

--- a/lib/export.js
+++ b/lib/export.js
@@ -2073,7 +2073,7 @@ class FHIRExporter {
     }
     snapshotEl[property] = differentialEl[property] = value;
     // If max cardinality is 1, then remove all other types from the choice
-    if (snapshotEl.max === '1') {
+    if (snapshotEl.max === '1' && snapshotEl.type.length > 1) {
       snapshotEl.type = differentialEl.type = snapshotEl.type.filter(t => t.code === typeCode);
     }
     if (REPORT_PROFILE_INDICATORS) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -200,6 +200,7 @@ class FHIRExporter {
       }
 
       // When SHR specifies a choice value, remove the others!
+      const choiceElementIDsToRemove = [];
       for (const el of profile.snapshot.element) {
         if (el.path.endsWith('[x]') || (el.type && el.type.length > 1)) {
           const shrSelected = el.type.filter(t => t._shrSelected).map(t => {
@@ -216,7 +217,50 @@ class FHIRExporter {
             }
             df.type = el.type;
           }
+          // If it's a choice of one now, and there is an explicit path already, remove the choice.
+          // e.g., don't have value[x] w/ only 'Quantity' *and* valueQuantity (as they're redundant).
+          if (el.path.endsWith('[x]') && el.type.length === 1) {
+            // Check to see if explicit path (e.g., valueQuantity) exists
+            const explicitPath = el.path.replace(/\[x\]$/, common.capitalize(el.type[0].code));
+            const explicitEl = profile.snapshot.element.find(e => e.path === explicitPath);
+            if (typeof explicitEl !== 'undefined') {
+              // Since we're removing the [x], we don't need the special slice either
+              if (el.slicing && el.slicing.discriminator.some(d => d.type === 'type' && d.path === '$this')) {
+                if (explicitEl.id.endsWith(`:${explicitEl.sliceName}`)) {
+                  // Grab the original ID and determine the new ID
+                  const originalID = explicitEl.id;
+                  const newID = originalID.substr(0, explicitEl.id.lastIndexOf(':'));
+                  // Remove slicename from the snapshot
+                  delete(explicitEl.sliceName);
+                  // Fixup all snapshots rooted in this ID
+                  for (const thisEl of profile.snapshot.element) {
+                    if (thisEl.id.startsWith(originalID)) {
+                      thisEl.id = thisEl.id.replace(originalID, newID);
+                    }
+                  }
+                  // Fixup the differential
+                  const explicitDfEl = common.getDifferentialElementById(profile, explicitEl.id);
+                  if (typeof explicitDfEl !== 'undefined') {
+                    // Remove slicename from the differential
+                    delete(explicitDfEl.sliceName);
+                  }
+                  // Fixup all differentials rooted in this ID
+                  for (const thisEl of profile.differential.element) {
+                    if (thisEl.id.startsWith(originalID)) {
+                      thisEl.id = thisEl.id.replace(originalID, newID);
+                    }
+                  }
+                }
+              }
+              choiceElementIDsToRemove.push(el.id);
+            }
+          }
         }
+      }
+      // Remove any choice (e.g., value[x]) elements that were deemed redundant
+      if (choiceElementIDsToRemove.length > 0) {
+        profile.snapshot.element = profile.snapshot.element.filter(e => !choiceElementIDsToRemove.some(id => id === e.id));
+        profile.differential.element = profile.differential.element.filter(e => !choiceElementIDsToRemove.some(id => id === e.id));
       }
 
       // Remove any temporary properties we used to help along the way
@@ -857,9 +901,16 @@ class FHIRExporter {
       }
     }
 
+    // Mark the choice as selected, so we can filter down the choice to selected types only later
+    for (const type of snapshotEl.type) {
+      if (type.code === sdToAdd.type) {
+        this.markSelectedOptionsInChoice(snapshotEl.type, [type]);
+      }
+    }
+
     // Check to be sure we don't already have one
     const sliceName = sdToAdd.id;
-    const baseId = `${snapshotEl.id.replace('[x]', common.capitalize(sdToAdd.type))}:${sliceName}`;
+    const baseId = `${snapshotEl.id.replace(/\[x\]$/, common.capitalize(sdToAdd.type))}:${sliceName}`;
     const existing = profile.snapshot.element.find(e => e.id == baseId);
     if (existing) {
       const dfExisting = common.getDifferentialElementById(profile, existing.id, true);
@@ -880,12 +931,17 @@ class FHIRExporter {
     }
     const ssChoiceEl = {
       id: baseId,
-      path: snapshotEl.path.replace('[x]', common.capitalize(sdToAdd.type)),
+      path: snapshotEl.path.replace(/\[x\]$/, common.capitalize(sdToAdd.type)),
       sliceName,
       short: snapshotEl.short,
       definition: snapshotEl.definition,
       min: snapshotEl.min,
       max: snapshotEl.max,
+      base: {
+        path: snapshotEl.path,
+        min: snapshotEl.min,
+        max: snapshotEl.max
+      },
       type: [newType],
       isSummary: snapshotEl.isSummary
     };

--- a/lib/export.js
+++ b/lib/export.js
@@ -116,8 +116,12 @@ class FHIRExporter {
       logger.info('Profile Indicators JSON:', JSON.stringify(indicatorJSON, null, 2));
     }
 
+    const profiles = Array.from(this._profilesMap.values()).filter(p => common.isCustomProfile(p));
+    for (const p of profiles) {
+      delete(p._shr);
+    }
     return {
-      profiles: Array.from(this._profilesMap.values()).filter(p => common.isCustomProfile(p)),
+      profiles,
       extensions: this._extensionExporter.extensions,
       valueSets: this._valueSetExporter.valueSets,
       codeSystems: this._codeSystemExporter.codeSystems,
@@ -147,6 +151,7 @@ class FHIRExporter {
         return;
       }
       let profile = common.cloneJSON(def);
+      profile._shr = true;
       delete(profile.meta);
       delete(profile.extension);
       delete(profile.version);
@@ -262,8 +267,6 @@ class FHIRExporter {
         const originalId = profile.id;
         // Now re-set the profile to the original resource
         profile = common.cloneJSON(def);
-        // Set a flag so we can easily identify these "no-diff" profiles
-        profile._noDiffProfile = profileID;
         this._profilesMap.set(originalId, profile);
       } else {
         // Perform additional QA
@@ -856,7 +859,7 @@ class FHIRExporter {
 
     // Check to be sure we don't already have one
     const sliceName = sdToAdd.id;
-    const baseId = `${snapshotEl.id.replace('[x]', sdToAdd.type)}:${sliceName}`;
+    const baseId = `${snapshotEl.id.replace('[x]', common.capitalize(sdToAdd.type))}:${sliceName}`;
     const existing = profile.snapshot.element.find(e => e.id == baseId);
     if (existing) {
       const dfExisting = common.getDifferentialElementById(profile, existing.id, true);
@@ -877,7 +880,7 @@ class FHIRExporter {
     }
     const ssChoiceEl = {
       id: baseId,
-      path: snapshotEl.path.replace('[x]', sdToAdd.type),
+      path: snapshotEl.path.replace('[x]', common.capitalize(sdToAdd.type)),
       sliceName,
       short: snapshotEl.short,
       definition: snapshotEl.definition,
@@ -2243,15 +2246,8 @@ class FHIRExporter {
   }
 
   getSnapshotElementForFieldTarget(profile, fieldTarget, sliceCard) {
-    // First handle the case where we're referencing an option in a choice (TODO: Support drilling into options)
-    let choice;
-    let parts = [profile.type, ...fieldTarget.target.split('.')];
-    if (parts.length > 1 && parts[parts.length-2].endsWith('[x]')) {
-      // The last part of the target is the actual choice, but the real FHIR element path ends with [x]
-      choice = parts.pop();
-    }
-
     // Unroll paths as necessary to support drilling into types
+    let parts = [profile.type, ...fieldTarget.target.split('.')];
     for (let i=0; i < parts.length; i++) {
       let path = parts.slice(0, i+1).join('.');
       if (profile.snapshot.element.some(e => e.path == path)) {
@@ -2396,11 +2392,6 @@ class FHIRExporter {
       element = elements[0];
     }
 
-    // Since this was a choice, we need to validate that it's a valid choice (and also mark it as used)
-    if (path.endsWith('[x]') && typeof choice != 'undefined' && !common.elementTypeContainsTypeName(element.type, choice)) {
-      // Don't return the element since it doesn't contain the requested choice
-      return;
-    }
     return element;
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -888,9 +888,8 @@ class FHIRExporter {
   }
 
   processCardinalityMappingRule(map, rule, profile) {
-    const target = FieldTarget.parse(rule.target).target;
-
-    const ss = common.getSnapshotElement(profile, target);
+    const fieldTarget = FieldTarget.parse(rule.target);
+    const ss = this.getSnapshotElementForFieldTarget(profile, fieldTarget);
     if (typeof ss === 'undefined') {
       logger.error('Invalid target path. Cannot apply cardinality constraint. ERROR_CODE:13013');
       return;
@@ -918,10 +917,11 @@ class FHIRExporter {
   }
 
   processFixedValueMappingRule(map, rule, profile) {
-    const target = FieldTarget.parse(rule.target).target;
+    const fieldTarget = FieldTarget.parse(rule.target);
+    const target = fieldTarget.target;
     const fixedValue = rule.value;
 
-    const ss = common.getSnapshotElement(profile, target);
+    const ss = this.getSnapshotElementForFieldTarget(profile, fieldTarget);
     if (typeof ss === 'undefined') {
       logger.error('Invalid target path. Cannot apply fixed value. ERROR_CODE:13015');
       return;
@@ -936,16 +936,144 @@ class FHIRExporter {
       };
     }
 
-    if (fixedValue.indexOf('#') != -1) {
-      let type = ss.type.find(t => t.code == 'code' || t.code == 'Coding' || t.code == 'CodeableConcept');
+    // TODO: Don't allow 'fix value[x].boolean to 'hello'
+    // TODO: Don't allow multiple fixings on a single element if its upper card is 1
+
+    // Guess the type based on the value
+
+    // Fixed codes (and fallback to URIs with a # character)
+    const codeRE = /^(\w+:\/?\/?[^\s]+)?#[^\s]+$/; // regex that matches http://foo#bar or #bar
+    if (codeRE.test(fixedValue)) {
+      const allowableTypes = ['code', 'Coding', 'CodeableConcept'];
+      if (fixedValue[0] !== '#') {
+        allowableTypes.push('uri');
+      }
+      const type = ss.type.find(t => {
+        return allowableTypes.indexOf(t.code) >= 0;
+      });
       if (typeof type != 'undefined') {
-        const parts = fixedValue.split('#', 2);
-        this.fixCodeOnElement(type.code, profile, ss, df, new mdls.Concept(parts[0], parts[1]));
+        if (type.code === 'uri') {
+          this.fixURIOnElement(profile, ss, df, fixedValue);
+        } else {
+          const parts = fixedValue.split('#', 2);
+          this.fixCodeOnElement(type.code, profile, ss, df, new mdls.Concept(parts[0], parts[1]));
+        }
         if (dfIsNew && Object.keys(df).length > 2) {
           profile.differential.element.push(df);
         }
-        return;
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not a code, Coding, or CodeableConcept. ERROR_CODE:13???', target, fixedValue, target);
       }
+      return;
+    }
+
+    // Fixed URIs
+    const uriRE = /^\w+:\/?\/?[^\s]+$/; // regex that matches http://google.com or urn:1.2.3.4.5
+    if (uriRE.test(fixedValue)) {
+      const type = ss.type.find(t => t.code == 'uri');
+      if (typeof type != 'undefined') {
+        this.fixURIOnElement(profile, ss, df, fixedValue);
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not a URI. ERROR_CODE:13???', target, fixedValue, target);
+      }
+      return;
+    }
+
+    // Fixed booleans
+    const booleanRE = /^(true|false)$/; // regex that matches true or false
+    if (booleanRE.test(fixedValue)) {
+      const type = ss.type.find(t => t.code == 'boolean');
+      if (typeof type != 'undefined') {
+        this.fixBooleanOnElement(profile, ss, df, fixedValue === 'true');
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not a boolean. ERROR_CODE:13???', target, fixedValue, target);
+      }
+      return;
+    }
+
+    // Fixed strings
+    // NOTE that the grammar right now chokes if you try to fix to a string with a space in it
+    const stringRE = /^(('(.*)')|("(.*)"))$/; // regex that matches 'hello' or "hello"
+    const matches = fixedValue.match(stringRE);
+    if (matches && matches.length > 0) {
+      const stringValue = fixedValue[0] === `'` ? matches[3] : matches[5];
+      const type = ss.type.find(t => t.code == 'string');
+      if (typeof type != 'undefined') {
+        this.fixStringOnElement(profile, ss, df, stringValue);
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not a string. ERROR_CODE:13???', target, fixedValue, target);
+      }
+      return;
+    }
+
+    // Fixed numbers (and fallback to 4-digit year-only dates)
+    const numberRE = /^-?\d+(\.\d+)?$/; // regex that matches 10, 10.2, -10, -10.2, etc.
+    if (numberRE.test(fixedValue)) {
+      const isInteger = fixedValue.indexOf('.') === -1;
+      const numValue = isInteger ? parseInt(fixedValue) : parseFloat(fixedValue);
+      const allowableTypes = [];
+      if (isInteger) {
+        allowableTypes.push('integer');
+        // if it's not negative, it could also be an unsignedInt or (maybe) positiveInt
+        if (numValue >= 0) {
+          allowableTypes.push('unsignedInt');
+          // If it's not zero, it could be a positiveInt
+          if (fixedValue > 0) {
+            allowableTypes.push('positiveInt');
+          }
+        }
+      }
+      allowableTypes.push('decimal');
+      // If it's a positive or negative 4-digit integer, it may be a year, so allow date/dateTime as well,
+      // but add this to the end of allowable types, since we'll "prefer" an integer type if possible
+      if (isInteger) {
+        if ((numValue >= 0 && fixedValue.length === 4) || (numValue < 0 && fixedValue.length === 5)) {
+          allowableTypes.push('date', 'dateTime');
+        }
+      }
+      const type = ss.type.find(t => {
+        return allowableTypes.indexOf(t.code) >= 0;
+      });
+      if (typeof type !== 'undefined') {
+        if (type.code === 'date' || type.code === 'dateTime') {
+          this.fixDateOrTimeOnElement(profile, ss, df, fixedValue, type);
+        } else {
+          this.fixNumberOnElement(profile, ss, df, numValue, type);
+        }
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not one of: %s. ERROR_CODE:13???', target, fixedValue, target, allowableTypes.join(', '));
+      }
+      return;
+    }
+
+    // Fixed datesTimes (regex from FHIR spec)
+    const dateRE = /^-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/; // regex that matches true or false
+    if (dateRE.test(fixedValue)) {
+      const allowableTypes = fixedValue.indexOf('T') >= 0 ? ['dateTime', 'instant'] : ['date', 'dateTime'];
+      const type = ss.type.find(t => {
+        return allowableTypes.indexOf(t.code) >= 0;
+      });
+      if (typeof type != 'undefined') {
+        this.fixDateOrTimeOnElement(profile, ss, df, fixedValue, type);
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not one of: %s. ERROR_CODE:13???. ERROR_CODE:13???', target, fixedValue, target, allowableTypes.join(', '));
+      }
+      return;
     }
 
     // If we got this far, it's a currently unsupported use case
@@ -1865,23 +1993,118 @@ class FHIRExporter {
     const boolConstraints = sourceValue.constraintsFilter.own.boolean.constraints;
     if (boolConstraints.length > 0) {
       [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
-      const value = boolConstraints[0].value;
-      if (typeof snapshotEl.fixedBoolean !== 'undefined') {
-        if (snapshotEl.fixedBoolean == value) {
-          // It's already fixed to this value, so there's nothing to do.
-          return;
-        }
-        // Found another non-matching fixed value.  Put on the brakes.
-        logger.error('Cannot override boolean constraint from %s to %s. ERROR_CODE:13035', snapshotEl.fixedBoolean, value);
-        return;
-      }
-      snapshotEl.fixedBoolean = differentialEl.fixedBoolean = value;
-      if (REPORT_PROFILE_INDICATORS) {
-        this.addFixedValueIndicator(profile, snapshotEl.path, value);
-      }
+      const boolValue = boolConstraints[0].value;
+      this.fixBooleanOnElement(profile, snapshotEl, differentialEl, boolValue)
       if (boolConstraints.length > 1) {
         logger.error('Found more than one boolean to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13036', snapshotEl.id);
       }
+    }
+  }
+
+  fixBooleanOnElement(profile, snapshotEl, differentialEl, boolValue) {
+    if (! snapshotEl.type.some(t => t.code === 'boolean')) {
+      // This can't be fixed to a boolean, as it's not a boolean type.
+      logger.error('Cannot fix %s to %s since it is not a boolean type. ERROR_CODE:13???', snapshotEl.path, boolValue);
+      return;
+    }
+    if (typeof snapshotEl.fixedBoolean !== 'undefined') {
+      if (snapshotEl.fixedBoolean === boolValue) {
+        // It's already fixed to this value, so there's nothing to do.
+        return;
+      }
+      // Found another non-matching fixed value.  Put on the brakes.
+      logger.error('Cannot override boolean constraint from %s to %s. ERROR_CODE:13035', snapshotEl.fixedBoolean, boolValue);
+      return;
+    }
+    snapshotEl.fixedBoolean = differentialEl.fixedBoolean = boolValue;
+    if (REPORT_PROFILE_INDICATORS) {
+      this.addFixedValueIndicator(profile, snapshotEl.path, boolValue);
+    }
+  }
+
+  fixStringOnElement(profile, snapshotEl, differentialEl, stringValue) {
+    if (! snapshotEl.type.some(t => t.code === 'string')) {
+      // This can't be fixed to a boolean, as it's not a boolean type.
+      logger.error('Cannot fix %s to %s since it is not a string type. ERROR_CODE:13???', snapshotEl.path, stringValue);
+      return;
+    }
+    if (typeof snapshotEl.fixedString !== 'undefined') {
+      if (snapshotEl.fixedString === stringValue) {
+        // It's already fixed to this value, so there's nothing to do.
+        return;
+      }
+      // Found another non-matching fixed value.  Put on the brakes.
+      logger.error('Cannot override string constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedString, stringValue);
+      return;
+    }
+    snapshotEl.fixedString = differentialEl.fixedString = stringValue;
+    if (REPORT_PROFILE_INDICATORS) {
+      this.addFixedValueIndicator(profile, snapshotEl.path, stringValue);
+    }
+  }
+
+  fixNumberOnElement(profile, snapshotEl, differentialEl, numberValue, type) {
+    if (! snapshotEl.type.some(t => t.code === type.code)) {
+      // This can't be fixed to a number, as it's not a number type.
+      logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13???', snapshotEl.path, numberValue, type.code);
+      return;
+    }
+    const property = `fixed${common.capitalize(type.code)}`;
+    if (typeof snapshotEl[property] !== 'undefined') {
+      if (snapshotEl[property] === numberValue) {
+        // It's already fixed to this value, so there's nothing to do.
+        return;
+      }
+      // Found another non-matching fixed value.  Put on the brakes.
+      logger.error('Cannot override number constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedString, numberValue);
+      return;
+    }
+    snapshotEl[property] = differentialEl[property] = numberValue;
+    if (REPORT_PROFILE_INDICATORS) {
+      this.addFixedValueIndicator(profile, snapshotEl.path, numberValue);
+    }
+  }
+
+  fixDateOrTimeOnElement(profile, snapshotEl, differentialEl, dtValue, type) {
+    if (! snapshotEl.type.some(t => t.code === type.code)) {
+      // This can't be fixed to a date or time, as it's not a date or time type.
+      logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13???', snapshotEl.path, dtValue, type.code);
+      return;
+    }
+    const property = `fixed${common.capitalize(type.code)}`;
+    if (typeof snapshotEl[property] !== 'undefined') {
+      if (snapshotEl[property] === dtValue) {
+        // It's already fixed to this value, so there's nothing to do.
+        return;
+      }
+      // Found another non-matching fixed value.  Put on the brakes.
+      logger.error('Cannot override number constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedString, dtValue);
+      return;
+    }
+    snapshotEl[property] = differentialEl[property] = dtValue;
+    if (REPORT_PROFILE_INDICATORS) {
+      this.addFixedValueIndicator(profile, snapshotEl.path, dtValue);
+    }
+  }
+
+  fixURIOnElement(profile, snapshotEl, differentialEl, uriValue) {
+    if (! snapshotEl.type.some(t => t.code === 'uri')) {
+      // This can't be fixed to a URI, as it's not a URI type.
+      logger.error('Cannot fix %s to %s since it is not a URI type. ERROR_CODE:13???', snapshotEl.path, uriValue);
+      return;
+    }
+    if (typeof snapshotEl.fixedUri !== 'undefined') {
+      if (snapshotEl.fixedUri === uriValue) {
+        // It's already fixed to this value, so there's nothing to do.
+        return;
+      }
+      // Found another non-matching fixed value.  Put on the brakes.
+      logger.error('Cannot override URI constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedUri, uriValue);
+      return;
+    }
+    snapshotEl.fixedUri = differentialEl.fixedUri = uriValue;
+    if (REPORT_PROFILE_INDICATORS) {
+      this.addFixedValueIndicator(profile, snapshotEl.path, uriValue);
     }
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -953,7 +953,7 @@ class FHIRExporter {
       });
       if (typeof type != 'undefined') {
         if (type.code === 'uri') {
-          this.fixURIOnElement(profile, ss, df, fixedValue);
+          this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
         } else {
           const parts = fixedValue.split('#', 2);
           this.fixCodeOnElement(type.code, profile, ss, df, new mdls.Concept(parts[0], parts[1]));
@@ -967,27 +967,12 @@ class FHIRExporter {
       return;
     }
 
-    // Fixed URIs
-    const uriRE = /^\w+:\/?\/?[^\s]+$/; // regex that matches http://google.com or urn:1.2.3.4.5
-    if (uriRE.test(fixedValue)) {
-      const type = ss.type.find(t => t.code == 'uri');
-      if (typeof type != 'undefined') {
-        this.fixURIOnElement(profile, ss, df, fixedValue);
-        if (dfIsNew && Object.keys(df).length > 2) {
-          profile.differential.element.push(df);
-        }
-      } else {
-        logger.error('Can\'t fix %s to %s since %s is not a URI. ERROR_CODE:13???', target, fixedValue, target);
-      }
-      return;
-    }
-
     // Fixed booleans
     const booleanRE = /^(true|false)$/; // regex that matches true or false
     if (booleanRE.test(fixedValue)) {
       const type = ss.type.find(t => t.code == 'boolean');
       if (typeof type != 'undefined') {
-        this.fixBooleanOnElement(profile, ss, df, fixedValue === 'true');
+        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue === 'true', type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
           profile.differential.element.push(df);
         }
@@ -1005,7 +990,7 @@ class FHIRExporter {
       const stringValue = fixedValue[0] === `'` ? matches[3] : matches[5];
       const type = ss.type.find(t => t.code == 'string');
       if (typeof type != 'undefined') {
-        this.fixStringOnElement(profile, ss, df, stringValue);
+        this.fixPrimitiveValueOnElement(profile, ss, df, stringValue, type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
           profile.differential.element.push(df);
         }
@@ -1045,9 +1030,9 @@ class FHIRExporter {
       });
       if (typeof type !== 'undefined') {
         if (type.code === 'date' || type.code === 'dateTime') {
-          this.fixDateOrTimeOnElement(profile, ss, df, fixedValue, type);
+          this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
         } else {
-          this.fixNumberOnElement(profile, ss, df, numValue, type);
+          this.fixPrimitiveValueOnElement(profile, ss, df, numValue, type.code);
         }
         if (dfIsNew && Object.keys(df).length > 2) {
           profile.differential.element.push(df);
@@ -1059,25 +1044,55 @@ class FHIRExporter {
     }
 
     // Fixed datesTimes (regex from FHIR spec)
-    const dateRE = /^-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/; // regex that matches true or false
+    const dateRE = /^-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/; // regex from FHIR spec
     if (dateRE.test(fixedValue)) {
       const allowableTypes = fixedValue.indexOf('T') >= 0 ? ['dateTime', 'instant'] : ['date', 'dateTime'];
       const type = ss.type.find(t => {
         return allowableTypes.indexOf(t.code) >= 0;
       });
       if (typeof type != 'undefined') {
-        this.fixDateOrTimeOnElement(profile, ss, df, fixedValue, type);
+        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
         if (dfIsNew && Object.keys(df).length > 2) {
           profile.differential.element.push(df);
         }
       } else {
-        logger.error('Can\'t fix %s to %s since %s is not one of: %s. ERROR_CODE:13???. ERROR_CODE:13???', target, fixedValue, target, allowableTypes.join(', '));
+        logger.error('Can\'t fix %s to %s since %s is not one of: %s. ERROR_CODE:13???', target, fixedValue, target, allowableTypes.join(', '));
+      }
+      return;
+    }
+
+    // Fixed times
+    const timeRE = /^([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?$/; // regex from FHIR spec
+    if (timeRE.test(fixedValue)) {
+      const type = ss.type.find(t => t.code == 'time');
+      if (typeof type != 'undefined') {
+        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not a time. ERROR_CODE:13???', target, fixedValue, target);
+      }
+      return;
+    }
+
+    // Fixed URIs
+    const uriRE = /^\w+:\/?\/?[^\s]+$/; // regex that matches http://google.com or urn:1.2.3.4.5
+    if (uriRE.test(fixedValue)) {
+      const type = ss.type.find(t => t.code == 'uri');
+      if (typeof type != 'undefined') {
+        this.fixPrimitiveValueOnElement(profile, ss, df, fixedValue, type.code);
+        if (dfIsNew && Object.keys(df).length > 2) {
+          profile.differential.element.push(df);
+        }
+      } else {
+        logger.error('Can\'t fix %s to %s since %s is not a URI. ERROR_CODE:13???', target, fixedValue, target);
       }
       return;
     }
 
     // If we got this far, it's a currently unsupported use case
-    logger.error('Currently, only fixing codes is supported (value must contain "#").  Unable to fix to %s. ERROR_CODE:13016', fixedValue);
+    logger.error('Could not fix %s to %s; failed to detect compatible type for value %s. ERROR_CODE:13???', target, fixedValue, fixedValue);
   }
 
   processFieldToFieldCardinality(map, rule, profile, snapshotEl, differentialEl) {
@@ -1994,117 +2009,32 @@ class FHIRExporter {
     if (boolConstraints.length > 0) {
       [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
       const boolValue = boolConstraints[0].value;
-      this.fixBooleanOnElement(profile, snapshotEl, differentialEl, boolValue)
+      this.fixPrimitiveValueOnElement(profile, snapshotEl, differentialEl, boolValue, 'boolean');
       if (boolConstraints.length > 1) {
         logger.error('Found more than one boolean to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13036', snapshotEl.id);
       }
     }
   }
 
-  fixBooleanOnElement(profile, snapshotEl, differentialEl, boolValue) {
-    if (! snapshotEl.type.some(t => t.code === 'boolean')) {
-      // This can't be fixed to a boolean, as it's not a boolean type.
-      logger.error('Cannot fix %s to %s since it is not a boolean type. ERROR_CODE:13???', snapshotEl.path, boolValue);
+  fixPrimitiveValueOnElement(profile, snapshotEl, differentialEl, value, typeCode) {
+    if (! snapshotEl.type.some(t => t.code === typeCode)) {
+      // This can't be fixed to the value, as it's not the right type
+      logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13???', snapshotEl.path, value, typeCode);
       return;
     }
-    if (typeof snapshotEl.fixedBoolean !== 'undefined') {
-      if (snapshotEl.fixedBoolean === boolValue) {
-        // It's already fixed to this value, so there's nothing to do.
-        return;
-      }
-      // Found another non-matching fixed value.  Put on the brakes.
-      logger.error('Cannot override boolean constraint from %s to %s. ERROR_CODE:13035', snapshotEl.fixedBoolean, boolValue);
-      return;
-    }
-    snapshotEl.fixedBoolean = differentialEl.fixedBoolean = boolValue;
-    if (REPORT_PROFILE_INDICATORS) {
-      this.addFixedValueIndicator(profile, snapshotEl.path, boolValue);
-    }
-  }
-
-  fixStringOnElement(profile, snapshotEl, differentialEl, stringValue) {
-    if (! snapshotEl.type.some(t => t.code === 'string')) {
-      // This can't be fixed to a boolean, as it's not a boolean type.
-      logger.error('Cannot fix %s to %s since it is not a string type. ERROR_CODE:13???', snapshotEl.path, stringValue);
-      return;
-    }
-    if (typeof snapshotEl.fixedString !== 'undefined') {
-      if (snapshotEl.fixedString === stringValue) {
-        // It's already fixed to this value, so there's nothing to do.
-        return;
-      }
-      // Found another non-matching fixed value.  Put on the brakes.
-      logger.error('Cannot override string constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedString, stringValue);
-      return;
-    }
-    snapshotEl.fixedString = differentialEl.fixedString = stringValue;
-    if (REPORT_PROFILE_INDICATORS) {
-      this.addFixedValueIndicator(profile, snapshotEl.path, stringValue);
-    }
-  }
-
-  fixNumberOnElement(profile, snapshotEl, differentialEl, numberValue, type) {
-    if (! snapshotEl.type.some(t => t.code === type.code)) {
-      // This can't be fixed to a number, as it's not a number type.
-      logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13???', snapshotEl.path, numberValue, type.code);
-      return;
-    }
-    const property = `fixed${common.capitalize(type.code)}`;
+    const property = `fixed${common.capitalize(typeCode)}`;
     if (typeof snapshotEl[property] !== 'undefined') {
-      if (snapshotEl[property] === numberValue) {
+      if (snapshotEl[property] === value) {
         // It's already fixed to this value, so there's nothing to do.
         return;
       }
       // Found another non-matching fixed value.  Put on the brakes.
-      logger.error('Cannot override number constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedString, numberValue);
+      logger.error('Cannot fix %s to %s since it is already fixed to %s. ERROR_CODE:13???', snapshotEl.path, value, snapshotEl[property]);
       return;
     }
-    snapshotEl[property] = differentialEl[property] = numberValue;
+    snapshotEl[property] = differentialEl[property] = value;
     if (REPORT_PROFILE_INDICATORS) {
-      this.addFixedValueIndicator(profile, snapshotEl.path, numberValue);
-    }
-  }
-
-  fixDateOrTimeOnElement(profile, snapshotEl, differentialEl, dtValue, type) {
-    if (! snapshotEl.type.some(t => t.code === type.code)) {
-      // This can't be fixed to a date or time, as it's not a date or time type.
-      logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13???', snapshotEl.path, dtValue, type.code);
-      return;
-    }
-    const property = `fixed${common.capitalize(type.code)}`;
-    if (typeof snapshotEl[property] !== 'undefined') {
-      if (snapshotEl[property] === dtValue) {
-        // It's already fixed to this value, so there's nothing to do.
-        return;
-      }
-      // Found another non-matching fixed value.  Put on the brakes.
-      logger.error('Cannot override number constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedString, dtValue);
-      return;
-    }
-    snapshotEl[property] = differentialEl[property] = dtValue;
-    if (REPORT_PROFILE_INDICATORS) {
-      this.addFixedValueIndicator(profile, snapshotEl.path, dtValue);
-    }
-  }
-
-  fixURIOnElement(profile, snapshotEl, differentialEl, uriValue) {
-    if (! snapshotEl.type.some(t => t.code === 'uri')) {
-      // This can't be fixed to a URI, as it's not a URI type.
-      logger.error('Cannot fix %s to %s since it is not a URI type. ERROR_CODE:13???', snapshotEl.path, uriValue);
-      return;
-    }
-    if (typeof snapshotEl.fixedUri !== 'undefined') {
-      if (snapshotEl.fixedUri === uriValue) {
-        // It's already fixed to this value, so there's nothing to do.
-        return;
-      }
-      // Found another non-matching fixed value.  Put on the brakes.
-      logger.error('Cannot override URI constraint from %s to %s. ERROR_CODE:13???', snapshotEl.fixedUri, uriValue);
-      return;
-    }
-    snapshotEl.fixedUri = differentialEl.fixedUri = uriValue;
-    if (REPORT_PROFILE_INDICATORS) {
-      this.addFixedValueIndicator(profile, snapshotEl.path, uriValue);
+      this.addFixedValueIndicator(profile, snapshotEl.path, value);
     }
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -937,7 +937,7 @@ class FHIRExporter {
   processFixedValueMappingRule(map, rule, profile) {
     const fieldTarget = FieldTarget.parse(rule.target);
     const target = fieldTarget.target;
-    const fixedValue = rule.value;
+    const fixedValue = rule.value.trim();
 
     const ss = this.getSnapshotElementForFieldTarget(profile, fieldTarget);
     if (typeof ss === 'undefined') {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -84,7 +84,7 @@ class ExtensionExporter {
     // Now add all the snapshot and differential elements.  Since the extension is in the map by
     // reference, we shouldn't need to set it in the map again after.
     this.pushDefExtensionElements(ext, baseId, '', def);
-    this._processTracker.stop(identifier.fqn), common.fhirID(identifier, 'extension');
+    this._processTracker.stop(identifier.fqn, common.fhirID(identifier, 'extension'));
     return ext;
   }
 
@@ -277,7 +277,7 @@ class ExtensionExporter {
     const ssExt = {
       id: `${baseId}.extension`,
       path: `${this.getExtensionPathFromExtensionID(baseId)}.extension`,
-      slicing: common.createSlicingObject('value', 'url'),
+      slicing: common.createSlicingObject(extension, 'value', 'url'),
       short: 'Extension',
       definition: 'An Extension',
       min: 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR adds support for fixing the values with type:
- `code`, `CodeableConcept`, `Coding`
    - e.g., `fix foo to http://foo.com/codes#bar`, `fix foo to #bar`
- `boolean`
    - e.g., `fix foo to true`
- `string`
    - e.g., `fix foo to 'hello'`
    - _NOTE: due to grammar limitations, strings with spaces are not currently supported_
- `integer`, `unsignedInt`, `postiveInt`, `decimal`
    - e.g., `fix foo to 123`, `fix foo to 1.23`, `fix foo to -123`
- `date`, `dateTime`, `instant`, `time`
    - e.g., `fix foo to 2012-01-01T00:00:00Z`, `fix foo to 2012-01-01`, `fix foo to 01:38:00`
- `uri`
    - e.g., `fix foo to http://google.com`

This also fixes several bugs found along the way and enhances the way that choices (e.g., `value[x]`) are handled.

Lastly, it changes the slice ID strategy from a global counter to a counter unique to each profile.  This makes it easier to compare outputs across different versions of the exporters (since adding a slice now only affects slice IDs within the same profile, instead of slice IDs across the project).

To simplify testing, I've attached a set of simple definitions that demonstrate fixing values of the supported types: [fixed_value_examples.zip](https://github.com/standardhealth/shr-fhir-export/files/1593677/fixed_value_examples.zip)