### PR TITLE
Fix extensions and multi profiles

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -202,20 +202,31 @@ class FHIRExporter {
       // When SHR specifies a choice value, remove the others!
       const choiceElementIDsToRemove = [];
       for (const el of profile.snapshot.element) {
-        if (el.path.endsWith('[x]') || (el.type && el.type.length > 1)) {
-          const shrSelected = el.type.filter(t => t._shrSelected).map(t => {
-            delete(t._shrSelected); // Remove the special marker
+        if (el.path.endsWith('[x]') || (el.type && (el.type.length > 1 || this.optionIsSelected(el.type[0])))) {
+          const shrSelected = el.type.filter(t => t._shrSelected || t._originalProfile || t._originalTargetProfile).map(t => {
+            // Remove the special markers
+            delete(t._shrSelected);
+            delete(t._originalProfile);
+            delete(t._originalTargetProfile);
             return t;
           });
-          if (shrSelected.length > 0 && shrSelected.length < el.type.length) {
-            el.type = shrSelected;
-            // Do it in differential too
+          if (shrSelected.length > 0) {
             let df = common.getDifferentialElementById(profile, el.id);
-            if (typeof df === 'undefined') {
-              df = { id: el.id, path: el.path };
-              profile.differential.element.push(df);
+            if (shrSelected.length < el.type.length) {
+              el.type = shrSelected;
+              // Do it in differential too
+              if (typeof df === 'undefined') {
+                df = { id: el.id, path: el.path };
+                profile.differential.element.push(df);
+              }
+              df.type = el.type;
+            } else if (typeof df !== 'undefined' && typeof df.type !== 'undefined') {
+              df.type.forEach(t => {
+                delete(t._shrSelected);
+                delete(t._originalProfile);
+                delete(t._originalTargetProfile);
+              });
             }
-            df.type = el.type;
           }
           // If it's a choice of one now, and there is an explicit path already, remove the choice.
           // e.g., don't have value[x] w/ only 'Quantity' *and* valueQuantity (as they're redundant).
@@ -1347,23 +1358,58 @@ class FHIRExporter {
       const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
       const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
       const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL, false));
-      for (const t of targetTypes) {
-        if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(t.profile) || basedOnTargetProfiles.includes(t.profile)) {
+      for (let i=0; i < targetTypes.length; i++) {
+        const t = targetTypes[i];
+        const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
+        const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
+        if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
           matchedType = t;
           // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
-          // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
-          if (!this.optionIsSelected(t) || basedOnTargetProfiles.includes(t.profile)) {
+          // or if the original type is a supertype (i.e., a profile of one of its basedOn types)
+          if (this.optionIsSelected(t)) {
+            // This type has already been mapped to once.  Determine if we can add another type to represent additional
+            // applicable profiles.  This is done by checking if the new profile fits in the old type / profile.
             if (common.isCustomProfile(sourceProfile)) {
+              if (typeof originalProfile === 'undefined' || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
+                // Create a new type for the additional profile and splice it into the types
+                const t2 = common.cloneJSON(t);
+                t2.profile = sourceProfile.url;
+                targetTypes.splice(i+1, 0, t2);
+                matchedType = t2;
+              }
+              // else it wasn't a valid sub-type of the original type, and this will cause an error further down
+            } else {
+              // The existing type narrows it to a profile, but since this new type represents a no-profile type,
+              // remove the profile from the existing type
+              delete(t.profile);
+            }
+            break;
+          } else {
+            // This is the first time mapping to this type, so overwrite profile if applicable, and mark as selected
+            if (common.isCustomProfile(sourceProfile)) {
+              if (typeof t.profile !== 'undefined') {
+                // keep track of the original profile so we can check on other options in the future
+                t._originalProfile = t.profile;
+              }
               t.profile = sourceProfile.url;
             }
             this.markSelectedOptionsInChoice(targetTypes, [t]);
           }
           break;
-        } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(t.targetProfile) || basedOnTargetProfiles.includes(t.targetProfile))) {
+        } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(originalTargetProfile) || basedOnTargetProfiles.includes(originalTargetProfile))) {
           matchedType = t;
           // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
           // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
-          if (!this.optionIsSelected(t) || basedOnTargetProfiles.includes(t.targetProfile)) {
+          if (this.optionIsSelected(t)) {
+            // This type has already been mapped to once, and we've already determined that the new profile is a match.
+            // Create a new type for the additional target profile and splice it into the types
+            const t2 = common.cloneJSON(t);
+            t2.targetProfile = sourceProfile.url;
+            targetTypes.splice(i+1, 0, t2);
+            matchedType = t2;
+          } else {
+            // This is the first time mapping to this type, so overwrite targetProfile and mark as selected
+            t._originalTargetProfile = t.targetProfile;
             t.targetProfile = sourceProfile.url;
             this.markSelectedOptionsInChoice(targetTypes, [t]);
           }
@@ -1481,11 +1527,8 @@ class FHIRExporter {
   }
 
   markSelectedOptionsInChoice(allTypes, selectedTypes) {
-    // Only mark them if it really is a choice (e.g., more than one type available)
-    if (allTypes.length > 1) {
-      for (const t of selectedTypes) {
-        t._shrSelected = true;
-      }
+    for (const t of selectedTypes) {
+      t._shrSelected = true;
     }
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -2118,14 +2118,14 @@ class FHIRExporter {
     for (const field of common.valueAndFields(def)) {
       // TODO: Apply constraints to extensions
       if (field instanceof mdls.IdentifiableValue) {
-        if (!map.rules.some(r => r.sourcePath && r.sourcePath.length > 0 && r.sourcePath[0].equals(field.identifier))) {
+        if (!map.rules.some(r => r.sourcePath && r.sourcePath.length > 0 && r.sourcePath[0].equals(field.effectiveIdentifier))) {
           const lastLogger = logger;
-          logger = logger.child({ extension: field.identifier.fqn });
+          logger = logger.child({ extension: field.effectiveIdentifier.fqn });
           logger.debug('Start mapping extension');
           try {
-            this.addExtension(def, profile, [field.identifier]);
+            this.addExtension(def, profile, [field.effectiveIdentifier]);
             if (TRACK_UNMAPPED_PATHS) {
-              this.removeMappedPath(def, [field.identifier]);
+              this.removeMappedPath(def, [field.effectiveIdentifier]);
             }
           } catch (e) {
             logger.error('Unexpected error adding extension. ERROR_CODE:13051', e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.3.5",
+  "version": "5.3.6",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR contains two fixes:

**Detect needed extensions by effectiveIdentifier:**
Previously, when looking for unmapped fields (to create extensions for), the code looked for the mapping based on the identifier.  Now it (correctly) looks for it based on effectiveIdentifier.

**Allow multiple profiles for same type:**
Sometimes it makes sense to allow multiple profiles of the same type, for example, a Quantity type could specify that an IntegerQuantity or DecimalQuantity could be applied.  Prior to this change, only one profile could be applied per type.

The following definitions and mappings demonstrate multiple profiles on the same type:

Definitions:
```
EntryElement: Observation
Value: Quantity or dateTime

Element: QuantityA
Based on: Quantity
1..1 A

Element: QuantityB
Based on: Quantity
1..1 B

EntryElement: OtherObservation
Based on: Observation
Value: QuantityA or QuantityB

Element: A
Element: B
```

Mappings:
```
Observation maps to Observation:
Value maps to value[x]
```