### PR TITLE
Primary selection updates

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -57,11 +57,12 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   }
 
   let isPrimaryFn;
+  // If strategy is "namespace", set every entry within selected namespaces as primary
   if (config.implementationGuide.primarySelectionStrategy && config.implementationGuide.primarySelectionStrategy.strategy === 'namespace') {
     const primary = config.implementationGuide.primarySelectionStrategy.primary;
     if (Array.isArray(primary)) {
       isPrimaryFn = (id) => {
-        return primary.indexOf(idToElementMap.get(id).identifier.namespace) != -1;
+        return (idToElementMap.get(id).isEntry) && (primary.indexOf(idToElementMap.get(id).identifier.namespace) != -1);
       };
     } else {
       // TODO: Get a logger!
@@ -69,7 +70,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     }
   }
   if (isPrimaryFn == null) {
-    // Default to entry strategy
+    // If strategy is "entry" or default, set every entry as primary
     isPrimaryFn = (id) => {
       return idToElementMap.get(id).isEntry;
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The "namespace" primary selection strategy for the IG previously selected all entries and elements to be primary. This patches the operation to only allow entries and not elements to be selected as primary.