### PR TITLE
Accomodate refactored config file

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -30,7 +30,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   //Rewrite base files to use project names
   const igIndexHtmlPath = path.join(outDir, 'pages','index.html');
   const igIndexHtml = fs.readFileSync(igIndexHtmlPath, 'utf8');
-  const igIndexContentPath = path.join(specPath, config.igIndexContent);
+  const igIndexContentPath = path.join(specPath, config.implementationGuide.indexContent);
   var igIndexContent;
   try {
     igIndexContent = fs.readFileSync(igIndexContentPath, 'utf8');
@@ -57,15 +57,15 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   }
 
   let isPrimaryFn;
-  if (config.igPrimarySelectionStrategy && config.igPrimarySelectionStrategy.strategy === 'namespace') {
-    const primary = config.igPrimarySelectionStrategy.primary;
+  if (config.implementationGuide.primarySelectionStrategy && config.implementationGuide.primarySelectionStrategy.strategy === 'namespace') {
+    const primary = config.implementationGuide.primarySelectionStrategy.primary;
     if (Array.isArray(primary)) {
       isPrimaryFn = (id) => {
         return primary.indexOf(idToElementMap.get(id).identifier.namespace) != -1;
       };
     } else {
       // TODO: Get a logger!
-      console.error('Namespace strategy requires config.igPrimarySelectionStrategy.primary to be an array');
+      console.error('Namespace strategy requires config.implementationGuide.primarySelectionStrategy.primary to be an array');
     }
   }
   if (isPrimaryFn == null) {
@@ -226,7 +226,7 @@ ${match[1]}
     `);
   }
 
-  if (config.igLogicalModels) {
+  if (config.implementationGuide.includeLogicalModels) {
     fhirResults.models.sort(byName);
     for (const model of fhirResults.models) {
       const hasConstraints = model.snapshot.element.some(e => e.constraints != null);
@@ -348,14 +348,14 @@ ${match[1]}
   fs.writeFileSync(modelsHtmlPath, modelsHtml.replace('<primary-models-go-here/>', htmlPrimaryModels.join(''))
                                              .replace('<support-models-go-here/>', htmlSupportModels.join(''))
                                              .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
-  if (!config.igLogicalModels || !config.igModelDoc) {
+  if (!config.implementationGuide.includeLogicalModels || !config.implementationGuide.includeModelDoc) {
     const navbarPath = path.join(outDir, 'pages', '_includes', 'navbar.html');
     let navbarHtml = fs.readFileSync(navbarPath, 'utf8');
-    if (!config.igLogicalModels) {
+    if (!config.implementationGuide.includeLogicalModels) {
       const modelsItem = '<li><a href="logical.html">Logical Models</a></li>';
       navbarHtml = navbarHtml.replace(modelsItem, '<!-- no logical models -->');
     }
-    if (!config.igModelDoc) {
+    if (!config.implementationGuide.includeModelDoc) {
       const browserItem = '<li><a href="modeldoc/index.html" target="_blank">Reference Model</a></li>';
       navbarHtml = navbarHtml.replace(browserItem, '<!-- no reference model -->');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.5.2",
+  "version": "5.6.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
PR 4 of 5 for config-updates. The remaining are in `shr_spec`, `shr-cli`, `shr-text-import`, and `shr-es6-export`.

These PRs implement:
-A refactored configuration file
-A split between primary selection strategy and filter strategy
-The ability to select a configuration file from the command line
-Added documentation in shr-cli for configuration file usage