### PR TITLE
Fixes/Enhancements to FHIR Export based on Connectathon

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -141,6 +141,13 @@ function capitalize(string) {
   return string;
 }
 
+function lowerFirst(string) {
+  if (typeof string === 'string') {
+    return string.charAt(0).toLowerCase() + string.slice(1);
+  }
+  return string;
+}
+
 function todayString() {
   return (new Date()).toISOString().split('T')[0];
 }
@@ -185,4 +192,4 @@ class FHIRExportError extends Error {
   }
 }
 
-module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, todayString, isCustomProfile, ProcessTracker};
+module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, lowerFirst, todayString, isCustomProfile, ProcessTracker};

--- a/lib/export.js
+++ b/lib/export.js
@@ -768,7 +768,7 @@ class FHIRExporter {
     }
 
 
-    let ss = this.getSnapshotElementForFieldTarget(profile, fieldTarget, sliceCard);
+    let ss = this.getSnapshotElementForFieldTarget(profile, fieldTarget, sourceValue, sliceCard);
     if (typeof ss === 'undefined' && fieldTarget.target.endsWith('[x]')) {
       // In some cases (like FHIR VitalSigns profiles), the value[x] is removed and replaced w/ instance (e.g., valueQuantity)
       // TODO: Support when sourceValue is a choice
@@ -779,7 +779,7 @@ class FHIRExporter {
         if (typeof map !== 'undefined') {
           const newTarget = fieldTarget.target.replace(/\[x\]$/, common.capitalize(map.targetItem));
           const newFieldTarget = new FieldTarget(newTarget, fieldTarget.commands, fieldTarget.comments);
-          ss = this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sliceCard);
+          ss = this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sourceValue, sliceCard);
         }
       }
     }
@@ -1672,14 +1672,14 @@ class FHIRExporter {
         for (const cstPath of cstPaths) {
           const targetSubPath = this.findTargetFHIRPath(sourceValue.effectiveIdentifier, cstPath);
           if (targetSubPath) {
-            // Get the target snapshot and differential elements
-            const targetPath = `${snapshotEl.path}.${targetSubPath}`;
-            const fieldTarget = new FieldTarget(targetPath.slice(targetPath.indexOf('.')+1)); // Remove resource prefix
-            const targetSS = this.getSnapshotElementForFieldTarget(profile, fieldTarget);
-            const targetDf = common.getDifferentialElementById(profile, targetSS.id, true);
             // Get the childValue with all constraints merged to it
             const def = this._specs.dataElements.findByIdentifier(sourceValue.effectiveIdentifier);
             const childValue = this.findValueByPath(cstPath, def, false, sourceValue.constraints);
+            // Get the target snapshot and differential elements
+            const targetPath = `${snapshotEl.path}.${targetSubPath}`;
+            const fieldTarget = new FieldTarget(targetPath.slice(targetPath.indexOf('.')+1)); // Remove resource prefix
+            const targetSS = this.getSnapshotElementForFieldTarget(profile, fieldTarget, childValue);
+            const targetDf = common.getDifferentialElementById(profile, targetSS.id, true);
             // Since applyConstraints doesn't apply cardinality constraints, do that now before calling applyConstraints
             const targetCard = getFHIRElementCardinality(targetSS);
             if (childValue.effectiveCard.fitsWithinCardinalityOf(targetCard)) {
@@ -2440,7 +2440,7 @@ class FHIRExporter {
     return this._fhir.find(id);
   }
 
-  getSnapshotElementForFieldTarget(profile, fieldTarget, sliceCard) {
+  getSnapshotElementForFieldTarget(profile, fieldTarget, sourceValue, sliceCard) {
     // Unroll paths as necessary to support drilling into types
     let parts = [profile.type, ...fieldTarget.target.split('.')];
     for (let i=0; i < parts.length; i++) {
@@ -2458,7 +2458,7 @@ class FHIRExporter {
         // Clone the target with the new path and try again
         const newTarget = fieldTarget.target.replace(`${parts[i-1]}.${parts[i]}`, ssEl.path.split('.').pop());
         const newFieldTarget = new FieldTarget(newTarget, fieldTarget.commands, fieldTarget.comments);
-        return this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sliceCard);
+        return this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sourceValue, sliceCard);
       } else if (typeof parentEl === 'undefined' || !Array.isArray(parentEl.type) || parentEl.type.length != 1) {
         // The parent isn't a drillable element
         return;
@@ -2536,10 +2536,24 @@ class FHIRExporter {
         dfSliceSection.splice(0, 0, { id: ssSliceSection[0].id, path: ssSliceSection[0].path, sliceName: sliceName });
       }
 
+      // Set the slice name
+      ssSliceSection[0].sliceName = dfSliceSection[0].sliceName = sliceName;
+
       // The base slice section element has slicing (from the copy), but we don't need to repeat that
       delete(ssSliceSection[0].slicing);
       delete(dfSliceSection[0].slicing);
-      ssSliceSection[0].sliceName = dfSliceSection[0].sliceName = sliceName;
+      // We also don't really need to repeat the comment and requirements
+      delete(ssSliceSection[0].comment);
+      delete(dfSliceSection[0].comment);
+      delete(ssSliceSection[0].requirements);
+      delete(dfSliceSection[0].requirements);
+
+      // "Personalize" the base slice to this specific element
+      if (typeof sourceValue !== 'undefined' && sourceValue instanceof mdls.IdentifiableValue) {
+        ssSliceSection[0].short = dfSliceSection[0].short = sourceValue.effectiveIdentifier.name;
+        ssSliceSection[0].definition = dfSliceSection[0].definition =
+          this.getDescription(sourceValue.effectiveIdentifier, sourceValue.effectiveIdentifier.name);
+      }
 
       // If a sliceCard was passed in, set it
       if (typeof sliceCard !== 'undefined') {

--- a/lib/export.js
+++ b/lib/export.js
@@ -339,8 +339,14 @@ class FHIRExporter {
       profile.differential.element = fixedDifferentials;
 
       // Check if this is a "no-diff" profile.
-      if (profile.differential.element.length <= 1) {
-        // This is a "no-diff" profile.  Substitute it with the original resource!
+      const isNoDiffProfile = profile.differential.element.length <= 1 || profile.differential.element.every(e => {
+        const keys = Object.keys(e);
+        return keys.every(k => {
+          return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition';
+        });
+      });
+      if (isNoDiffProfile) {
+        // Substitute it with the original resource!
         // First, remember the original id
         const originalId = profile.id;
         // Now re-set the profile to the original resource
@@ -1310,8 +1316,75 @@ class FHIRExporter {
         sourceString += ` (mapped to ${sMapsTo.targetItem})`;
       }
       logger.error('Mismatched types. Cannot map %s to %s. ERROR_CODE:13022', sourceString, typesToString(snapshotEl.type));
+      return;
     }
+
+    // Mapping was successful, so update the element to reflect the source value's definitions
+
+    /* This is a bit too agressive, as it often overwrites more specific definitions w/ less specific definitions.
+    if (sourceValue instanceof mdls.IdentifiableValue) {
+      snapshotEl.short = differentialEl.short = sourceValue.effectiveIdentifier.name;
+      snapshotEl.definition = differentialEl.definition =
+        this.getDescription(sourceValue.effectiveIdentifier, sourceValue.effectiveIdentifier.name);
+    }
+    */
+
+    // If this is mapped from the element's value, make the definition correspond to the element's definition
+    if (def.description && rule.sourcePath.length === 1 && def.value) {
+      const id = rule.sourcePath[0];
+      const val = def.value;
+      const isElementValue = id.isValueKeyWord || id.equals(val.identifier) || id.equals(val.effectiveIdentifier)
+        || (val.options && val.aggregateOptions.some(o => id.equals(o.identifier) || id.equals(o.effectiveIdentifier)));
+      if (isElementValue) {
+        snapshotEl.definition = differentialEl.definition = def.description.trim();
+      }
+    }
+
+    // If the original short definition was an enumeration, we should try to replace it if possible
+    if (snapshotEl.short && snapshotEl.short.indexOf('|') !== -1) {
+      // Only replace it if we provide a value set constraint
+      if (sourceValue.constraintsFilter.own.valueSet.hasConstraints) {
+        const vsURL = sourceValue.constraintsFilter.own.valueSet.constraints[0].valueSet;
+        const short = this.getShortFromValueSet(vsURL);
+        if (short) {
+          snapshotEl.short = differentialEl.short = short;
+        }
+      }
+    }
+
     return;
+  }
+
+  getShortFromValueSet(vsURL) {
+    let short;
+    if (vsURL.startsWith('http://hl7.org/fhir/ValueSet' || vsURL.startsWith('urn:tbd'))) {
+      // It's an HL7 or TBD VS.  Just leave what's there in place...
+    } else if (vsURL.startsWith('http://standardhealthrecord.org')) {
+      // It's an SHR value set, so we can be smart about constructing a short
+      const items = [];
+      const vs = this._specs.valueSets.findByURL(vsURL);
+      for (const r of vs.rules) {
+        if (r instanceof mdls.ValueSetIncludesCodeRule) {
+          items.push(r.code.code);
+        } else if (r instanceof mdls.ValueSetIncludesDescendentsRule) {
+          items.push(`descendents of ${r.code.code}`);
+        } else if (r instanceof mdls.ValueSetExcludesDescendentsRule) {
+          items.push(`not descendents of ${r.code.code}`);
+        } else if (r instanceof mdls.ValueSetIncludesFromCodeRule) {
+          items.push(`codes from ${r.code.code}`);
+        } else if (r instanceof mdls.ValueSetIncludesFromCodeSystemRule) {
+          items.push(`codes from ${r.system}`);
+        }
+      }
+      short = items.slice(0, 5).join(' | ');
+      if (items.length > 5) {
+        short += ' | ...';
+      }
+    } else {
+      // It's an external value set, so just reference it
+      short = `codes from ${vsURL}`;
+    }
+    return short;
   }
 
   knownMappingIssue(lhs, rhs, sourcePath, value, types) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -1319,24 +1319,15 @@ class FHIRExporter {
       return;
     }
 
-    // Mapping was successful, so update the element to reflect the source value's definitions
-
-    /* This is a bit too agressive, as it often overwrites more specific definitions w/ less specific definitions.
-    if (sourceValue instanceof mdls.IdentifiableValue) {
-      snapshotEl.short = differentialEl.short = sourceValue.effectiveIdentifier.name;
-      snapshotEl.definition = differentialEl.definition =
-        this.getDescription(sourceValue.effectiveIdentifier, sourceValue.effectiveIdentifier.name);
-    }
-    */
-
-    // If this is mapped from the element's value, make the definition correspond to the element's definition
+    // If this is mapped from the element's value, make the definition refer to the element's definition
     if (def.description && rule.sourcePath.length === 1 && def.value) {
       const id = rule.sourcePath[0];
       const val = def.value;
       const isElementValue = id.isValueKeyWord || id.equals(val.identifier) || id.equals(val.effectiveIdentifier)
         || (val.options && val.aggregateOptions.some(o => id.equals(o.identifier) || id.equals(o.effectiveIdentifier)));
       if (isElementValue) {
-        snapshotEl.definition = differentialEl.definition = def.description.trim();
+        const desc = `${common.capitalize(this.getValueName(val))} representing ${common.lowerFirst(def.description.trim())}`;
+        snapshotEl.definition = differentialEl.definition = desc;
       }
     }
 
@@ -1353,6 +1344,26 @@ class FHIRExporter {
     }
 
     return;
+  }
+
+  getValueName(value) {
+    let name;
+    if (value instanceof mdls.ChoiceValue) {
+      const opts = value.aggregateOptions;
+      // If it's only 2 choices, spell them out, otherwise just say "Choice of types"
+      if (opts.length <= 2) {
+        name = opts.map(o => this.getValueName(o)).join(' or ');
+      } else {
+        name = 'Choice of types';
+      }
+    } else if (value instanceof mdls.TBD) {
+      name = value.toString();
+    } else if (['Coding', 'CodeableConcept'].indexOf(value.identifier.name) != -1) {
+      name = 'code';
+    } else {
+      name = value.identifier.name;
+    }
+    return name;
   }
 
   getShortFromValueSet(vsURL) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -2101,7 +2101,7 @@ class FHIRExporter {
       }
 
       const baseCodingDf = common.getDifferentialElementById(profile, baseCoding.id, true);
-      common.addSlicingToBaseElement(profile, baseCoding, baseCodingDf, 'value', 'path');
+      common.addSlicingToBaseElement(profile, baseCoding, baseCodingDf, 'value', 'code');
       const sliceName = `Fixed_${code.code}`;
       const sliceEl = {
         id: `${baseCoding.id}:${sliceName}`,

--- a/lib/export.js
+++ b/lib/export.js
@@ -274,6 +274,29 @@ class FHIRExporter {
         profile.differential.element = profile.differential.element.filter(e => !choiceElementIDsToRemove.some(id => id === e.id));
       }
 
+      // For paths that are sliced, we want only the actual slices to remain -- so we must remove the
+      // elements that are under the slice root, but are not slices themselves.
+      const slicedIdsToRemove = [];
+      const slicedIdRootStack = new Stack();
+      for (const el of profile.snapshot.element) {
+        if (el.slicing) {
+          // start of a new slice section, push the root element id
+          slicedIdRootStack.push(el.id);
+        } else if (!slicedIdRootStack.isEmpty()) {
+          if (el.id.startsWith(`${slicedIdRootStack.peekLast()}.`)) {
+            // non-slice element in the slice section, so remove it
+            slicedIdsToRemove.push(el.id);
+          } else if (! el.id.startsWith(`${slicedIdRootStack.peekLast()}:`)) {
+            // end of the slice section, pop the root element id
+            slicedIdRootStack.pop();
+          }
+        }
+      }
+      if (slicedIdsToRemove.length > 0) {
+        profile.snapshot.element = profile.snapshot.element.filter(e => !slicedIdsToRemove.some(id => id === e.id));
+        profile.differential.element = profile.differential.element.filter(e => !slicedIdsToRemove.some(id => id === e.id));
+      }
+
       // Remove any temporary properties we used to help along the way
       for (const el of profile.differential.element) {
         delete(el._originalProperties);


### PR DESCRIPTION
This pull request addresses several fixes/enhancements that were requested as a result of the recent connectathon.  It includes:

* Fixed incorrect discriminator when slicing to fix codes
* Removed "extraneous" slices from profiles so only the meaningful slices are preserved
* Improved documentation of slices in profiles (to reflect the thing the slice represents)
* Improved documentation of mapped values
* Improved documentation of some constrained codes, where applicable

I did not bump the version number, as there will be a follow-up PR that bumps the version.