### PR TITLE
De-duplication of error 03003

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 /out
 /test/actuals
+*.swp

--- a/lib/export.js
+++ b/lib/export.js
@@ -1951,7 +1951,7 @@ class FHIRExporter {
             return;
           }
         } else if (bind.strength == 'extensible') {
-          const bindVSURI = bind.valueSetReference ? bind.valueSetReference.reference : bind.valueSetUri;
+          const bindVSURI = bind.valueSetReference ? bind.valueSetReference.reference : bind.valueSetUri; //VSURI comes from sourceValue, bindVSURI comes from snapshotEl
           if (!this.isValueSetSubsetOfOther(vsURI, bindVSURI)) {
             if (!this.shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath)) {
               logger.warn('Overriding extensible value set constraint from %s to %s.  Only allowed when new codes do not overlap meaning of old codes. ERROR_CODE:03003', bindVSURI, vsURI);
@@ -2058,7 +2058,7 @@ class FHIRExporter {
     const snapshotDataElement = this._specs.dataElements.findByIdentifier(snapshotElID);
 
     if (snapshotDataElement) {
-      const pathClone = [...sourcePath];
+      const pathClone = [...sourcePath]; //clone the source path to not mutate the original
       let currEl = snapshotDataElement;
 
       //Search the mapped element for relevant field (being mapped)
@@ -2068,9 +2068,11 @@ class FHIRExporter {
         let matchedField;
         // const combinedFieldsAndValue = (currEl.fields && currEl.value) ? [currEl.value, ...currEl.fields] : (currEl.fields) ? currEl.fields : [currEl.value]; //potentially more thorough than current implentation, although tests show no difference
 
-        if (snapshotEl.id.split(':').length == 2) {
+        if (snapshotEl.id.split(':').length == 2) { //This is used to determine whether or not this is an 'includesType' slice. Includes type slices have two ':' paths
           //Handle normal slices
-          //Additionally, account
+
+          //Find the field on the element
+          //Additionally, account for TypeConstraints that would also match field's path
           matchedField = currEl.fields.find(f => f.identifier.equals(pathID) || f.constraintsFilter.type.constraints.filter(c => c.isA.equals(pathID)).length > 0);
 
         } else {

--- a/lib/export.js
+++ b/lib/export.js
@@ -2066,41 +2066,55 @@ class FHIRExporter {
       while (pathClone.length > 1) {
         const pathID = pathClone.shift();
         let matchedField;
-        // const combinedFieldsAndValue = (currEl.fields && currEl.value) ? [currEl.value, ...currEl.fields] : (currEl.fields) ? currEl.fields : [currEl.value]; //potentially more thorough than current implentation, although tests show no difference
+        const combinedFieldsAndValue = (currEl.fields && currEl.value) ? [currEl.value, ...currEl.fields] : (currEl.fields) ? currEl.fields : [currEl.value]; //potentially more thorough than current implentation, although tests show no difference
 
         if (snapshotEl.id.split(':').length == 2) { //This is used to determine whether or not this is an 'includesType' slice. Includes type slices have two ':' paths
           //Handle normal slices
 
           //Find the field on the element
           //Additionally, account for TypeConstraints that would also match field's path
-          matchedField = currEl.fields.find(f => f.identifier.equals(pathID) || f.constraintsFilter.type.constraints.filter(c => c.isA.equals(pathID)).length > 0);
+          matchedField = combinedFieldsAndValue.find(f => f.identifier && f.identifier.equals(pathID) || f.constraintsFilter.type.constraints.filter(c => c.isA.equals(pathID)).length > 0);
 
         } else {
           //Handle complex 'includesType' slices
-          matchedField = currEl.fields
+          matchedField = combinedFieldsAndValue
             .filter(f => f.constraintsFilter.includesType.hasConstraints)
-            .filter(f => f.constraintsFilter.includesType.constraints
-              .filter(c => c.isA.equals(pathID)).length > 0);
+            .filter(f => f.constraintsFilter.includesType.constraints.some(c => c.isA.equals(pathID)));
           if (matchedField.length >= 1) {
             matchedField = matchedField[0];
           }
         }
 
         if (matchedField) {
+          let compareToParentMaps = () => {
+            //If it is inherited, check mapping differences with parent
+            const childMaps = this._specs.maps.findByTargetAndIdentifier('FHIR_STU_3', currEl.identifier);
+            const parentMaps = this._specs.maps.findByTargetAndIdentifier('FHIR_STU_3', currEl.basedOn[0]);
+            if (!parentMaps || !childMaps) {
+              return false;
+            }
+
+            //If it's 'inherited' then it has no further constraints (and especially no VS constraints).
+            //Parent mapping comparison
+            const matchedParentMapping = parentMaps.rules.filter(r=>r.sourcePath && r.sourcePath[0].equals(matchedField.identifier));
+            const matchedChildMapping = childMaps.rules.filter(r=>r.sourcePath && r.sourcePath[0].equals(matchedField.identifier));
+            const matchedIsDuplicate = JSON.stringify(matchedChildMapping) === JSON.stringify(matchedParentMapping);
+            return matchedIsDuplicate;
+          };
+
           if (!matchedField.inheritance) {
             //If it's not inherited, it's not a duplicate
             vscIsDuplicate = false;
             break;
           } else if (matchedField.inheritance == 'inherited') {
-            //If it is inherited, this error is a duplicate
-            vscIsDuplicate = true;
+            vscIsDuplicate = compareToParentMaps();
             break;
           } else if (matchedField.inheritance == 'overridden') {
             //Only overrides relevant are ValueSetConstraint overrides, which would make it unique.
             //Although, with a Type Constraint, you should skip and check the Type'd Element
             if (!matchedField.constraintsFilter.valueSet.hasConstraints) {
               if (!matchedField.constraintsFilter.own.type.hasConstraints) {
-                vscIsDuplicate = true;
+                vscIsDuplicate = compareToParentMaps();
                 break;
               }
             } else {

--- a/lib/export.js
+++ b/lib/export.js
@@ -1953,7 +1953,7 @@ class FHIRExporter {
         } else if (bind.strength == 'extensible') {
           const bindVSURI = bind.valueSetReference ? bind.valueSetReference.reference : bind.valueSetUri; //VSURI comes from sourceValue, bindVSURI comes from snapshotEl
           if (!this.isValueSetSubsetOfOther(vsURI, bindVSURI)) {
-            if (!this.shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath)) {
+            if (this._config.showDuplicateErrors || !this.shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath)) {
               logger.warn('Overriding extensible value set constraint from %s to %s.  Only allowed when new codes do not overlap meaning of old codes. ERROR_CODE:03003', bindVSURI, vsURI);
               // this is technically allowed, so don't return yet -- just continue...
             }
@@ -2125,7 +2125,7 @@ class FHIRExporter {
         } else {
           //If there are no matching fields, it's hard to determine.
           //Default to showing warning as opposed to suppressing
-          vscIsDuplicate = true;
+          vscIsDuplicate = false;
           break;
         }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -1823,7 +1823,7 @@ class FHIRExporter {
 
   findTargetFHIRPath(rootIdentifier, shrPath) {
     // Lookup rootIdentifier mapping
-    const map = this._specs.maps.findByTargetAndIdentifier('FHIR_STU_3', rootIdentifier);
+    const map = this._specs.maps.findByTargetAndIdentifier(TARGET, rootIdentifier);
     // Look for fieldmapping w/ shrPath
     if (map) {
       const rules = map.rulesFilter.field.withSourcePath(shrPath).rules;
@@ -2047,14 +2047,17 @@ class FHIRExporter {
 
   /*
     Determines whether a ValueSetConstraint on a mapped element is inherited from a parent.
-    Inheritance is determined by going matching sourcePath of the mapping with fields from
+    Inheritance is determined by matching sourcePath of the mapping with fields from
     the mapped element, and determining inheritance status at each level of depth
   */
   shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath) {
     var vscIsDuplicate = false;
 
-    const snapshotElFQN = snapshotEl.id.match(/\w*:((\w*-)+[A-za-z0-9\-]*).*/)[1].replace('-', '.').replace('-', '.');
-    const snapshotElID = { 'name': snapshotElFQN.split('.').pop(), 'namespace': snapshotElFQN.split('.').slice(0, -1).join('.') };
+    const snapshotElFqn = snapshotEl.id.match(/\w*:((\w*-)+[A-za-z0-9\-]*).*/)[1];
+    const snapshotElNameIndex = snapshotElFqn.search(/-[A-Z]/);
+    const snapshotElNamespace = snapshotElFqn.slice(0, snapshotElNameIndex).replace(/-/g, '.');
+    const snapshotElName = snapshotElFqn.slice(snapshotElNameIndex + 1);
+    const snapshotElID = { 'name': snapshotElName, 'namespace': snapshotElNamespace };
     const snapshotDataElement = this._specs.dataElements.findByIdentifier(snapshotElID);
 
     if (snapshotDataElement) {
@@ -2088,8 +2091,8 @@ class FHIRExporter {
         if (matchedField) {
           let compareToParentMaps = () => {
             //If it is inherited, check mapping differences with parent
-            const childMaps = this._specs.maps.findByTargetAndIdentifier('FHIR_STU_3', currEl.identifier);
-            const parentMaps = this._specs.maps.findByTargetAndIdentifier('FHIR_STU_3', currEl.basedOn[0]);
+            const childMaps = this._specs.maps.findByTargetAndIdentifier(TARGET, currEl.identifier);
+            const parentMaps = this._specs.maps.findByTargetAndIdentifier(TARGET, currEl.basedOn[0]);
             if (!parentMaps || !childMaps) {
               return false;
             }

--- a/lib/export.js
+++ b/lib/export.js
@@ -181,7 +181,7 @@ class FHIRExporter {
       profile.id = profileID;
       profile.text = this.getText(originalMap);
       profile.url = profileURL;
-      profile.identifier = [{ system: this._config.projectURL, value: map.identifier.fqn }],
+      profile.identifier = [{ system: this._config.projectURL, value: map.identifier.fqn }];
       profile.name = `${map.identifier.name}Profile`;
       profile.title = `${this._config.projectShorthand} ${map.identifier.name} Profile`;
       profile.description = this.getDescription(map.identifier);
@@ -1470,13 +1470,13 @@ class FHIRExporter {
       const matchedTypes = targetTypes.filter(t => sourceIdentifier.name == t.code);
       if (matchedTypes.length > 0) {
         this.markSelectedOptionsInChoice(targetTypes, matchedTypes);
-        this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false);
+        this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false, sourcePath);
         return [clonedPath];
       }
       const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
       if (allowedConvertedTypes.length > 0) {
         this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
-        this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl);
+        this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
         return [clonedPath];
       }
       return undefined;
@@ -1589,14 +1589,14 @@ class FHIRExporter {
           if (typeof mappedProfile !== 'undefined') {
             differentialEl.type = snapshotEl.type;
           }
-          this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false);
+          this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false, sourcePath);
           matchedPaths.push(clonedPath);
         }
       } else {
         const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
         if (allowedConvertedTypes.length > 0) {
           this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
-          this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl);
+          this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
           matchedPaths.push(clonedPath);
         }
       }
@@ -1711,7 +1711,7 @@ class FHIRExporter {
     return [type.id];
   }
 
-  applyConstraints(sourceValue, profile, snapshotEl, differentialEl, isExtension) {
+  applyConstraints(sourceValue, profile, snapshotEl, differentialEl, isExtension, sourcePath) {
     // As a *very* special (and unfortunate) case, we must special-case quantity.  Essentially, the problem is that
     // Quantity maps Units.Coding onto itself, so the constraints on Units.Coding need to be applied to Quantity instead.
     if (sourceValue.identifier.equals(new mdls.Identifier('shr.core', 'Quantity'))) {
@@ -1736,7 +1736,7 @@ class FHIRExporter {
     }
 
     // First handle own constraints
-    this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl);
+    this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
     this.applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnIncludesCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnBooleanConstraints(sourceValue, profile, snapshotEl, differentialEl);
@@ -1775,7 +1775,7 @@ class FHIRExporter {
           if (dfIsNew) {
             diffElement = { id: element.id, path: element.path };
           }
-          this.applyOwnValueSetConstraints(childSourceValue, profile, element, diffElement);
+          this.applyOwnValueSetConstraints(childSourceValue, profile, element, diffElement, sourcePath);
           this.applyOwnCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnIncludesCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnBooleanConstraints(childSourceValue, profile, element, diffElement);
@@ -1811,7 +1811,7 @@ class FHIRExporter {
               logger.error('Cannot constrain cardinality from %s to %s. ERROR_CODE:13014', targetCard.toString(), childValue.effectiveCard.toString());
             }
             // Call applyConstraints to apply any other constraints to the child value
-            this.applyConstraints(childValue, profile, targetSS, targetDf, false);
+            this.applyConstraints(childValue, profile, targetSS, targetDf, false, cstPath);
           } else {
             const friendlyPath = [sourceValue.effectiveIdentifier, ...cstPath].map(id => id.name).join('.');
             logger.error('Could not determine how to map nested value (%s) to FHIR profile. ERROR_CODE:13060', friendlyPath);
@@ -1901,7 +1901,7 @@ class FHIRExporter {
     return [snapshotEl, differentialEl];
   }
 
-  applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl) {
+  applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl, sourcePath) {
     const vsConstraints = sourceValue.constraintsFilter.own.valueSet.constraints;
     if (vsConstraints.length > 0) {
       [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
@@ -1953,8 +1953,10 @@ class FHIRExporter {
         } else if (bind.strength == 'extensible') {
           const bindVSURI = bind.valueSetReference ? bind.valueSetReference.reference : bind.valueSetUri;
           if (!this.isValueSetSubsetOfOther(vsURI, bindVSURI)) {
-            logger.warn('Overriding extensible value set constraint from %s to %s.  Only allowed when new codes do not overlap meaning of old codes. ERROR_CODE:03003', bindVSURI, vsURI);
-            // this is technically allowed, so don't return yet -- just continue...
+            if (!this.shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath)) {
+              logger.warn('Overriding extensible value set constraint from %s to %s.  Only allowed when new codes do not overlap meaning of old codes. ERROR_CODE:03003', bindVSURI, vsURI);
+              // this is technically allowed, so don't return yet -- just continue...
+            }
           }
         }
       }
@@ -2041,6 +2043,82 @@ class FHIRExporter {
       }
     }
     return true;
+  }
+
+  /*
+    Determines whether a ValueSetConstraint on a mapped element is inherited from a parent.
+    Inheritance is determined by going matching sourcePath of the mapping with fields from
+    the mapped element, and determining inheritance status at each level of depth
+  */
+  shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath) {
+    var vscIsDuplicate = false;
+
+    const snapshotElFQN = snapshotEl.id.match(/\w*:((\w*-)+[A-za-z0-9\-]*).*/)[1].replace('-', '.').replace('-', '.');
+    const snapshotElID = { 'name': snapshotElFQN.split('.').pop(), 'namespace': snapshotElFQN.split('.').slice(0, -1).join('.') };
+    const snapshotDataElement = this._specs.dataElements.findByIdentifier(snapshotElID);
+
+    if (snapshotDataElement) {
+      const pathClone = [...sourcePath];
+      let currEl = snapshotDataElement;
+
+      //Search the mapped element for relevant field (being mapped)
+      //Use the full sourcePath array to capture 'submappings', e.g. a mapping on dataabsentreason.component
+      while (pathClone.length > 1) {
+        const pathID = pathClone.shift();
+        let matchedField;
+        // const combinedFieldsAndValue = (currEl.fields && currEl.value) ? [currEl.value, ...currEl.fields] : (currEl.fields) ? currEl.fields : [currEl.value]; //potentially more thorough than current implentation, although tests show no difference
+
+        if (snapshotEl.id.split(':').length == 2) {
+          //Handle normal slices
+          //Additionally, account
+          matchedField = currEl.fields.find(f => f.identifier.equals(pathID) || f.constraintsFilter.type.constraints.filter(c => c.isA.equals(pathID)).length > 0);
+
+        } else {
+          //Handle complex 'includesType' slices
+          matchedField = currEl.fields
+            .filter(f => f.constraintsFilter.includesType.hasConstraints)
+            .filter(f => f.constraintsFilter.includesType.constraints
+              .filter(c => c.isA.equals(pathID)).length > 0);
+          if (matchedField.length >= 1) {
+            matchedField = matchedField[0];
+          }
+        }
+
+        if (matchedField) {
+          if (!matchedField.inheritance) {
+            //If it's not inherited, it's not a duplicate
+            vscIsDuplicate = false;
+            break;
+          } else if (matchedField.inheritance == 'inherited') {
+            //If it is inherited, this error is a duplicate
+            vscIsDuplicate = true;
+            break;
+          } else if (matchedField.inheritance == 'overridden') {
+            //Only overrides relevant are ValueSetConstraint overrides, which would make it unique.
+            //Although, with a Type Constraint, you should skip and check the Type'd Element
+            if (!matchedField.constraintsFilter.valueSet.hasConstraints) {
+              if (!matchedField.constraintsFilter.own.type.hasConstraints) {
+                vscIsDuplicate = true;
+                break;
+              }
+            } else {
+              vscIsDuplicate = false;
+              break;
+            }
+          }
+        } else {
+          //If there are no matching fields, it's hard to determine.
+          //Default to showing warning as opposed to suppressing
+          vscIsDuplicate = true;
+          break;
+        }
+
+        //If there was a type constraint field, and it is an original definition
+        currEl = this._specs.dataElements.findByIdentifier(pathID);
+      }
+    }
+
+    return vscIsDuplicate;
   }
 
   applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl) {
@@ -2363,7 +2441,7 @@ class FHIRExporter {
   }
 
   // This function applies applicable constraints when there is a non-trival conversion -- and warns if constraints will be dropped.
-  applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl) {
+  applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath) {
     const sourceIdentifier = sourceValue.effectiveIdentifier;
     const targetTypes = snapshotEl.type;
 
@@ -2373,7 +2451,7 @@ class FHIRExporter {
     } else {
       const targetAllowsCodeConstraints = targetTypes.some(t => t.code == 'code' || t.code == 'Coding' || t.code == 'CodeableConcept' || t.code == 'string');
       if (targetAllowsCodeConstraints) {
-        this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl);
+        this.applyOwnValueSetConstraints(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
         this.applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
         this.applyOwnIncludesCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
         return;
@@ -2519,7 +2597,7 @@ class FHIRExporter {
       }
     }
 
-    this.applyConstraints(sourceValue, profile, ssEl, dfEl, true);
+    this.applyConstraints(sourceValue, profile, ssEl, dfEl, true, sourcePath);
 
     return;
   }


### PR DESCRIPTION
(Split off from https://github.com/standardhealth/shr-fhir-export/pull/85 to simplify organization)

Prior commit message:
> -Reduces the quantity of EC:03003 from 354 to 12
> -This is a recommended deduplication
> 

Updated commit message:
- eliminate formatting changes
- fixed error messages on spec:may-2018-ballot (resulted from expecting
namespaces to be two words long, e.g. `shr-base` vs `cimi`)
- On spec:master —> reduces EC:03003 from 356—>11