### PR TITLE
Logical model fixes

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1491,6 +1491,7 @@ class FHIRExporter {
         const t = targetTypes[i];
         const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
         const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
+        // @ts-ignore
         if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
           matchedType = t;
           // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
@@ -1500,6 +1501,7 @@ class FHIRExporter {
             // additional applicable profiles.  This is done by checking if its part of an includes type slice, and/or
             // by checking if the new profile fits in the old type / profile.
             if (common.isCustomProfile(sourceProfile)) {
+              // @ts-ignore
               if (typeof originalProfile === 'undefined' || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
                 if (sourceValue._derivedFromIncludesTypeConstraint) {
                   // This is the result of an includes type slicing, so we want the new profile to replace the existing one
@@ -1533,6 +1535,7 @@ class FHIRExporter {
             this.markSelectedOptionsInChoice(targetTypes, [t]);
           }
           break;
+        // @ts-ignore
         } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(originalTargetProfile) || basedOnTargetProfiles.includes(originalTargetProfile))) {
           matchedType = t;
           // Only change the type if it hasn't already been selected (e.g. changed) by the mapper

--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -480,11 +480,11 @@ class ElementDefinition {
           codingSystem.fixedUri = code.system;
         } else {
           codingSystem.min = 0;
-          codingSystem.max = 0;
+          codingSystem.max = '0';
           const codingVersion = this.findChild('version', resolve);
           if (codingVersion) {
             codingVersion.min = 0;
-            codingVersion.max = 0;
+            codingVersion.max = '0';
           }
         }
       }

--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -882,6 +882,7 @@ class ElementDefinition {
     const detached = [];
     const toDetach = [this];
     if (detachChildren) {
+      // @ts-ignore
       toDetach.push(...this.children());
     }
     for (const el of toDetach) {
@@ -960,9 +961,9 @@ class ElementDefinition {
  * @returns {string} the name extracted from the type
  */
 function nameFromType(type) {
-  type = common.typeToString(type);
+  const stringType = common.typeToString(type);
   // If it's a URI, then just return the last part
-  return type.split('/').pop();
+  return stringType.split('/').pop();
 }
 
 /**

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -794,17 +794,17 @@ class ModelsExporter {
    * @returns {StructureDefinition} the StructureDefinition representing the type
    */
   resolve(type) {
-    type = common.typeToString(type);
+    const stringType = common.typeToString(type);
 
     const re = new RegExp(`${this._config.fhirURL}/StructureDefinition/([a-z].*)-([A-Z].*)-model`);
-    const localMatches = re.exec(type);
+    const localMatches = re.exec(stringType);
     if (localMatches) {
       const [ns, name] = [localMatches[1].replace(/-/g, '.'), localMatches[2]];
       // NOTE: possible recursion here!
       // TODO: Caching
       return this.exportModel(this._specs.dataElements.find(ns, name));
     }
-    const def = this._fhir.find(type);
+    const def = this._fhir.find(stringType);
     if (def && def.resourceType === 'StructureDefinition') {
       return StructureDefinition.fromJSON(def);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Mostly fixes just to make IDE type-checking happy with one very minor fix related to the `max` property on `Coding` (per FHIR spec, it should be a `string`, not an `integer`).