### PR TITLE
Hide supporting extensions

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -15,6 +15,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
 
   const igControlPath = path.join(outDir, 'ig.json');
   const igControl = fs.readJsonSync(igControlPath);
+  const primaryExtensionUrls = new Set();
   const xmlResources = [];
   const htmlPrimaryProfiles = [];
   const htmlSupportProfiles = [];
@@ -124,6 +125,17 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     `;
     if (isPrimaryFn(profile.id)) {
       htmlPrimaryProfiles.push(htmlSnippet);
+
+      for (const element of profile.snapshot.element) {
+        if (element.path === `${profile.type}.extension`
+        || element.path === `${profile.type}.modifierExtension`) {
+          for (const type of element.type) {
+            if (type.profile) {
+              primaryExtensionUrls.add(type.profile);
+            }
+          }
+        }
+      }
     } else {
       htmlSupportProfiles.push(htmlSnippet);
     }
@@ -159,8 +171,14 @@ ${match[1]}
   };
   fs.copySync(patchPath, sdPath, { filter: filterFunc });
 
-  fhirResults.extensions.sort(byName);
-  for (const extension of fhirResults.extensions) {
+  const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
+  && config.implementationGuide.primarySelectionStrategy.hideSupporting;
+
+  let fhirExtensions = fhirResults.extensions.sort(byName);
+  if (hideSupporting) {
+    fhirExtensions = fhirExtensions.filter(ext => primaryExtensionUrls.has(ext.url));
+  }
+  for (const extension of fhirExtensions) {
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${extension.id}.json`), JSON.stringify(extension, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${extension.id}`] = {
       'base': `StructureDefinition-${extension.id}.html`,
@@ -338,8 +356,6 @@ ${match[1]}
   let updatedProfilesHtml = profilesHtml.replace('<primary-profiles-go-here/>', htmlPrimaryProfiles.join(''))
     .replace('<support-profiles-go-here/>', htmlSupportProfiles.join(''))
     .replace('<project-shorthand-go-here/>', config.projectShorthand);
-  const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
-    && config.implementationGuide.primarySelectionStrategy.hideSupporting;
   if (hideSupporting) {
     updatedProfilesHtml = updatedProfilesHtml
       .replace('<h2 id="supporting-profiles-header">', '<h2 id="supporting-profiles-header" style="display: none">')

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -174,11 +174,7 @@ ${match[1]}
   const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
   && config.implementationGuide.primarySelectionStrategy.hideSupporting;
 
-  let fhirExtensions = fhirResults.extensions.sort(byName);
-  if (hideSupporting) {
-    fhirExtensions = fhirExtensions.filter(ext => primaryExtensionUrls.has(ext.url));
-  }
-  for (const extension of fhirExtensions) {
+  for (const extension of fhirResults.extensions.sort(byName)) {
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${extension.id}.json`), JSON.stringify(extension, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${extension.id}`] = {
       'base': `StructureDefinition-${extension.id}.html`,
@@ -193,12 +189,14 @@ ${match[1]}
         </resource>
         `);
     const name = extension.title.replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ Extension$/, '');
-    htmlExtensions.push(
-    `<tr>
-      <td><a href="StructureDefinition-${extension.id}.html">${name}</a></td>
-      <td>${markdownifiedText(extension.description)}</td>
-    </tr>
-    `);
+    if (!hideSupporting || primaryExtensionUrls.has(extension.url)) {
+      htmlExtensions.push(
+        `<tr>
+          <td><a href="StructureDefinition-${extension.id}.html">${name}</a></td>
+          <td>${markdownifiedText(extension.description)}</td>
+        </tr>
+        `);
+    }
   }
 
   fhirResults.valueSets.sort(byName);
@@ -367,8 +365,17 @@ ${match[1]}
   // Rewrite the updated Extensions HTML file
   const extensionsHtmlPath = path.join(outDir, 'pages', 'extensions.html');
   const extensionsHtml = fs.readFileSync(extensionsHtmlPath, 'utf8');
-  fs.writeFileSync(extensionsHtmlPath, extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
-                                                     .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedExtensionsHtml = extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand)
+  if (hideSupporting) {
+    updatedExtensionsHtml = updatedExtensionsHtml
+      .replace('<extensions-header/>', '<h2>Primary extensions defined as part of this Implementation Guide</h2>');
+  } else {
+    updatedExtensionsHtml = updatedExtensionsHtml
+      .replace('<extensions-header/>', '<h2>Extensions defined as part of this Implementation Guide</h2>');
+    }
+
+  fs.writeFileSync(extensionsHtmlPath, updatedExtensionsHtml, 'utf8');
 
   // Rewrite the updated ValueSets HTML file
   const valueSetsHtmlPath = path.join(outDir, 'pages', 'valuesets.html');

--- a/lib/ig_files/pages/extensions.html
+++ b/lib/ig_files/pages/extensions.html
@@ -21,9 +21,7 @@
 
 <!-- ============CONTENT CONTENT=============== -->
 
-<h2>
-  Extensions defined as part of this Implementation Guide
-</h2>
+<extensions-header/>
 <table class="codes">
   <thead>
     <tr>


### PR DESCRIPTION
Makes the `hideSupporting` config option hide any extensions in the IG that are not directly tied to primary profiles.