### PR TITLE
Error deduplication rebase

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2972,7 +2972,11 @@ class FHIRExporter {
       // Allow this for "base" classes
       if (!profile.id.endsWith(`-${profile.type}`)) {
         if (!def._isAbstract) {
-          logger.warn('The \'%s\' property is not bound to a value set, fixed to a code, or fixed to a quantity unit. This property is core to the target resource and usually should be constrained. ERROR_CODE:03006', path);
+          if (def.basedOn[0].name == profile.type) {
+            logger.warn('The \'%s\' property is not bound to a value set, fixed to a code, or fixed to a quantity unit. This property is core to the target resource and usually should be constrained. ERROR_CODE:03006', path);
+          } else {
+            logger.info('The inherited \'%s\' property is not bound to a value set, fixed to a code, or fixed to a quantity unit. This property is core to the target resource and usually should be constrained.', path);
+          }
         } else {
           logger.info('Abstract Class: The \'%s\' property is not bound to a value set or fixed to a code. This property is core to the target resource and usually should be constrained.', path);
         }

--- a/lib/export.js
+++ b/lib/export.js
@@ -2924,39 +2924,60 @@ class FHIRExporter {
   }
 
   additionalQA(profile) {
-    switch(profile.type) {
-    case 'Basic':
-      logger.warn('Element profiled on Basic. Consider a more specific mapping. ERROR_CODE:03004');
-      break;
-    case 'Observation': {
-      this.checkMappedAndConstrained(profile, 'code');
-      this.checkMappedAndConstrained(profile, 'value[x]');
-      break;
-    }
-    case 'Condition': {
-      this.checkMappedAndConstrained(profile, 'code');
-      break;
-    }
-    case 'AllergyIntolerance': {
-      this.checkMappedAndConstrained(profile, 'code');
-      break;
-    }
-    case 'Medication': {
-      this.checkMappedAndConstrained(profile, 'code');
-      break;
-    }
-    case 'MedicationStatement': {
-      this.checkMappedAndConstrained(profile, 'medication[x]');
-      break;
-    }
-    case 'MedicationRequest': {
-      this.checkMappedAndConstrained(profile, 'medication[x]');
-      break;
-    }
-    case 'ProcedureRequest': {
-      this.checkMappedAndConstrained(profile, 'code');
-      break;
-    }
+    switch (profile.type) {
+      case 'Basic': {
+        const fqn = profile.identifier[0].value.split('.');
+        const identifier = { 'name': fqn.pop(), 'namespace': fqn.join('.') };
+        const def = this._specs.dataElements.findByIdentifier(identifier);
+
+        if (!def.isAbstract) {
+          if (def.basedOn.length > 0) {
+            var parent = this._specs.dataElements.findByIdentifier(def.basedOn[0]);
+            var parentProfile = this.lookupProfile(def.basedOn[0]);
+          }
+
+          //Hide warning if the parent profile is also Basic (avoid duplicates through inheritance)
+          //Override and show warning anyway if the parent is abstract, as children of abstract should show message
+          //Also show warning if there is no warning
+          //a. No Parent
+          //b. The parent is abstract
+          //b. The parent type isn't also basic (avoid duplicate error message) AND the parent isn't abstract (show children of abstracts even if duplicate)
+          if (!parentProfile || parentProfile.type != 'Basic' || parent.isAbstract) {
+            logger.warn('Element profiled on Basic. Consider a more specific mapping. ERROR_CODE:03004');
+          }
+        }
+
+        break;
+      }
+      case 'Observation': {
+        this.checkMappedAndConstrained(profile, 'code');
+        this.checkMappedAndConstrained(profile, 'value[x]');
+        break;
+      }
+      case 'Condition': {
+        this.checkMappedAndConstrained(profile, 'code');
+        break;
+      }
+      case 'AllergyIntolerance': {
+        this.checkMappedAndConstrained(profile, 'code');
+        break;
+      }
+      case 'Medication': {
+        this.checkMappedAndConstrained(profile, 'code');
+        break;
+      }
+      case 'MedicationStatement': {
+        this.checkMappedAndConstrained(profile, 'medication[x]');
+        break;
+      }
+      case 'MedicationRequest': {
+        this.checkMappedAndConstrained(profile, 'medication[x]');
+        break;
+      }
+      case 'ProcedureRequest': {
+        this.checkMappedAndConstrained(profile, 'code');
+        break;
+      }
     }
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -2,11 +2,11 @@ const bunyan = require('bunyan');
 const mdls = require('shr-models');
 const load = require('./load');
 const common = require('./common');
-const {CodeSystemExporter} = require('./codeSystems');
-const {ValueSetExporter} = require('./valueSets');
-const {ExtensionExporter} = require('./extensions');
-const {ModelsExporter} = require('./logical/export');
-const {exportIG} = require('./ig');
+const { CodeSystemExporter } = require('./codeSystems');
+const { ValueSetExporter } = require('./valueSets');
+const { ExtensionExporter } = require('./extensions');
+const { ModelsExporter } = require('./logical/export');
+const { exportIG } = require('./ig');
 
 const TARGET = 'FHIR_STU_3';
 const ENTRY_ID = new mdls.Identifier('shr.base', 'Entry');
@@ -17,7 +17,7 @@ const CONCEPT_ID = new mdls.Identifier('shr.core', 'CodeableConcept');
 const TRACK_UNMAPPED_PATHS = false;
 const REPORT_PROFILE_INDICATORS = false;
 
-var rootLogger = bunyan.createLogger({name: 'shr-fhir-export'});
+var rootLogger = bunyan.createLogger({ name: 'shr-fhir-export' });
 var logger = rootLogger;
 function setLogger(bunyanLogger) {
   rootLogger = logger = bunyanLogger;
@@ -119,7 +119,7 @@ class FHIRExporter {
 
     const profiles = Array.from(this._profilesMap.values()).filter(p => common.isCustomProfile(p));
     for (const p of profiles) {
-      delete(p._shr);
+      delete (p._shr);
     }
     return {
       profiles,
@@ -175,14 +175,14 @@ class FHIRExporter {
       }
 
       profile._shr = true;
-      delete(profile.meta);
-      delete(profile.extension);
-      delete(profile.version);
+      delete (profile.meta);
+      delete (profile.extension);
+      delete (profile.version);
       profile.id = profileID;
       profile.text = this.getText(originalMap);
       profile.url = profileURL;
       profile.identifier = [{ system: this._config.projectURL, value: map.identifier.fqn }],
-      profile.name = `${map.identifier.name}Profile`;
+        profile.name = `${map.identifier.name}Profile`;
       profile.title = `${this._config.projectShorthand} ${map.identifier.name} Profile`;
       profile.description = this.getDescription(map.identifier);
       profile.publisher = this._config.publisher;
@@ -200,15 +200,17 @@ class FHIRExporter {
       rootSS.definition = this.getDescription(map.identifier, rootSS.definition);
 
       // Reset the differential elements so we only have differences from our baseDefinition
-      profile.differential = { element: [{
-        id : rootSS.id,
-        path : rootSS.path,
-        short : rootSS.short,
-        definition : rootSS.definition,
-        mustSupport : rootSS.mustSupport,
-        isModifier : rootSS.isModifier,
-        isSummary : rootSS.isSummary
-      }] };
+      profile.differential = {
+        element: [{
+          id: rootSS.id,
+          path: rootSS.path,
+          short: rootSS.short,
+          definition: rootSS.definition,
+          mustSupport: rootSS.mustSupport,
+          isModifier: rootSS.isModifier,
+          isSummary: rootSS.isSummary
+        }]
+      };
 
       if (TRACK_UNMAPPED_PATHS) {
         this._unmappedPaths.set(map.identifier.fqn, this.buildUnmappedPathsTree(map.identifier));
@@ -229,9 +231,9 @@ class FHIRExporter {
         if (el.path.endsWith('[x]') || (el.type && (el.type.length > 1 || this.optionIsSelected(el.type[0])))) {
           const shrSelected = el.type.filter(t => t._shrSelected || t._originalProfile || t._originalTargetProfile).map(t => {
             // Remove the special markers
-            delete(t._shrSelected);
-            delete(t._originalProfile);
-            delete(t._originalTargetProfile);
+            delete (t._shrSelected);
+            delete (t._originalProfile);
+            delete (t._originalTargetProfile);
             return t;
           });
           if (shrSelected.length > 0) {
@@ -246,9 +248,9 @@ class FHIRExporter {
               df.type = el.type;
             } else if (typeof df !== 'undefined' && typeof df.type !== 'undefined') {
               df.type.forEach(t => {
-                delete(t._shrSelected);
-                delete(t._originalProfile);
-                delete(t._originalTargetProfile);
+                delete (t._shrSelected);
+                delete (t._originalProfile);
+                delete (t._originalTargetProfile);
               });
             }
           }
@@ -267,7 +269,7 @@ class FHIRExporter {
                   const originalID = explicitEl.id;
                   const newID = originalID.substr(0, explicitEl.id.lastIndexOf(':'));
                   // Remove slicename from the snapshot
-                  delete(explicitEl.sliceName);
+                  delete (explicitEl.sliceName);
                   // Fixup all snapshots rooted in this ID
                   for (const thisEl of profile.snapshot.element) {
                     if (thisEl.id.startsWith(originalID)) {
@@ -278,7 +280,7 @@ class FHIRExporter {
                   const explicitDfEl = common.getDifferentialElementById(profile, explicitEl.id);
                   if (typeof explicitDfEl !== 'undefined') {
                     // Remove slicename from the differential
-                    delete(explicitDfEl.sliceName);
+                    delete (explicitDfEl.sliceName);
                   }
                   // Fixup all differentials rooted in this ID
                   for (const thisEl of profile.differential.element) {
@@ -322,7 +324,7 @@ class FHIRExporter {
           if (el.id.startsWith(`${slicedIdRootStack.peekLast()}.`)) {
             // non-slice element in the slice section, so remove it
             slicedIdsToRemove.push(el.id);
-          } else if (! el.id.startsWith(`${slicedIdRootStack.peekLast()}:`)) {
+          } else if (!el.id.startsWith(`${slicedIdRootStack.peekLast()}:`)) {
             // end of the slice section, pop the root element id
             slicedIdRootStack.pop();
           }
@@ -335,7 +337,7 @@ class FHIRExporter {
 
       // Remove any temporary properties we used to help along the way
       for (const el of profile.differential.element) {
-        delete(el._originalProperties);
+        delete (el._originalProperties);
       }
 
       // If there are extensions, update the base extension element(s)
@@ -359,14 +361,14 @@ class FHIRExporter {
       let lastIdParts = [];
       for (const dfEl of profile.differential.element) {
         const idParts = dfEl.id.split('.');
-        for (let i=0; i < (idParts.length - 1); i++) {
+        for (let i = 0; i < (idParts.length - 1); i++) {
           if (lastIdParts.length <= i || lastIdParts[i] != idParts[i]) {
             // This is a missing path that must be added
             fixedDifferentials.push({
-              id: idParts.slice(0, i+1).join('.'),
-              path: dfEl.path.split('.').slice(0, i+1).join('.')
+              id: idParts.slice(0, i + 1).join('.'),
+              path: dfEl.path.split('.').slice(0, i + 1).join('.')
             });
-            lastIdParts = idParts.slice(0, i+1);
+            lastIdParts = idParts.slice(0, i + 1);
           }
         }
         fixedDifferentials.push(dfEl);
@@ -439,12 +441,12 @@ class FHIRExporter {
   // NOTE: This function only called if TRACK_UNMAPPED_PATHS is set to true
   removeMappedPath(def, sourcePath) {
     let map = this._unmappedPaths.get(def.identifier.fqn);
-    for (let i=0; i < sourcePath.length; i++) {
+    for (let i = 0; i < sourcePath.length; i++) {
       const p = sourcePath[i];
       // For now, don't deal with _Entry.* or _Concept.*
       if (p.isEntryKeyWord || p.isConceptKeyWord) {
         return;
-      } else if (i == sourcePath.length-1) {
+      } else if (i == sourcePath.length - 1) {
         map.set('_has_mapped_children', true);
         map.delete(p.fqn);
       } else {
@@ -464,7 +466,7 @@ class FHIRExporter {
     return {
       status: 'generated',
       div:
-`<div xmlns="http://www.w3.org/1999/xhtml">
+        `<div xmlns="http://www.w3.org/1999/xhtml">
   <p><b>${common.escapeHTML(this._config.projectShorthand + ' ' + map.identifier.name)} Profile</b></p>
   <p>${common.escapeHTML(this.getDescription(map.identifier))}</p>
   <p><b>${common.escapeHTML(this._config.projectShorthand)} Mapping Summary</b></p>
@@ -488,7 +490,7 @@ class FHIRExporter {
   setCodeOnBasic(map, profile) {
     const ssEl = common.getSnapshotElement(profile, 'code');
     if (typeof ssEl.fixedCodeableConcept === 'undefined' && typeof ssEl.patternCodeableConcept === 'undefined') {
-      let dfEl =  common.getDifferentialElementById(profile, ssEl.id);
+      let dfEl = common.getDifferentialElementById(profile, ssEl.id);
       if (typeof dfEl === 'undefined') {
         dfEl = {
           id: ssEl.id,
@@ -497,7 +499,7 @@ class FHIRExporter {
         profile.differential.element.push(dfEl);
       }
       ssEl.patternCodeableConcept = dfEl.patternCodeableConcept = {
-        coding: [ { system: `${this._config.fhirURL}/basic-resource-type`, code: profile.id }]
+        coding: [{ system: `${this._config.fhirURL}/basic-resource-type`, code: profile.id }]
       };
       if (REPORT_PROFILE_INDICATORS) {
         this.addFixedValueIndicator(profile, ssEl.path, ssEl.patternCodeableConcept);
@@ -523,7 +525,7 @@ class FHIRExporter {
     // In the future we should determine what is the approved way to reference an includetype in a path.
     // The following block of code does the expansion as noted above:
     const def = this._specs.dataElements.findByIdentifier(map.identifier);
-    for (let i=0; i < map.rules.length; i++) {
+    for (let i = 0; i < map.rules.length; i++) {
       const rule = map.rules[i];
       if (!(rule instanceof mdls.FieldMappingRule)) {
         continue;
@@ -556,14 +558,14 @@ class FHIRExporter {
             }
             // Substitute the original identifier in the path with the includesType identifier instead
             const newSourcePath = rule.sourcePath.slice();
-            newSourcePath[newSourcePath.length-1] = incl.isA;
+            newSourcePath[newSourcePath.length - 1] = incl.isA;
             if (incl.card && incl.card.min) {
               minCard += incl.card.min;
             }
             // Create and store a new rule, but remove "slice strategy" from the commands since it only applies to parent
             includesTypeRules.push(new mdls.FieldMappingRule(newSourcePath, new FieldTarget(t.target, t.commands.filter(c => c.key != 'slice strategy')).toRuleTarget()));
             // Copy, update, and add specific child rules within the slice
-            let j=i+1;
+            let j = i + 1;
             for (; j < map.rules.length; j++) {
               const sliceRule = map.rules[j];
               // First check if this is a child of the slice path.  If not, stop looking and break.
@@ -578,7 +580,7 @@ class FHIRExporter {
               // It's a match -- so it's a child of the slice path
               // Substitute the original identifier in the path with the includesType identifier instead
               const newSliceSourcePath = sliceRule.sourcePath.slice();
-              newSliceSourcePath[rule.sourcePath.length-1] = incl.isA;
+              newSliceSourcePath[rule.sourcePath.length - 1] = incl.isA;
               includesTypeRules.push(new mdls.FieldMappingRule(newSliceSourcePath, sliceRule.target));
             }
             // We're at the end of the original rules defining the slices, so this is where we'll
@@ -619,7 +621,7 @@ class FHIRExporter {
     const sliceAtMap = new Map();
     const sliceTargetStack = new Stack();
     const sliceNameStack = new Stack();
-    let i=0;
+    let i = 0;
     for (const rule of map.rules) {
       rule._i = i++; // Helps maintain original order of "equivalent" rules when sorting
       if (!(rule instanceof mdls.FieldMappingRule)) {
@@ -663,7 +665,7 @@ class FHIRExporter {
         }
 
         // Start a new slice!
-        const sliceName = common.fhirID(rule.sourcePath[rule.sourcePath.length-1]);
+        const sliceName = common.fhirID(rule.sourcePath[rule.sourcePath.length - 1]);
         t.addInSliceCommand(`${sliceTargetStack.peekLast()}[${sliceName}]`);
         sliceNameStack.push(sliceName);
       } else if (!sliceTargetStack.isEmpty() && t.target == sliceTargetStack.peekLast()) {
@@ -676,7 +678,7 @@ class FHIRExporter {
         }
 
         // Start a new slice in the slice group!
-        const sliceName = common.fhirID(rule.sourcePath[rule.sourcePath.length-1]);
+        const sliceName = common.fhirID(rule.sourcePath[rule.sourcePath.length - 1]);
         t.addInSliceCommand(`${sliceTargetStack.peekLast()}[${sliceName}]`);
         sliceNameStack.pop();
         sliceNameStack.push(sliceName);
@@ -873,7 +875,7 @@ class FHIRExporter {
         if (typeof rootId === 'undefined') {
           // This is the "root" element where the contentReference is.  Replace the definitions in place as necessary.
           rootId = ss.id;
-          delete(snapshotEl.contentReference);
+          delete (snapshotEl.contentReference);
           snapshotEl.type = ss.type;
           snapshotEl.defaultValue = ss.defaultValue;
           snapshotEl.fixed = ss.fixed;
@@ -937,7 +939,7 @@ class FHIRExporter {
     let [baseId, basePath] = [snapshotEl.id, snapshotEl.path];
     const baseEl = sdToUnroll.snapshot.element[0];
     // Skip the base, since we really only want to unroll the children (the base is already represented)
-    for (let i=1; i < sdToUnroll.snapshot.element.length; i++) {
+    for (let i = 1; i < sdToUnroll.snapshot.element.length; i++) {
       const ss = common.cloneJSON(sdToUnroll.snapshot.element[i]);
       ss.id = `${baseId}${ss.id.slice(baseEl.id.length)}`;
       ss.path = `${basePath}${ss.path.slice(baseEl.path.length)}`;
@@ -1092,8 +1094,8 @@ class FHIRExporter {
     // If the path is something like value[x].boolean, get the intended type
     let targetType;
     const parts = target.split('.');
-    if (parts.length > 1 && parts[parts.length-2].endsWith('[x]')) {
-      targetType = parts[parts.length-1];
+    if (parts.length > 1 && parts[parts.length - 2].endsWith('[x]')) {
+      targetType = parts[parts.length - 1];
     }
 
     // A function to fix the code or print out a relevant error if it's not the right type
@@ -1179,7 +1181,7 @@ class FHIRExporter {
           allowableTypes.push('date', 'dateTime');
         }
       }
-      const value = (type) => type && ! type.code.startsWith('date') ? numValue : fixedValue;
+      const value = (type) => type && !type.code.startsWith('date') ? numValue : fixedValue;
       fixIt(profile, ss, df, value, ...allowableTypes);
       return;
     }
@@ -1243,8 +1245,8 @@ class FHIRExporter {
         // Check if all parts of target path are mapped.  If they aren't, then constraining the cardinality is ambiguous
         const targetPath = FieldTarget.parse(rule.target).target.split('.');
         let isMatch = true;
-        for (let i=0; i < targetPath.length; i++) {
-          const tp = targetPath.slice(0, i+1).join('.');
+        for (let i = 0; i < targetPath.length; i++) {
+          const tp = targetPath.slice(0, i + 1).join('.');
           if (tp.endsWith('[x]')) {
             // Due to our target path syntax, this looks like an intermediate path, but it isn't really
             continue;
@@ -1457,13 +1459,13 @@ class FHIRExporter {
       const matchedTypes = targetTypes.filter(t => sourceIdentifier.name == t.code);
       if (matchedTypes.length > 0) {
         this.markSelectedOptionsInChoice(targetTypes, matchedTypes);
-        this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false);
+        this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false, sourcePath);
         return [clonedPath];
       }
       const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
       if (allowedConvertedTypes.length > 0) {
         this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
-        this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl);
+        this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
         return [clonedPath];
       }
       return undefined;
@@ -1487,7 +1489,7 @@ class FHIRExporter {
       const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
       const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
       const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL));
-      for (let i=0; i < targetTypes.length; i++) {
+      for (let i = 0; i < targetTypes.length; i++) {
         const t = targetTypes[i];
         const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
         const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
@@ -1510,7 +1512,7 @@ class FHIRExporter {
                   // profile and splice it into the types
                   const t2 = common.cloneJSON(t);
                   t2.profile = sourceProfile.url;
-                  targetTypes.splice(i+1, 0, t2);
+                  targetTypes.splice(i + 1, 0, t2);
                   matchedType = t2;
                 }
               }
@@ -1518,7 +1520,7 @@ class FHIRExporter {
             } else {
               // The existing type narrows it to a profile, but since this new type represents a no-profile type,
               // remove the profile from the existing type
-              delete(t.profile);
+              delete (t.profile);
             }
             break;
           } else {
@@ -1548,7 +1550,7 @@ class FHIRExporter {
               // target profile and splice it into the types
               const t2 = common.cloneJSON(t);
               t2.targetProfile = sourceProfile.url;
-              targetTypes.splice(i+1, 0, t2);
+              targetTypes.splice(i + 1, 0, t2);
               matchedType = t2;
             }
           } else {
@@ -1573,14 +1575,14 @@ class FHIRExporter {
           if (typeof mappedProfile !== 'undefined') {
             differentialEl.type = snapshotEl.type;
           }
-          this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false);
+          this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false, sourcePath);
           matchedPaths.push(clonedPath);
         }
       } else {
         const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
         if (allowedConvertedTypes.length > 0) {
           this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
-          this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl);
+          this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
           matchedPaths.push(clonedPath);
         }
       }
@@ -1695,7 +1697,7 @@ class FHIRExporter {
     return [type.id];
   }
 
-  applyConstraints(sourceValue, profile, snapshotEl, differentialEl, isExtension) {
+  applyConstraints(sourceValue, profile, snapshotEl, differentialEl, isExtension, sourcePath) {
     // As a *very* special (and unfortunate) case, we must special-case quantity.  Essentially, the problem is that
     // Quantity maps Units.Coding onto itself, so the constraints on Units.Coding need to be applied to Quantity instead.
     if (sourceValue.identifier.equals(new mdls.Identifier('shr.core', 'Quantity'))) {
@@ -1720,7 +1722,7 @@ class FHIRExporter {
     }
 
     // First handle own constraints
-    this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl);
+    this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
     this.applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnIncludesCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnBooleanConstraints(sourceValue, profile, snapshotEl, differentialEl);
@@ -1748,7 +1750,7 @@ class FHIRExporter {
             logger.error('Failed to resolve element path from %s to %s. ERROR_CODE:13024', snapshotEl.id, path);
             continue;
           }
-          const childSourceValue = new mdls.IdentifiableValue(path[path.length-1]);
+          const childSourceValue = new mdls.IdentifiableValue(path[path.length - 1]);
           for (const childCst of csts) {
             // Add the constraint, cloning it and making its path at the root
             childSourceValue.addConstraint(childCst.clone().withPath([]));
@@ -1759,7 +1761,7 @@ class FHIRExporter {
           if (dfIsNew) {
             diffElement = { id: element.id, path: element.path };
           }
-          this.applyOwnValueSetConstraints(childSourceValue, profile, element, diffElement);
+          this.applyOwnValueSetConstraints(childSourceValue, profile, element, diffElement, sourcePath);
           this.applyOwnCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnIncludesCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnBooleanConstraints(childSourceValue, profile, element, diffElement);
@@ -1771,7 +1773,7 @@ class FHIRExporter {
         // Determine the unique subpaths which must be addressed
         const cstPaths = [];
         for (const cst of sourceValue.constraintsFilter.child.constraints) {
-          if(!cstPaths.some(cp => common.equalShrElementPaths(cp, cst.path))) {
+          if (!cstPaths.some(cp => common.equalShrElementPaths(cp, cst.path))) {
             cstPaths.push(cst.path);
           }
         }
@@ -1784,7 +1786,7 @@ class FHIRExporter {
             const childValue = this.findValueByPath(cstPath, def, false, sourceValue.constraints);
             // Get the target snapshot and differential elements
             const targetPath = `${snapshotEl.path}.${targetSubPath}`;
-            const fieldTarget = new FieldTarget(targetPath.slice(targetPath.indexOf('.')+1)); // Remove resource prefix
+            const fieldTarget = new FieldTarget(targetPath.slice(targetPath.indexOf('.') + 1)); // Remove resource prefix
             const targetSS = this.getSnapshotElementForFieldTarget(profile, fieldTarget, childValue);
             const targetDf = common.getDifferentialElementById(profile, targetSS.id, true);
             // Since applyConstraints doesn't apply cardinality constraints, do that now before calling applyConstraints
@@ -1795,7 +1797,7 @@ class FHIRExporter {
               logger.error('Cannot constrain cardinality from %s to %s. ERROR_CODE:13014', targetCard.toString(), childValue.effectiveCard.toString());
             }
             // Call applyConstraints to apply any other constraints to the child value
-            this.applyConstraints(childValue, profile, targetSS, targetDf, false);
+            this.applyConstraints(childValue, profile, targetSS, targetDf, false, cstPath);
           } else {
             const friendlyPath = [sourceValue.effectiveIdentifier, ...cstPath].map(id => id.name).join('.');
             logger.error('Could not determine how to map nested value (%s) to FHIR profile. ERROR_CODE:13060', friendlyPath);
@@ -1818,10 +1820,10 @@ class FHIRExporter {
         // It couldn't find by the path, but if the path length is > 1, we should see if we can chain rules
         // together to get the right path (e.g., if the root is A and path is [B, C, D], then see if there is a rule
         // for A [B, C] and another rule for C [D] -- because this would also get us to the full path A [B, C, D]).
-        for (let i=1; i < shrPath.length; i++) {
-          const path1 = this.findTargetFHIRPath(rootIdentifier, shrPath.slice(0, shrPath.length-i));
+        for (let i = 1; i < shrPath.length; i++) {
+          const path1 = this.findTargetFHIRPath(rootIdentifier, shrPath.slice(0, shrPath.length - i));
           if (path1) {
-            const path2 = this.findTargetFHIRPath(shrPath[shrPath.length-i-1], shrPath.slice(shrPath.length - i));
+            const path2 = this.findTargetFHIRPath(shrPath[shrPath.length - i - 1], shrPath.slice(shrPath.length - i));
             if (path1 && path2) {
               return `${path1}.${path2}`;
             }
@@ -1835,7 +1837,7 @@ class FHIRExporter {
     // If the path length is only 1, we can return the snapshotEl since it's always the match for the first element in the path
     if (shrPath.length <= 1) {
       // Because SHR sometimes uses implicit values (and sometimes not), we don't yet know if we can stop here.
-      if (shrPath.length == 0 || snapshotEl.id.substr(snapshotEl.id.lastIndexOf('.')+1).startsWith('value')) {
+      if (shrPath.length == 0 || snapshotEl.id.substr(snapshotEl.id.lastIndexOf('.') + 1).startsWith('value')) {
         return snapshotEl;
       }
     }
@@ -1885,7 +1887,7 @@ class FHIRExporter {
     return [snapshotEl, differentialEl];
   }
 
-  applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl) {
+  applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl, sourcePath) {
     const vsConstraints = sourceValue.constraintsFilter.own.valueSet.constraints;
     if (vsConstraints.length > 0) {
       [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
@@ -1937,15 +1939,17 @@ class FHIRExporter {
         } else if (bind.strength == 'extensible') {
           const bindVSURI = bind.valueSetReference ? bind.valueSetReference.reference : bind.valueSetUri;
           if (!this.isValueSetSubsetOfOther(vsURI, bindVSURI)) {
-            logger.warn('Overriding extensible value set constraint from %s to %s.  Only allowed when new codes do not overlap meaning of old codes. ERROR_CODE:03003', bindVSURI, vsURI);
-            // this is technically allowed, so don't return yet -- just continue...
+            if (!this.shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath)) {
+              logger.warn('Overriding extensible value set constraint from %s to %s.  Only allowed when new codes do not overlap meaning of old codes. ERROR_CODE:03003', bindVSURI, vsURI);
+              // this is technically allowed, so don't return yet -- just continue...
+            }
           }
         }
       }
       snapshotEl.binding = differentialEl.binding = {
-        strength : strength,
-        valueSetReference : {
-          reference : vsConstraint.valueSet
+        strength: strength,
+        valueSetReference: {
+          reference: vsConstraint.valueSet
         }
       };
       if (vsConstraints.length > 1) {
@@ -1963,7 +1967,7 @@ class FHIRExporter {
         const result = {};
         for (const r of valueSet.rules) {
           if (!(r instanceof mdls.ValueSetIncludesCodeRule)) {
-            return {_unsupported: true};
+            return { _unsupported: true };
           }
           if (typeof result[r.code.system] === 'undefined') {
             result[r.code.system] = [];
@@ -1978,15 +1982,15 @@ class FHIRExporter {
         // It's a FHIR value set
         const result = {};
         if (typeof valueSet.compose === 'undefined') {
-          return {_unsupported: true};
+          return { _unsupported: true };
         } else if (typeof valueSet.compose.exclude !== 'undefined' && valueSet.compose.exclude.length > 0) {
-          return {_unsupported: true};
+          return { _unsupported: true };
         } else if (typeof valueSet.compose.include === 'undefined' || valueSet.compose.include.length == 0) {
-          return {_unsupported: true};
+          return { _unsupported: true };
         }
         for (const incl of valueSet.compose.include) {
           if (typeof incl.system === 'undefined' || (typeof incl.filter !== 'undefined' && incl.filter.length > 0) || (typeof incl.valueSet !== 'undefined' && incl.valueSet.length > 0)) {
-            return {_unsupported: true};
+            return { _unsupported: true };
           }
           if (typeof result[incl.system] === 'undefined') {
             result[incl.system] = [];
@@ -1999,11 +2003,11 @@ class FHIRExporter {
         }
         return result;
       } else {
-        return {_unsupported: true};
+        return { _unsupported: true };
       }
     });
 
-    if (vs._unsupported ||  otherVS._unsupported) {
+    if (vs._unsupported || otherVS._unsupported) {
       return false;
     }
 
@@ -2020,11 +2024,87 @@ class FHIRExporter {
       }
 
       // Only match if every code is in the other
-      if (! codes.every(c => otherCodes.includes(c))) {
+      if (!codes.every(c => otherCodes.includes(c))) {
         return false;
       }
     }
     return true;
+  }
+
+  /*
+    Determines whether a ValueSetConstraint on a mapped element is inherited from a parent.
+    Inheritance is determined by going matching sourcePath of the mapping with fields from
+    the mapped element, and determining inheritance status at each level of depth
+  */
+  shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath) {
+    var vscIsDuplicate = false;
+
+    const snapshotElFQN = snapshotEl.id.match(/\w*:(\w*-\w*-[A-za-z0-9\-]*).*/)[1].replace('-', '.').replace('-', '.');
+    const snapshotElID = { 'name': snapshotElFQN.split('.').pop(), 'namespace': snapshotElFQN.split('.').slice(0, -1).join('.') };
+    const snapshotDataElement = this._specs.dataElements.findByIdentifier(snapshotElID);
+
+    if (snapshotDataElement) {
+      const pathClone = [...sourcePath];
+      let currEl = snapshotDataElement;
+
+      //Search the mapped element for relevant field (being mapped)
+      //Use the full sourcePath array to capture 'submappings', e.g. a mapping on dataabsentreason.component
+      while (pathClone.length > 1) {
+        const pathID = pathClone.shift();
+        let matchedField;
+        // const combinedFieldsAndValue = (currEl.fields && currEl.value) ? [currEl.value, ...currEl.fields] : (currEl.fields) ? currEl.fields : [currEl.value]; //potentially more thorough than current implentation, although tests show no difference
+
+        if (snapshotEl.id.split(':').length == 2) {
+          //Handle normal slices
+          //Additionally, account
+          matchedField = currEl.fields.find(f => f.identifier.equals(pathID) || f.constraintsFilter.type.constraints.filter(c => c.isA.equals(pathID)).length > 0);
+
+        } else {
+          //Handle complex 'includesType' slices
+          matchedField = currEl.fields
+            .filter(f => f.constraintsFilter.includesType.hasConstraints)
+            .filter(f => f.constraintsFilter.includesType.constraints
+              .filter(c => c.isA.equals(pathID)).length > 0);
+          if (matchedField.length >= 1) {
+            matchedField = matchedField[0];
+          }
+        }
+
+        if (matchedField) {
+          if (!matchedField.inheritance) {
+            //If it's not inherited, it's not a duplicate
+            vscIsDuplicate = false;
+            break;
+          } else if (matchedField.inheritance == 'inherited') {
+            //If it is inherited, this error is a duplicate
+            vscIsDuplicate = true;
+            break;
+          } else if (matchedField.inheritance == 'overridden') {
+            //Only overrides relevant are ValueSetConstraint overrides, which would make it unique.
+            //Although, with a Type Constraint, you should skip and check the Type'd Element
+            if (!matchedField.constraintsFilter.valueSet.hasConstraints) {
+              if (!matchedField.constraintsFilter.own.type.hasConstraints) {
+                vscIsDuplicate = true;
+                break;
+              }
+            } else {
+              vscIsDuplicate = false;
+              break;
+            }
+          }
+        } else {
+          //If there are no matching fields, it's hard to determine.
+          //Default to showing warning as opposed to suppressing
+          vscIsDuplicate = true;
+          break;
+        }
+
+        //If there was a type constraint field, and it is an original definition
+        currEl = this._specs.dataElements.findByIdentifier(pathID);
+      }
+    }
+
+    return vscIsDuplicate;
   }
 
   applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl) {
@@ -2042,7 +2122,7 @@ class FHIRExporter {
     // This requires slicing.  See: https://chat.fhir.org/#narrow/stream/implementers/subject/fixedUri
     let sliced = false;
     const icConstraints = sourceValue.constraintsFilter.own.includesCode.constraints;
-    for (let i=0; i < icConstraints.length; i++) {
+    for (let i = 0; i < icConstraints.length; i++) {
       const code = icConstraints[i].code;
       if (code.system == 'urn:tbd') {
         // Skip TBD code
@@ -2078,20 +2158,20 @@ class FHIRExporter {
     if (sliced) {
       // Need to set the slicing up on the base element
       switch (sourceValue.identifier.fqn) {
-      case 'code':
-        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', '$this');
-        break;
-      case 'shr.core.Coding':
-      case 'shr.core.Quantity':
-        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'system');
-        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'code');
-        break;
-      case 'shr.core.CodeableConcept':
-        common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'coding');
-        break;
-      default:
-        logger.error('Can\'t fix code on %s because source value isn\'t code-like. This should never happen and is probably a bug in the tool. ERROR_CODE:13032', snapshotEl.id);
-        return;
+        case 'code':
+          common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', '$this');
+          break;
+        case 'shr.core.Coding':
+        case 'shr.core.Quantity':
+          common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'system');
+          common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'code');
+          break;
+        case 'shr.core.CodeableConcept':
+          common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'value', 'coding');
+          break;
+        default:
+          logger.error('Can\'t fix code on %s because source value isn\'t code-like. This should never happen and is probably a bug in the tool. ERROR_CODE:13032', snapshotEl.id);
+          return;
       }
     }
   }
@@ -2115,36 +2195,39 @@ class FHIRExporter {
 
     // Different behavior based on code type
     switch (codeType) {
-    case 'code':
-      if (snapshotEl.fixedCode && snapshotEl.fixedCode !== code.code) {
-        logger.error('Cannot override code constraint from %s to %s. ERROR_CODE:13034', snapshotEl.fixedCode, code.code);
-      } else {
-        snapshotEl.fixedCode = differentialEl.fixedCode = code.code;
-        if (REPORT_PROFILE_INDICATORS) {
-          this.addFixedValueIndicator(profile, snapshotEl.path, code.code);
+      case 'code':
+        if (snapshotEl.fixedCode && snapshotEl.fixedCode !== code.code) {
+          logger.error('Cannot override code constraint from %s to %s. ERROR_CODE:13034', snapshotEl.fixedCode, code.code);
+        } else {
+          snapshotEl.fixedCode = differentialEl.fixedCode = code.code;
+          if (REPORT_PROFILE_INDICATORS) {
+            this.addFixedValueIndicator(profile, snapshotEl.path, code.code);
+          }
         }
-      }
-      return; // we're done here!
-    case 'shr.core.Coding':
-    case 'Coding':
-    case 'shr.core.Quantity':
-    case 'Quantity': {
-      // First check if there's an existing fixed[x] or pattern[x] applied
-      let fixedPropName;
-      for (const propName of ['fixedCoding', 'patternCoding', 'fixedQuantity', 'patternQuantity']) {
-        if (snapshotEl[propName]) {
-          fixedPropName = propName;
-          break;
+        return; // we're done here!
+      case 'shr.core.Coding':
+      case 'Coding':
+      case 'shr.core.Quantity':
+      case 'Quantity': {
+        // First check if there's an existing fixed[x] or pattern[x] applied
+        let fixedPropName;
+        for (const propName of ['fixedCoding', 'patternCoding', 'fixedQuantity', 'patternQuantity']) {
+          if (snapshotEl[propName]) {
+            fixedPropName = propName;
+            break;
+          }
         }
-      }
-      if (fixedPropName) {
-        const fixedX = snapshotEl[fixedPropName];
-        if ((fixedX.system && fixedX.system != code.system) || (fixedX.code && fixedX.code != code.code)) {
-          logger.error('Cannot override code constraint from %s|%s to %s|%s. ERROR_CODE:13048', fixedX.system, fixedX.code, code.system, code.code);
-        } else if (!fixedX.system || !fixedX.code) {
-          // Use the fixed[x] or pattern[x] since it's already established, but add the missing property
-          if (typeof code.system !== 'undefined' && code.system !== null) {
-            fixedX.system = code.system;
+        if (fixedPropName) {
+          const fixedX = snapshotEl[fixedPropName];
+          if ((fixedX.system && fixedX.system != code.system) || (fixedX.code && fixedX.code != code.code)) {
+            logger.error('Cannot override code constraint from %s|%s to %s|%s. ERROR_CODE:13048', fixedX.system, fixedX.code, code.system, code.code);
+          } else if (!fixedX.system || !fixedX.code) {
+            // Use the fixed[x] or pattern[x] since it's already established, but add the missing property
+            if (typeof code.system !== 'undefined' && code.system !== null) {
+              fixedX.system = code.system;
+            }
+            fixedX.code = code.code;
+            differentialEl[fixedPropName] = common.cloneJSON(fixedX);
           }
           fixedX.code = code.code;
           differentialEl[fixedPropName] = common.cloneJSON(fixedX);
@@ -2152,135 +2235,131 @@ class FHIRExporter {
             snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
           }
         }
-        return;
-      }
 
-      // Now check for subpaths (system and code)
-      const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, snapshotEl, identifier);
-      if ((systemEl.fixedUri && systemEl.fixedUri != code.system) || (codeEl.fixedCode && codeEl.fixedCode != code.code)) {
-        logger.error('Cannot override code constraint from %s|%s to %s|%s. ERROR_CODE:13048', systemEl.fixedUri, codeEl.fixedCode, code.system, code.code);
-        return;
-      }
-      if (typeof code.system !== 'undefined' && code.system !== null) {
-        const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
-        systemEl.fixedUri = systemDf.fixedUri = code.system;
-      }
-      const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
-      codeEl.fixedCode = codeDf.fixedCode = code.code;
-
-      if (code.display) {
-        snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
-      }
-
-      if (REPORT_PROFILE_INDICATORS) {
-        this.addFixedValueIndicator(profile, snapshotEl.path, code);
-      }
-      // TODO: Differentials?
-    } return;
-    case 'shr.core.CodeableConcept':
-    case 'CodeableConcept': {
-      // First check if there's an existing fixedCodeableConcept or patternCodeableConcept applied
-      let fixedPropName;
-      for (const propName of ['fixedCodeableConcept', 'patternCodeableConcept']) {
-        if (snapshotEl[propName]) {
-          fixedPropName = propName;
-          break;
-        }
-      }
-      if (fixedPropName) {
-        const fixedX = snapshotEl[fixedPropName];
-        if (typeof fixedX.coding === 'undefined' || fixedX.coding.length === 0) {
-          // I can't imagin this ever happening, but just in case
-          fixedX.coding = [{}];
-        }
-
-        // We assume there won't ever be a fixed CodeableConcept w/ more than one coding in it (let's hope we're right)
-        if ((fixedX.coding[0].system && fixedX.coding[0].system != code.system) || (fixedX.coding[0].code && fixedX.coding[0].code != code.code)) {
-          logger.error('Cannot override code constraint from %s|%s to %s|%s. ERROR_CODE:13048', fixedX.coding[0].system, fixedX.coding[0].code, code.system, code.code);
-        } else if (!fixedX.coding[0].system || !fixedX.coding[0].code) {
-          // Use the fixedCodeableConcept or patternCodeableConcept since it's already established, but add the missing property
-          fixedX.coding[0].system = code.system;
-          fixedX.coding[0].code = code.code;
-          differentialEl[fixedPropName] = common.cloneJSON(fixedX);
-          if (code.display) {
-            snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
-          }
-        }
-        return;
-      }
-
-      // Go through the existing slices to see if there are system/code pairs we can modify.
-      // If a slice has no system or code fixed, we'll fix both.  If system is fixed and matches, but code is not fixed,
-      // we'll fix just the code.  Otherwise we'll add a new slice with the fixed system and code.
-      const codingSlices = profile.snapshot.element.filter(e => e.id.startsWith(snapshotEl.id) && e.path === `${snapshotEl.path}.coding` && e.sliceName);
-      for (const slice of codingSlices) {
-        const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, slice, identifier, false);
-        if (typeof systemEl.fixedUri === 'undefined' && typeof codeEl.fixedCode === 'undefined') {
-          if (typeof code.system !== 'undefined' && code.system !== null) {
-            const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
-            systemEl.fixedUri = systemDf.fixedUri = code.system;
-          }
-          const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
-          codeEl.fixedCode = codeDf.fixedCode = code.code;
-          if (code.display) {
-            const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
-            slice.short = slice.definition = sliceDf.short = sliceDf.definition = code.display;
-          }
-          return;
-        } else if (systemEl.fixedUri && systemEl.fixedUri == code.system && typeof codeEl.fixedCode === 'undefined') {
-          const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
-          codeEl.fixedCode = codeDf.fixedCode = code.code;
-          if (code.display) {
-            const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
-            slice.short = slice.definition = sliceDf.short = sliceDf.definition = code.display;
-          }
-          return;
-        } else if (systemEl.fixedUri && systemEl.fixedUri == code.system && typeof codeEl.fixedCode && codeEl.fixedCode == code.code) {
-          // Nothing to do here.  We're good!
+        // Now check for subpaths (system and code)
+        const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, snapshotEl, identifier);
+        if ((systemEl.fixedUri && systemEl.fixedUri != code.system) || (codeEl.fixedCode && codeEl.fixedCode != code.code)) {
+          logger.error('Cannot override code constraint from %s|%s to %s|%s. ERROR_CODE:13048', systemEl.fixedUri, codeEl.fixedCode, code.system, code.code);
           return;
         }
-      }
+        if (typeof code.system !== 'undefined' && code.system !== null) {
+          const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
+          systemEl.fixedUri = systemDf.fixedUri = code.system;
+        }
+        const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
+        codeEl.fixedCode = codeDf.fixedCode = code.code;
 
-      // There were either no slices, or none of the slices were suitable for updating w/ the fixed code
-      let baseCoding = profile.snapshot.element.find(e => e.id.startsWith(snapshotEl.id) && e.path === `${snapshotEl.path}.coding`);
-      if (typeof baseCoding === 'undefined') {
-        this.unrollElement(identifier, profile, snapshotEl);
-        baseCoding = profile.snapshot.element.find(e => e.id.startsWith(snapshotEl.id) && e.path === `${snapshotEl.path}.coding`);
-      }
+        if (code.display) {
+          snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
+        }
 
-      const baseCodingDf = common.getDifferentialElementById(profile, baseCoding.id, true);
-      common.addSlicingToBaseElement(profile, baseCoding, baseCodingDf, 'value', 'code');
-      const sliceName = `Fixed_${code.code}`;
-      const sliceEl = {
-        id: `${baseCoding.id}:${sliceName}`,
-        path: baseCoding.path,
-        sliceName: sliceName,
-        short: code.display,
-        definition: code.display ? code.display : baseCoding.definition,
-        min: 1, // We're fixing the coding, so make it 1..1
-        max: '1', // We're fixing the coding, so make it 1..1
-        type: common.cloneJSON(baseCoding.type),
-        isSummary: baseCoding.isSummary
-      };
-      // Insert the sliced element into the snapshot and differential
-      const start = profile.snapshot.element.findIndex(e => e.id == baseCoding.id) + 1;
-      profile.snapshot.element.splice(start, 0, sliceEl);
-      profile.differential.element.push(common.cloneJSON(sliceEl));
-      // Add the code constraint
-      // TODO: This unrolls it as a Coding, not an SHR Coding (if there was a difference)
-      const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, sliceEl, 'Coding');
-      if (typeof code.system !== 'undefined' && code.system !== null) {
-        const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
-        systemEl.fixedUri = systemDf.fixedUri = code.system;
-      }
-      const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
-      codeEl.fixedCode = codeDf.fixedCode = code.code;
+        if (REPORT_PROFILE_INDICATORS) {
+          this.addFixedValueIndicator(profile, snapshotEl.path, code);
+        }
+        // TODO: Differentials?
+      } return;
+      case 'shr.core.CodeableConcept':
+      case 'CodeableConcept': {
+        // First check if there's an existing fixedCodeableConcept or patternCodeableConcept applied
+        let fixedPropName;
+        for (const propName of ['fixedCodeableConcept', 'patternCodeableConcept']) {
+          if (snapshotEl[propName]) {
+            fixedPropName = propName;
+            break;
+          }
+        }
+        if (fixedPropName) {
+          const fixedX = snapshotEl[fixedPropName];
+          if (typeof fixedX.coding === 'undefined' || fixedX.coding.length === 0) {
+            // I can't imagin this ever happening, but just in case
+            fixedX.coding = [{}];
+          }
 
-    } return;
+          // We assume there won't ever be a fixed CodeableConcept w/ more than one coding in it (let's hope we're right)
+          if ((fixedX.coding[0].system && fixedX.coding[0].system != code.system) || (fixedX.coding[0].code && fixedX.coding[0].code != code.code)) {
+            logger.error('Cannot override code constraint from %s|%s to %s|%s. ERROR_CODE:13048', fixedX.coding[0].system, fixedX.coding[0].code, code.system, code.code);
+          } else if (!fixedX.coding[0].system || !fixedX.coding[0].code) {
+            // Use the fixedCodeableConcept or patternCodeableConcept since it's already established, but add the missing property
+            fixedX.coding[0].system = code.system;
+            fixedX.coding[0].code = code.code;
+            differentialEl[fixedPropName] = common.cloneJSON(fixedX);
+            if (code.display) {
+              snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
+            }
+          }
+        }
+        // Go through the existing slices to see if there are system/code pairs we can modify.
+        // If a slice has no system or code fixed, we'll fix both.  If system is fixed and matches, but code is not fixed,
+        // we'll fix just the code.  Otherwise we'll add a new slice with the fixed system and code.
+        const codingSlices = profile.snapshot.element.filter(e => e.id.startsWith(snapshotEl.id) && e.path === `${snapshotEl.path}.coding` && e.sliceName);
+        for (const slice of codingSlices) {
+          const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, slice, identifier, false);
+          if (typeof systemEl.fixedUri === 'undefined' && typeof codeEl.fixedCode === 'undefined') {
+            if (typeof code.system !== 'undefined' && code.system !== null) {
+              const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
+              systemEl.fixedUri = systemDf.fixedUri = code.system;
+            }
+            const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
+            codeEl.fixedCode = codeDf.fixedCode = code.code;
+            if (code.display) {
+              const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
+              slice.short = slice.definition = sliceDf.short = sliceDf.definition = code.display;
+            }
+            return;
+          } else if (systemEl.fixedUri && systemEl.fixedUri == code.system && typeof codeEl.fixedCode === 'undefined') {
+            const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
+            codeEl.fixedCode = codeDf.fixedCode = code.code;
+            if (code.display) {
+              const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
+              slice.short = slice.definition = sliceDf.short = sliceDf.definition = code.display;
+            }
+            return;
+          } else if (systemEl.fixedUri && systemEl.fixedUri == code.system && typeof codeEl.fixedCode && codeEl.fixedCode == code.code) {
+            // Nothing to do here.  We're good!
+            return;
+          }
+        }
+
+        // There were either no slices, or none of the slices were suitable for updating w/ the fixed code
+        let baseCoding = profile.snapshot.element.find(e => e.id.startsWith(snapshotEl.id) && e.path === `${snapshotEl.path}.coding`);
+        if (typeof baseCoding === 'undefined') {
+          this.unrollElement(identifier, profile, snapshotEl);
+          baseCoding = profile.snapshot.element.find(e => e.id.startsWith(snapshotEl.id) && e.path === `${snapshotEl.path}.coding`);
+        }
+
+        const baseCodingDf = common.getDifferentialElementById(profile, baseCoding.id, true);
+        common.addSlicingToBaseElement(profile, baseCoding, baseCodingDf, 'value', 'code');
+        const sliceName = `Fixed_${code.code}`;
+        const sliceEl = {
+          id: `${baseCoding.id}:${sliceName}`,
+          path: baseCoding.path,
+          sliceName: sliceName,
+          short: code.display,
+          definition: code.display ? code.display : baseCoding.definition,
+          min: 1, // We're fixing the coding, so make it 1..1
+          max: '1', // We're fixing the coding, so make it 1..1
+          type: common.cloneJSON(baseCoding.type),
+          isSummary: baseCoding.isSummary
+        };
+        // Insert the sliced element into the snapshot and differential
+        const start = profile.snapshot.element.findIndex(e => e.id == baseCoding.id) + 1;
+        profile.snapshot.element.splice(start, 0, sliceEl);
+        profile.differential.element.push(common.cloneJSON(sliceEl));
+        // Add the code constraint
+        // TODO: This unrolls it as a Coding, not an SHR Coding (if there was a difference)
+        const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, sliceEl, 'Coding');
+        if (typeof code.system !== 'undefined' && code.system !== null) {
+          const systemDf = common.getDifferentialElementById(profile, systemEl.id, true);
+          systemEl.fixedUri = systemDf.fixedUri = code.system;
+        }
+        const codeDf = common.getDifferentialElementById(profile, codeEl.id, true);
+        codeEl.fixedCode = codeDf.fixedCode = code.code;
+
+      } return;
     }
   }
 
-  findSystemAndCodeElements(profile, snapshotEl, identifier, createIfMissing=true) {
+  findSystemAndCodeElements(profile, snapshotEl, identifier, createIfMissing = true) {
     let rootEl = snapshotEl;
     let systemEl, codeEl;
     if (snapshotEl.type[0].code === 'Extension') {
@@ -2316,7 +2395,7 @@ class FHIRExporter {
   }
 
   fixValueOnElement(profile, snapshotEl, differentialEl, value, typeCode) {
-    if (! snapshotEl.type.some(t => t.code === typeCode)) {
+    if (!snapshotEl.type.some(t => t.code === typeCode)) {
       // This can't be fixed to the value, as it's not the right type
       logger.error('Cannot fix %s to %s since it is not a %s type. ERROR_CODE:13058', snapshotEl.path, value, typeCode);
       return;
@@ -2347,7 +2426,7 @@ class FHIRExporter {
   }
 
   // This function applies applicable constraints when there is a non-trival conversion -- and warns if constraints will be dropped.
-  applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl) {
+  applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath) {
     const sourceIdentifier = sourceValue.effectiveIdentifier;
     const targetTypes = snapshotEl.type;
 
@@ -2357,7 +2436,7 @@ class FHIRExporter {
     } else {
       const targetAllowsCodeConstraints = targetTypes.some(t => t.code == 'code' || t.code == 'Coding' || t.code == 'CodeableConcept' || t.code == 'string');
       if (targetAllowsCodeConstraints) {
-        this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl);
+        this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
         this.applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
         this.applyOwnIncludesCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
         return;
@@ -2445,16 +2524,16 @@ class FHIRExporter {
       ssEl.definition = this.getDescription(identifier, `${this._config.projectShorthand} ${identifier.name} Extension`);
       ssEl.min = sourceValue.effectiveCard.min;
       ssEl.max = typeof sourceValue.effectiveCard.max === 'undefined' ? '*' : sourceValue.effectiveCard.max.toString();
-      ssEl.type = [{ code : 'Extension', profile : extURL }];
+      ssEl.type = [{ code: 'Extension', profile: extURL }];
       // TODO: Do we need to add the condition and constraints here?
       if (isModifier) {
         ssEl.mustSupport = ssEl.isModifier = true;
       }
-      delete(ssEl.base);
-      delete(ssEl.short);
-      delete(ssEl.comment);
-      delete(ssEl.alias);
-      delete(ssEl.mapping);
+      delete (ssEl.base);
+      delete (ssEl.short);
+      delete (ssEl.comment);
+      delete (ssEl.alias);
+      delete (ssEl.mapping);
       this.insertExtensionElementInList(ssEl, profile.snapshot.element);
 
       dfEl = common.cloneJSON(ssEl);
@@ -2490,12 +2569,12 @@ class FHIRExporter {
       if (isModifier && (typeof ssEl.isModifier === 'undefined' || !ssEl.isModifier)) {
         dfEl.isModifier = ssEl.isModifier = true;
       }
-      delete(ssEl.short);
-      delete(dfEl.short);
+      delete (ssEl.short);
+      delete (dfEl.short);
       // Some IGs (e.g., US Core) repeat the slicing element in the extension.  I don't think this is right.
       if (ssEl.slicing && baseExtEl.slicing && ssEl.slicing.id === baseExtEl.slicing.id) {
-        delete(ssEl.slicing);
-        delete(dfEl.short);
+        delete (ssEl.slicing);
+        delete (dfEl.short);
       }
 
       if (dfIsNew) {
@@ -2503,7 +2582,7 @@ class FHIRExporter {
       }
     }
 
-    this.applyConstraints(sourceValue, profile, ssEl, dfEl, true);
+    this.applyConstraints(sourceValue, profile, ssEl, dfEl, true, sourcePath);
 
     return;
   }
@@ -2514,7 +2593,7 @@ class FHIRExporter {
     if (extElement.isModifier) {
       priorPaths.push('modifierExtension');
     }
-    for (let i=0; i < elements.length; i++) {
+    for (let i = 0; i < elements.length; i++) {
       const pathParts = elements[i].path.split('.');
       if (pathParts.length > 1 && priorPaths.indexOf(pathParts[1]) == -1) {
         elements.splice(i, 0, extElement);
@@ -2528,7 +2607,7 @@ class FHIRExporter {
     }
   }
 
-  lookupProfile(identifier, createIfNeeded=true, warnIfProfileIsProcessing=false) {
+  lookupProfile(identifier, createIfNeeded = true, warnIfProfileIsProcessing = false) {
     let p = this._profilesMap.get(common.fhirID(identifier));
     if (typeof p === 'undefined' && createIfNeeded) {
       const mapping = this._specs.maps.findByTargetAndIdentifier(TARGET, identifier);
@@ -2547,7 +2626,7 @@ class FHIRExporter {
     return p;
   }
 
-  lookupStructureDefinition(id, warnIfStructureDefinitionIsProcessing=false) {
+  lookupStructureDefinition(id, warnIfStructureDefinitionIsProcessing = false) {
     // First check profiles
     const profile = this._profilesMap.get(id);
     if (typeof profile !== 'undefined') {
@@ -2569,8 +2648,8 @@ class FHIRExporter {
   getSnapshotElementForFieldTarget(profile, fieldTarget, sourceValue, sliceCard) {
     // Unroll paths as necessary to support drilling into types
     let parts = [profile.type, ...fieldTarget.target.split('.')];
-    for (let i=0; i < parts.length; i++) {
-      let path = parts.slice(0, i+1).join('.');
+    for (let i = 0; i < parts.length; i++) {
+      let path = parts.slice(0, i + 1).join('.');
       if (profile.snapshot.element.some(e => e.path == path)) {
         continue;
       }
@@ -2582,7 +2661,7 @@ class FHIRExporter {
         const parentDfEl = common.getDifferentialElementById(profile, parentEl.id, true);
         const [ssEl] = this.addExplicitChoiceElement(parts[i], profile, parentEl, parentDfEl);
         // Clone the target with the new path and try again
-        const newTarget = fieldTarget.target.replace(`${parts[i-1]}.${parts[i]}`, ssEl.path.split('.').pop());
+        const newTarget = fieldTarget.target.replace(`${parts[i - 1]}.${parts[i]}`, ssEl.path.split('.').pop());
         const newFieldTarget = new FieldTarget(newTarget, fieldTarget.commands, fieldTarget.comments);
         return this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sourceValue, sliceCard);
       } else if (typeof parentEl === 'undefined' || !Array.isArray(parentEl.type) || parentEl.type.length != 1) {
@@ -2615,7 +2694,7 @@ class FHIRExporter {
       let baseElement = elements[0];
       // If the mapping has a slice at command, then that's where we need to set the base element to apply slicing info
       if (fieldTarget.hasSliceAtCommand()) {
-        const sliceAt =  [profile.type, ...fieldTarget.findSliceAtCommand().value.split('.')].join('.');
+        const sliceAt = [profile.type, ...fieldTarget.findSliceAtCommand().value.split('.')].join('.');
         const atElements = profile.snapshot.element.filter(e => e.path == sliceAt);
         if (atElements.length == 0) {
           return;
@@ -2635,11 +2714,11 @@ class FHIRExporter {
 
       let sliceName;
       if (fieldTarget.hasInSliceCommand()) {
-        [/*match*/,/*path*/,sliceName] = /(.*)\s*\[(.*)\]/.exec(fieldTarget.findInSliceCommand());
+        [/*match*/,/*path*/, sliceName] = /(.*)\s*\[(.*)\]/.exec(fieldTarget.findInSliceCommand());
       } else {
         // this shouldn't ever happen, but just in case
         logger.error('No slice name supplied for target. This should never happen and is probably a bug in the tool. ERROR_CODE:13042');
-        sliceName = `gen-${elements.length+1}`;
+        sliceName = `gen-${elements.length + 1}`;
       }
 
       // Now add the snapshot and differential sections for the slice!
@@ -2666,13 +2745,13 @@ class FHIRExporter {
       ssSliceSection[0].sliceName = dfSliceSection[0].sliceName = sliceName;
 
       // The base slice section element has slicing (from the copy), but we don't need to repeat that
-      delete(ssSliceSection[0].slicing);
-      delete(dfSliceSection[0].slicing);
+      delete (ssSliceSection[0].slicing);
+      delete (dfSliceSection[0].slicing);
       // We also don't really need to repeat the comment and requirements
-      delete(ssSliceSection[0].comment);
-      delete(dfSliceSection[0].comment);
-      delete(ssSliceSection[0].requirements);
-      delete(dfSliceSection[0].requirements);
+      delete (ssSliceSection[0].comment);
+      delete (dfSliceSection[0].comment);
+      delete (ssSliceSection[0].requirements);
+      delete (dfSliceSection[0].requirements);
 
       // "Personalize" the base slice to this specific element
       if (typeof sourceValue !== 'undefined' && sourceValue instanceof mdls.IdentifiableValue) {
@@ -2691,7 +2770,7 @@ class FHIRExporter {
 
       // Find the insertion point, which should be at the end of any current slices
       let i = profile.snapshot.element.findIndex(e => e == baseElement) + 1;
-      for ( ; i < profile.snapshot.element.length && profile.snapshot.element[i].path.startsWith(baseElement.path); i++);
+      for (; i < profile.snapshot.element.length && profile.snapshot.element[i].path.startsWith(baseElement.path); i++);
       // Insert the section
       profile.snapshot.element.splice(i, 0, ...ssSliceSection);
     }
@@ -2703,7 +2782,7 @@ class FHIRExporter {
     if (elements.length > 1) {
       if (fieldTarget.hasInSliceCommand()) {
         // It's in a slice, so try to find the element in the specific slice
-        const [/*match*/,/*path*/,sliceName] = /(.*)\s*\[(.*)\]/.exec(fieldTarget.findInSliceCommand());
+        const [/*match*/,/*path*/, sliceName] = /(.*)\s*\[(.*)\]/.exec(fieldTarget.findInSliceCommand());
         element = elements.find(s => {
           return profile.snapshot.element.some(e => s.id.startsWith(e.id) && e.sliceName == sliceName);
         });
@@ -2714,7 +2793,7 @@ class FHIRExporter {
       } else {
         // It's not in a slice, so try to find the non-sliced path (for constraints on the base elements)
         const nonSlices = elements.filter(s => {
-          return ! profile.snapshot.element.some(e => s.id.startsWith(e.id) && typeof e.sliceName !== 'undefined');
+          return !profile.snapshot.element.some(e => s.id.startsWith(e.id) && typeof e.sliceName !== 'undefined');
         });
         if (nonSlices.length === 1) {
           element = nonSlices[0];
@@ -2732,7 +2811,7 @@ class FHIRExporter {
 
   // Given a path (identifier array) and a SHR data element definition, it will return the matching value at the tail
   // of the path with all constraints aggregrated onto it
-  findValueByPath(path, def, valueOnly=false, parentConstraints=[]) {
+  findValueByPath(path, def, valueOnly = false, parentConstraints = []) {
     if (path.length == 0) {
       return;
     }
@@ -2880,14 +2959,14 @@ class FHIRExporter {
     }
   }
 
-  mergeConstraintsToChild(parentConstraints, childValue, childIsElementValue=false) {
+  mergeConstraintsToChild(parentConstraints, childValue, childIsElementValue = false) {
     const constraints = [];
     for (const cst of parentConstraints) {
       if (childIsElementValue && cst.path.length == 0 && cst.onValue) {
         const transferredCst = cst.clone();
         transferredCst.onValue = false;
         constraints.push(transferredCst);
-      } else if (cst.path.length > 0 && (cst.path[0].equals(childValue.identifier) || cst.path[0].equals(childValue.effectiveIdentifier) )) {
+      } else if (cst.path.length > 0 && (cst.path[0].equals(childValue.identifier) || cst.path[0].equals(childValue.effectiveIdentifier))) {
         const transferredCst = cst.clone();
         transferredCst.path.shift(); // Remove the first element of the path since we're transferring this to the child
         constraints.push(transferredCst);
@@ -2916,8 +2995,8 @@ class FHIRExporter {
   getAggregateEffectiveCardinality(elementIdentifier, path) {
     const cards = [];
     const def = this._specs.dataElements.findByIdentifier(elementIdentifier);
-    for (let i=0; i < path.length; i++) {
-      const sourceValue = this.findValueByPath(path.slice(0, i+1), def);
+    for (let i = 0; i < path.length; i++) {
+      const sourceValue = this.findValueByPath(path.slice(0, i + 1), def);
       cards.push(sourceValue.effectiveCard);
     }
     return aggregateCardinality(...cards);
@@ -2984,7 +3063,7 @@ class FHIRExporter {
   checkMappedAndConstrained(profile, path) {
     const codeEl = common.getSnapshotElement(profile, path);
     let fqn = profile.identifier[0].value.split('.');
-    let identifier = {'name': fqn.pop(),'namespace': fqn.join('.')};
+    let identifier = { 'name': fqn.pop(), 'namespace': fqn.join('.') };
     const def = this._specs.dataElements.findByIdentifier(identifier);
 
     if (typeof codeEl === 'undefined' || (codeEl.min == 0 && codeEl.max == '0')) {
@@ -3039,7 +3118,7 @@ class FHIRExporter {
           if (i >= 0) {
             // This element matches an unconstrained path, so check if it's still unconstrained
             const rEl2 = this.getOriginalElement(pEl2) || rEl;
-            if (! this.codeNotConstrained(profile, pEl2, rEl2)) {
+            if (!this.codeNotConstrained(profile, pEl2, rEl2)) {
               // Remove the path from the unconstrained code paths!
               unconstrainedCodePaths.splice(i, 1);
             }
@@ -3114,7 +3193,7 @@ class FHIRExporter {
 }
 
 class FieldTarget {
-  constructor(target, commands=[], comments) {
+  constructor(target, commands = [], comments) {
     this._target = target;
     this._commands = commands;
     this._comments = comments;
@@ -3254,7 +3333,7 @@ function pathsAreEqual(path1, path2) {
   if (path1.length != path2.length) {
     return false;
   }
-  for (let i=0; i < path1.length; i++) {
+  for (let i = 0; i < path1.length; i++) {
     if (!path1[i].equals(path2[i])) {
       return false;
     }
@@ -3265,8 +3344,8 @@ function pathsAreEqual(path1, path2) {
 function getAggregateFHIRElementCardinality(profile, element) {
   const cards = [];
   const parts = element.id.split('.');
-  for (let i=1; i < parts.length; i++) {
-    const el = common.getSnapshotElementById(profile, parts.slice(0, i+1).join('.'));
+  for (let i = 1; i < parts.length; i++) {
+    const el = common.getSnapshotElementById(profile, parts.slice(0, i + 1).join('.'));
     cards.push(getFHIRElementCardinality(el));
   }
   return aggregateCardinality(...cards);
@@ -3283,7 +3362,7 @@ function getFHIRElementCardinality(element) {
   }
 }
 
-function setCardinalityOnFHIRElements(card, snapshotEl, differentialEl, skipIfEqual=true) {
+function setCardinalityOnFHIRElements(card, snapshotEl, differentialEl, skipIfEqual = true) {
   const ssCard = getFHIRElementCardinality(snapshotEl);
   if (!skipIfEqual || !ssCard.equals(card)) {
     const originalProperties = { min: snapshotEl.min, max: snapshotEl.max };
@@ -3300,8 +3379,8 @@ function setCardinalityOnFHIRElements(card, snapshotEl, differentialEl, skipIfEq
         differentialEl.min = snapshotEl.min;
         differentialEl.max = snapshotEl.max;
       } else {
-        delete(differentialEl.min);
-        delete(differentialEl.max);
+        delete (differentialEl.min);
+        delete (differentialEl.max);
       }
     }
   }
@@ -3324,7 +3403,7 @@ function aggregateCardinality(...card) {
   return new mdls.Cardinality(min, max);
 }
 
-function mappingAsText(map, simple=false) {
+function mappingAsText(map, simple = false) {
   let text = `${map.identifier.fqn} maps to ${map.targetItem}:\n`;
   for (const rule of map.rules) {
     text += `  ${rule.toString()}\n`;
@@ -3351,7 +3430,7 @@ function unmappedPathTreeAsText(tree, currentPrefix) {
     if (key === '_has_mapped_children') {
       continue;
     }
-    const name = key.substr(key.lastIndexOf('.')+1);
+    const name = key.substr(key.lastIndexOf('.') + 1);
     const entry = currentPrefix ? `${currentPrefix}.${name}` : name;
     if (!(value instanceof Map) || !value.has('_has_mapped_children')) {
       text += `${entry}\n`;
@@ -3364,18 +3443,18 @@ function unmappedPathTreeAsText(tree, currentPrefix) {
 
 function allowedBindingStrengthChange(originalStrength, newStrength) {
   switch (newStrength) {
-  case originalStrength:
-  case 'required':
-    return true;
-  case 'extensible':
-    return originalStrength != 'required';
-  case 'preferred':
-    return originalStrength != 'required' && originalStrength != 'extensible';
-  case 'example':
-    return originalStrength == 'example';
-  default:
-    // this shouldn't happen, so trigger an error if it does
-    return false;
+    case originalStrength:
+    case 'required':
+      return true;
+    case 'extensible':
+      return originalStrength != 'required';
+    case 'preferred':
+      return originalStrength != 'required' && originalStrength != 'extensible';
+    case 'example':
+      return originalStrength == 'example';
+    default:
+      // this shouldn't happen, so trigger an error if it does
+      return false;
   }
 }
 
@@ -3482,7 +3561,7 @@ class Stack {
 
   peekLast() {
     if (this._a.length > 0) {
-      return this._a[this._a.length-1];
+      return this._a[this._a.length - 1];
     }
   }
 
@@ -3491,4 +3570,4 @@ class Stack {
   }
 }
 
-module.exports = {exportToFHIR, FHIRExporter, exportIG, setLogger, TARGET, isTargetBasedOn, MODELS_INFO: mdls.MODELS_INFO};
+module.exports = { exportToFHIR, FHIRExporter, exportIG, setLogger, TARGET, isTargetBasedOn, MODELS_INFO: mdls.MODELS_INFO };


### PR DESCRIPTION
Reduces total warnings from ~485 to 66.

I'd review this PR by each individual error message (and commit message), as I don't recommend all changes equally. I suspect you may not agree with 'deduplicating' with particularly '03006'.

The most logically complex error was 03003.

### De-depuplication of error 03003
-Reduces the quantity of EC:03003 from 354 to 12
-This is a recommended deduplication

### De-depuplication of error 03004
-Reduces the quantity of EC:03004 from 43 to 15
-This is a maybe-recommended deduplication.

### De-duplication of error 03006  
-Reduces quantity of EC:03006 from 83 to 27. The method involves reclassifying all non-direct descendants of the profile.type to a lower level warning (‘info’)
-Not necessarily a recommended deduplication. Those lower level elements are also valid warnings that should be resolved…