### PR TITLE
5.3.7: Don't produce multiple profiles for includestype types

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1367,15 +1367,23 @@ class FHIRExporter {
           // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
           // or if the original type is a supertype (i.e., a profile of one of its basedOn types)
           if (this.optionIsSelected(t)) {
-            // This type has already been mapped to once.  Determine if we can add another type to represent additional
-            // applicable profiles.  This is done by checking if the new profile fits in the old type / profile.
+            // This type has already been mapped to once.  Determine if we should add another type to represent
+            // additional applicable profiles.  This is done by checking if its part of an includes type slice, and/or
+            // by checking if the new profile fits in the old type / profile.
             if (common.isCustomProfile(sourceProfile)) {
               if (typeof originalProfile === 'undefined' || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
-                // Create a new type for the additional profile and splice it into the types
-                const t2 = common.cloneJSON(t);
-                t2.profile = sourceProfile.url;
-                targetTypes.splice(i+1, 0, t2);
-                matchedType = t2;
+                if (sourceValue._derivedFromIncludesTypeConstraint) {
+                  // This is the result of an includes type slicing, so we want the new profile to replace the existing one
+                  // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
+                  t.profile = sourceProfile.url;
+                } else {
+                  // We should represent both the existing and the new profile, so create a new type for the additional
+                  // profile and splice it into the types
+                  const t2 = common.cloneJSON(t);
+                  t2.profile = sourceProfile.url;
+                  targetTypes.splice(i+1, 0, t2);
+                  matchedType = t2;
+                }
               }
               // else it wasn't a valid sub-type of the original type, and this will cause an error further down
             } else {
@@ -1402,11 +1410,18 @@ class FHIRExporter {
           // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
           if (this.optionIsSelected(t)) {
             // This type has already been mapped to once, and we've already determined that the new profile is a match.
-            // Create a new type for the additional target profile and splice it into the types
-            const t2 = common.cloneJSON(t);
-            t2.targetProfile = sourceProfile.url;
-            targetTypes.splice(i+1, 0, t2);
-            matchedType = t2;
+            if (sourceValue._derivedFromIncludesTypeConstraint) {
+              // This is the result of an includes type slicing, so we want the new profile to replace the existing one
+              // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
+              t.targetProfile = sourceProfile.url;
+            } else {
+              // We should represent both the existing and the new profile, so create a new type for the additional
+              // target profile and splice it into the types
+              const t2 = common.cloneJSON(t);
+              t2.targetProfile = sourceProfile.url;
+              targetTypes.splice(i+1, 0, t2);
+              matchedType = t2;
+            }
           } else {
             // This is the first time mapping to this type, so overwrite targetProfile and mark as selected
             t._originalTargetProfile = t.targetProfile;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.3.6",
+  "version": "5.3.7",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
When working in a slice that was the result of an includes type constraint, we want the type to reflect just the "include type" profile, not the profile it was based on.

For example, prior to this fix, the _BreastCancerBiomarkerPanel_ profile had these related types:

![image](https://user-images.githubusercontent.com/2278253/34730786-645f5be2-f52e-11e7-9e27-28bafb3353a5.png)

After the fix, only the most specific type is represented:

![image](https://user-images.githubusercontent.com/2278253/34730796-6a492830-f52e-11e7-8d6b-57fd9c0685f9.png)