### PR TITLE
To FHIR nested values

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -855,9 +855,11 @@ class FHIRExporter {
       df.mapping.push(shrMapping);
     } else {
       // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
-      // The shr.core.Quantity restriction is temporary, until support for that element is added
-      if (!sourceValue.identifier.isPrimitive && def.identifier.fqn != 'shr.core.Quantity') {
-        shrMapping['map'] = `<${sourceValue.identifier.fqn}>`;
+      if (!sourceValue.identifier.isPrimitive) {
+        // Build the mapping based on the sourcePath for the rule, to handle nested elements
+        shrMapping['map'] = rule.sourcePath.map((pathElem) => {
+          return `<${pathElem.fqn}>`;
+        }).join('.');
         ss.mapping.push(shrMapping);
         df.mapping.push(shrMapping);
       }


### PR DESCRIPTION
Added support for nested elements in building the SHR mapping rule.

NOTE: This currently only passes the test suite if you modify line 19 of `shr_fhir_map.txt` in `shr-es6-export` from:

`NestedStringValue maps to name.text`

to 

`NestedStringValue.StringValue maps to name.text`

@cmoesel, @Abhijay or other, can you confirm that the first form of mapping rule is or isn't valid? `NestedStringValue` has a value of `StringValue`, which has a value of `string`.
