### PR TITLE
Additional documentation pages and image support

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -43,23 +43,36 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   }
 
   // Rewrite base files to use project names
-  const igIndexHtmlPath = path.join(outDir, 'pages','index.html');
-  const igIndexHtml = fs.readFileSync(igIndexHtmlPath, 'utf8');
-  const igIndexContentPath = path.join(specPath, config.implementationGuide.indexContent);
-  var igIndexContent;
-  try {
-    igIndexContent = fs.readFileSync(igIndexContentPath, 'utf8');
-  } catch (error) {
-    igIndexContent =
-`<p> This is a ${config.projectName} FHIR implementation guide. </p>`;
-    fs.writeFileSync(igIndexContentPath, igIndexContent, 'utf8');
-  }
+  const igIndexHtmlPath = path.join(outDir, 'pages');
+  const igIndexHtml = fs.readFileSync(path.join(igIndexHtmlPath, 'index.html'), 'utf8');
+  let igIndexContentPath = path.join(specPath, config.implementationGuide.indexContent);
 
-  fs.writeFileSync(igIndexHtmlPath, igIndexHtml.replace('<igIndexContent-go-here>', igIndexContent), 'utf8');
+  if (fs.lstatSync(igIndexContentPath).isDirectory()) {
+    const files = fs.readdirSync(igIndexContentPath, 'utf8');
+    for (const file of files) {
+      if (file.endsWith('.html')) {
+        let fileContent = fs.readFileSync(path.join(igIndexContentPath, file), 'utf8');
+        fs.writeFileSync(path.join(igIndexHtmlPath, file), igIndexHtml.replace('<igIndexContent-go-here>', fileContent), 'utf8');
+      } else {
+        let readStream = fs.createReadStream(path.join(igIndexContentPath, file));
+        readStream.pipe(fs.createWriteStream(path.join(igIndexHtmlPath, file)));
+      }
+    }
+  } else {
+    let igIndexContent;
+    try {
+      igIndexContent = fs.readFileSync(igIndexContentPath, 'utf8');
+    } catch (error) {
+      igIndexContent =
+  `<p> This is a ${config.projectName} FHIR implementation guide. </p>`;
+      fs.writeFileSync(igIndexContentPath, igIndexContent, 'utf8');
+    }
+    fs.writeFileSync(path.join(igIndexHtmlPath, 'index.html'), igIndexHtml.replace('<igIndexContent-go-here>', igIndexContent), 'utf8');
+  }
 
   // For each profile, extension, value set, and code system
   // 1. Copy it into the corresponding resources subfolder
-  // 2. Add it to the IG JSON controle file
+  // 2. Add it to the IG JSON control file
   // 3. Add it to the IG XML file
   // 4. Add it to the corresponding HTML listing file
   // 5. Create the mapping xhtml file (profiles only)


### PR DESCRIPTION
Adds support for additional documentation pages in the IG, as well as support for images in the landing page and documentation pages.

In order to get this working, change the configuration file's `implementationGuide.indexContent` field to a directory name instead of a file name, and include all needed files in this directory within `shr_spec/spec/`. The file `index.html` in the given directory is used as the landing page. Any other `.html` files are given the appropriate header and footer information, and are also sent over (with their given names) to the same directory as the landing page in the generated IG. Any other files (namely image files) are directly copied to the same directory as the landing page in the generated IG.

Because these additional `.html` files and image files will be included in the same directory as the landing page, they can be referenced in the IG simply by having a relative link in a page.

For a trivial example. say I have a directory `shr_spec/spec/exampleIndex` and in this directory I have files `index.html`, `extra.html`, and `img.png`.

The contents of `index.html` are as follows:
```
<p> This is an Example Project FHIR implementation guide. </p>
<a href="extra.html">Extra Documentation</a>
```

The contents of `extra.html` are as follows:
```
<p> This is a sample extra documentation page. </p>
<img src="img.png" alt="img">
```

If we generate and publish an IG with the config file using `implementationGuide.indexContent` equals `exampleIndex`, this will create a landing page with a link to the extra documentation, and the extra documentation page will display the image.