### PR TITLE
Show only "primary" ValueSets and CodeSystems

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -201,6 +201,10 @@ ${match[1]}
   && config.implementationGuide.primarySelectionStrategy
   && config.implementationGuide.primarySelectionStrategy.hideSupporting;
 
+  const usingNamespaceStrategy = config.implementationGuide
+  && config.implementationGuide.primarySelectionStrategy
+  && (config.implementationGuide.primarySelectionStrategy.strategy === 'namespace');
+
   for (const extension of fhirResults.extensions.sort(byName)) {
     if (primaryExtensionUrls.has(extension.url)) {
       for (const element of extension.snapshot.element) {
@@ -245,6 +249,17 @@ ${match[1]}
   const vsPath = path.join(outDir, 'resources');
   fs.ensureDirSync(vsPath);
   for (const valueSet of fhirResults.valueSets) {
+    if (usingNamespaceStrategy) {
+      const inNamespace = config.implementationGuide.primarySelectionStrategy.primary.some((p) => {
+        return valueSet.identifier.some((i) => {
+          return i.value.startsWith(p);
+        })  
+      });
+      if (inNamespace) {
+        primaryValueSetUrls.add(valueSet.url);
+      }
+    }
+
     if (primaryValueSetUrls.has(valueSet.url)) {
       for (const include of valueSet.compose.include) {
         if (include.system) {
@@ -284,6 +299,15 @@ ${match[1]}
   const csPath = path.join(outDir, 'resources');
   fs.ensureDirSync(csPath);
   for (const codeSystem of fhirResults.codeSystems) {
+    if (usingNamespaceStrategy) {
+      const inNamespace = config.implementationGuide.primarySelectionStrategy.primary.some((p) => {
+        return codeSystem.identifier.value.startsWith(p);
+      });
+      if (inNamespace) {
+        primaryCodeSystemUrls.add(codeSystem.url);
+      }
+    }
+
     fs.writeFileSync(path.join(csPath, `codesystem-${codeSystem.id}.json`), JSON.stringify(codeSystem, null, 2), 'utf8');
     igControl.resources[`CodeSystem/${codeSystem.id}`] = {
       'base': `CodeSystem-${codeSystem.id}.html`

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -16,6 +16,8 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   const igControlPath = path.join(outDir, 'ig.json');
   const igControl = fs.readJsonSync(igControlPath);
   const primaryExtensionUrls = new Set();
+  const primaryValueSetUrls = new Set();
+  const primaryCodeSystemUrls = new Set();
   const xmlResources = [];
   const htmlPrimaryProfiles = [];
   const htmlSupportProfiles = [];
@@ -148,6 +150,17 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
             }
           }
         }
+
+        if (element.binding
+        && element.binding.valueSetReference
+        && element.binding.valueSetReference.reference) {
+          primaryValueSetUrls.add(element.binding.valueSetReference.reference);
+        }
+
+        if (element.path.endsWith('.system')
+        && element.fixedUri) {
+          primaryCodeSystemUrls.add(element.fixedUri);
+        }
       }
     } else {
       htmlSupportProfiles.push(htmlSnippet);
@@ -184,10 +197,26 @@ ${match[1]}
   };
   fs.copySync(patchPath, sdPath, { filter: filterFunc });
 
-  const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
+  const hideSupporting = config.implementationGuide
+  && config.implementationGuide.primarySelectionStrategy
   && config.implementationGuide.primarySelectionStrategy.hideSupporting;
 
   for (const extension of fhirResults.extensions.sort(byName)) {
+    if (primaryExtensionUrls.has(extension.url)) {
+      for (const element of extension.snapshot.element) {
+        if (element.binding
+        && element.binding.valueSetReference
+        && element.binding.valueSetReference.reference) {
+          primaryValueSetUrls.add(element.binding.valueSetReference.reference);
+        }
+  
+        if (element.path.endsWith('.system')
+        && element.fixedUri) {
+          primaryCodeSystemUrls.add(element.fixedUri);
+        }
+      }
+    }
+
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${extension.id}.json`), JSON.stringify(extension, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${extension.id}`] = {
       'base': `StructureDefinition-${extension.id}.html`,
@@ -216,6 +245,14 @@ ${match[1]}
   const vsPath = path.join(outDir, 'resources');
   fs.ensureDirSync(vsPath);
   for (const valueSet of fhirResults.valueSets) {
+    if (primaryValueSetUrls.has(valueSet.url)) {
+      for (const include of valueSet.compose.include) {
+        if (include.system) {
+          primaryCodeSystemUrls.add(include.system);
+        }
+      }
+    }
+
     fs.writeFileSync(path.join(vsPath, `valueset-${valueSet.id}.json`), JSON.stringify(valueSet, null, 2), 'utf8');
     igControl.resources[`ValueSet/${valueSet.id}`] = {
       'base': `ValueSet-${valueSet.id}.html`
@@ -233,12 +270,14 @@ ${match[1]}
         `);
 
     const name = valueSet.title.replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ ValueSet$/, '');
-    htmlValueSets.push(
-    `<tr>
-      <td><a href="ValueSet-${valueSet.id}.html">${name}</a></td>
-      <td>${markdownifiedText(valueSet.description)}</td>
-    </tr>
-    `);
+    if (!hideSupporting || primaryValueSetUrls.has(valueSet.url)) {
+      htmlValueSets.push(
+      `<tr>
+        <td><a href="ValueSet-${valueSet.id}.html">${name}</a></td>
+        <td>${markdownifiedText(valueSet.description)}</td>
+      </tr>
+      `);
+    }
   }
 
   fhirResults.codeSystems.sort(byName);
@@ -262,12 +301,14 @@ ${match[1]}
         `);
 
     const name = codeSystem.title.replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ CodeSystem$/, '');
-    htmlCodeSystems.push(
-    `<tr>
-      <td><a href="CodeSystem-${codeSystem.id}.html">${name}</a></td>
-      <td>${markdownifiedText(codeSystem.description)}</td>
-    </tr>
-    `);
+    if (!hideSupporting || primaryCodeSystemUrls.has(codeSystem.url)) {
+      htmlCodeSystems.push(
+      `<tr>
+        <td><a href="CodeSystem-${codeSystem.id}.html">${name}</a></td>
+        <td>${markdownifiedText(codeSystem.description)}</td>
+      </tr>
+      `);
+    }
   }
 
   if (config.implementationGuide.includeLogicalModels) {
@@ -379,28 +420,47 @@ ${match[1]}
   const extensionsHtmlPath = path.join(outDir, 'pages', 'extensions.html');
   const extensionsHtml = fs.readFileSync(extensionsHtmlPath, 'utf8');
   let updatedExtensionsHtml = extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
-    .replace('<project-shorthand-go-here/>', config.projectShorthand)
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
   if (hideSupporting) {
     updatedExtensionsHtml = updatedExtensionsHtml
       .replace('<extensions-header/>', '<h2>Primary extensions defined as part of this Implementation Guide</h2>');
   } else {
     updatedExtensionsHtml = updatedExtensionsHtml
       .replace('<extensions-header/>', '<h2>Extensions defined as part of this Implementation Guide</h2>');
-    }
+  }
 
   fs.writeFileSync(extensionsHtmlPath, updatedExtensionsHtml, 'utf8');
 
   // Rewrite the updated ValueSets HTML file
   const valueSetsHtmlPath = path.join(outDir, 'pages', 'valuesets.html');
   const valueSetsHtml = fs.readFileSync(valueSetsHtmlPath, 'utf8');
-  fs.writeFileSync(valueSetsHtmlPath, valueSetsHtml.replace('<valueSets-go-here/>', htmlValueSets.join(''))
-                                                   .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedValueSetsHtml = valueSetsHtml.replace('<valueSets-go-here/>', htmlValueSets.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+  if (hideSupporting) {
+    updatedValueSetsHtml = updatedValueSetsHtml
+      .replace('<value-sets-header/>', '<h2>Primary Value Sets defined as part of this Implementation Guide</h2>');
+  } else {
+    updatedValueSetsHtml = updatedValueSetsHtml
+      .replace('<value-sets-header/>', '<h2>Value Sets defined as part of this Implementation Guide</h2>');
+  }
+
+  fs.writeFileSync(valueSetsHtmlPath, updatedValueSetsHtml, 'utf8');
 
   // Rewrite the updated CodeSystems HTML file
   const codeSystemsHtmlPath = path.join(outDir, 'pages', 'codesystems.html');
   const codeSystemsHtml = fs.readFileSync(codeSystemsHtmlPath, 'utf8');
-  fs.writeFileSync(codeSystemsHtmlPath, codeSystemsHtml.replace('<codeSystems-go-here/>', htmlCodeSystems.join(''))
-                                                       .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedCodeSystemsHtml = codeSystemsHtml.replace('<codeSystems-go-here/>', htmlCodeSystems.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+
+  if (hideSupporting) {
+    updatedCodeSystemsHtml = updatedCodeSystemsHtml
+      .replace('<code-systems-header/>', '<h2>Primary Code Systems defined as part of this Implementation Guide</h2>');
+  } else {
+    updatedCodeSystemsHtml = updatedCodeSystemsHtml
+      .replace('<code-systems-header/>', '<h2>Code Systems defined as part of this Implementation Guide</h2>');
+  }
+
+  fs.writeFileSync(codeSystemsHtmlPath, updatedCodeSystemsHtml, 'utf8');
 
   // Rewrite the updated Models HTML file
   const modelsHtmlPath = path.join(outDir, 'pages', 'logical.html');

--- a/lib/ig_files/pages/codesystems.html
+++ b/lib/ig_files/pages/codesystems.html
@@ -21,9 +21,7 @@
 
 <!-- ============CONTENT CONTENT=============== -->
 
-<h2>
-  Code Systems defined as part of this Implementation Guide
-</h2>
+<code-systems-header/>
 
 <table class="codes">
   <thead>

--- a/lib/ig_files/pages/extensions.html
+++ b/lib/ig_files/pages/extensions.html
@@ -22,6 +22,7 @@
 <!-- ============CONTENT CONTENT=============== -->
 
 <extensions-header/>
+
 <table class="codes">
   <thead>
     <tr>

--- a/lib/ig_files/pages/valuesets.html
+++ b/lib/ig_files/pages/valuesets.html
@@ -21,9 +21,7 @@
 
 <!-- ============CONTENT CONTENT=============== -->
 
-<h2>
-  Value Sets defined as part of this Implementation Guide
-</h2>
+<value-sets-header/>
 
 <table class="codes">
   <thead>


### PR DESCRIPTION
This PR causes only VS and CS within the primary namespace(s) or directly referenced in the primary resources to be displayed on the Value Sets and Code Systems pages of the IG, when the `hideSupporting` flag is enabled in the config file.