### PR TITLE
De-duplication of error 03004

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2940,10 +2940,32 @@ class FHIRExporter {
   }
 
   additionalQA(profile) {
-    switch(profile.type) {
-    case 'Basic':
-      logger.warn('Element profiled on Basic. Consider a more specific mapping. ERROR_CODE:03004');
+    switch (profile.type) {
+    case 'Basic': {
+      const fqn = profile.identifier[0].value.split('.');
+      const identifier = { 'name': fqn.pop(), 'namespace': fqn.join('.') };
+      const def = this._specs.dataElements.findByIdentifier(identifier);
+
+      if (!def.isAbstract) {
+        let parent, parentProfile;
+        if (def.basedOn.length > 0) {
+          parent = this._specs.dataElements.findByIdentifier(def.basedOn[0]);
+          parentProfile = this.lookupProfile(def.basedOn[0]);
+        }
+
+          //Hide warning if the parent profile is also Basic (avoid duplicates through inheritance)
+          //Override and show warning anyway if the parent is abstract, as children of abstract should show message
+          //Also show warning if there is no warning
+          //a. No Parent
+          //b. The parent is abstract
+          //b. The parent type isn't also basic (avoid duplicate error message) AND the parent isn't abstract (show children of abstracts even if duplicate)
+        if (!parentProfile || parentProfile.type != 'Basic' || parent.isAbstract) {
+          logger.warn('Element profiled on Basic. Consider a more specific mapping. ERROR_CODE:03004');
+        }
+      }
+
       break;
+    }
     case 'Observation': {
       this.checkMappedAndConstrained(profile, 'code');
       this.checkMappedAndConstrained(profile, 'value[x]');


### PR DESCRIPTION
(Split off from https://github.com/standardhealth/shr-fhir-export/pull/85 to simplify organization)

Prior commit message:
> -Reduces the quantity of EC:03004 from 43 to 15
> -This is a maybe-recommended deduplication.
>
> (Hidden children will show up if somehow their parent is no longer Basic but they still are, so more errors will reveal themselves.)
> 


Updates:
(Incorporates the changes suggested by Chris in: https://github.com/standardhealth/shr-fhir-export/pull/85)
- eliminate whitespace changes
- eliminate usage of 'var'