### PR TITLE
Support for special keywords (_Value, _Entry, _Concept)

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -9,6 +9,7 @@ const {exportIG} = require('./ig');
 
 const TARGET = 'FHIR_STU_3';
 const ENTRY_ID = new mdls.Identifier('shr.base', 'Entry');
+const CONCEPT_ID = new mdls.Identifier('shr.core', 'CodeableConcept');
 
 // The following two constants toggle advanced developer features, usually not needed
 // or wanted (since they cause performance degradation).
@@ -405,8 +406,8 @@ class FHIRExporter {
     let map = this._unmappedPaths.get(def.identifier.fqn);
     for (let i=0; i < sourcePath.length; i++) {
       const p = sourcePath[i];
-      // For now, don't deal with Entry.*
-      if (p.name === 'Entry') {
+      // For now, don't deal with _Entry.* or _Concept.*
+      if (p.isEntryKeyWord || p.isConceptKeyWord) {
         return;
       } else if (i == sourcePath.length-1) {
         map.set('_has_mapped_children', true);
@@ -2705,9 +2706,8 @@ class FHIRExporter {
     // Find the value at the root of the path
     let value = this.findValueByIdentifier(path[0], fieldsToSearch);
 
-    // Some special case logic for 'Entry' (which may be an implicit field)
-    if (typeof value === 'undefined' && path[0].equals(ENTRY_ID)) {
-      // TODO: This will need to be adjusted if we support constraining entry fields from the entry instance
+    // Some special case logic for '_Entry' or _Concept (implicit fields)
+    if (typeof value === 'undefined' && path[0].isEntryKeyWord) {
       if (path.length == 1) {
         // This is the end of the path, so just give them a 1..1 Entry
         return new mdls.IdentifiableValue(ENTRY_ID).withMinMax(1, 1);
@@ -2716,6 +2716,25 @@ class FHIRExporter {
       def = this._specs.dataElements.findByIdentifier(ENTRY_ID);
       path = path.slice(1);
       value = this.findValueByIdentifier(path[0], common.valueAndFields(def));
+    } else if (typeof value === 'undefined' && path[0].isConceptKeyWord) {
+      if (path.length == 1) {
+        // This is the end of the path, so just give them a 1..1 CodeableConcept
+        const conceptValue = new mdls.IdentifiableValue(CONCEPT_ID).withMinMax(1, 1);
+        if (def.concepts.length == 1) {
+          // Add code constraint
+          conceptValue.addConstraint(new mdls.CodeConstraint(def.concepts[0]));
+        } else if (def.concepts.length > 1) {
+          // Update the card to be n to many and add includesCode constraints
+          conceptValue.card = new mdls.Cardinality(def.concepts.length);
+          for (const c of def.concepts) {
+            conceptValue.addConstraint(new mdls.IncludesCodeConstraint(c));
+          }
+        }
+        return conceptValue;
+      } else {
+        logger.error(`Mapping ${path[0].name} sub-fields is currently not supported. ERROR_CODE:13061`);
+      }
+
     }
 
     // If we didn't find the value, it could be one of those cases where we replaced the original identifier with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.3.8",
+  "version": "5.4.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "^5.2.1"
+    "shr-models": "standardhealth/shr-models#underscore_kw"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "standardhealth/shr-models#underscore_kw"
+    "shr-models": "^5.4.0"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.2.2"
+    "shr-models": "^5.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,9 +894,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@standardhealth/shr-models#underscore_kw:
-  version "5.3.0"
-  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/bc825be96868efef1c30daa3cb7f8df163185be4"
+shr-models@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.4.0.tgz#6fc2542dbdb900a7e0a7d172962ce540deda190a"
 
 slice-ansi@0.0.4:
   version "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,9 +894,9 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.1.tgz#23108d369a0be9fa2518d9be4c1e53685d9dd776"
+shr-models@standardhealth/shr-models#underscore_kw:
+  version "5.3.0"
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/bc825be96868efef1c30daa3cb7f8df163185be4"
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Adds support for the new special words allowed by the grammar: `_Value`, `_Entry`, `_Concept`.

Due to existing use of `isValue`, not much needed to change to support `_Value`, but made some changes to detect and properly handle `_Entry` and `_Concept`.  `_Entry` is treated like a `shr.base.Entry` and `_Concept` is treated like a `shr.core.CodeableConcept` with a fixed code or includes code constraint. 

NOTE:
* Once shr-* dependency PRs are approved and released, this will be updated to use them
* Version number will be bumped after final approval of the PR