### PR TITLE
Sep ballot fixes

### DIFF
--- a/lib/codeSystems.js
+++ b/lib/codeSystems.js
@@ -9,7 +9,11 @@ class CodeSystemExporter {
   }
 
   get codeSystems() {
-    return Array.from(this._codeSystemsMap.values());
+    const systems = Array.from(this._codeSystemsMap.values());
+    if (this._basicResourceTypeCodeSystem != null) {
+      systems.push(this._basicResourceTypeCodeSystem);
+    }
+    return systems;
   }
 
   lookupCodeSystemByURL(url) {
@@ -27,13 +31,13 @@ class CodeSystemExporter {
     fhirCS.id = common.fhirID(codeSystem.identifier);
     fhirCS.text.div = getTextDiv(codeSystem, this._config.projectShorthand);
     fhirCS.url = codeSystem.url;
+    fhirCS.identifier.system = this._config.projectURL;
     fhirCS.identifier.value = codeSystem.identifier.fqn;
     fhirCS.name = codeSystem.identifier.name;
     fhirCS.title = `${this._config.projectShorthand} ${codeSystem.identifier.name} CodeSystem`;
     fhirCS.date = this._config.publishDate || common.todayString();
     fhirCS.publisher = this._config.publisher;
     fhirCS.contact = this._config.contact;
-    fhirCS.identifier.system = this._config.projectURL;
     if (codeSystem.description) {
       fhirCS.description = codeSystem.description.trim();
     } else {
@@ -53,6 +57,34 @@ class CodeSystemExporter {
     }
 
     this._codeSystemsMap.set(codeSystem.url, fhirCS);
+  }
+
+  addTypeToBasicResourceTypeCodeSystem(typeCode, typeDescription) {
+    if (this._basicResourceTypeCodeSystem == null) {
+      const fhirCS = this._fhir.codeSystemTemplate;
+      fhirCS.id = `${this._config.projectShorthand}-basic-resource-type`;
+      fhirCS.text.div = `<div xmlns="http://www.w3.org/1999/xhtml">
+<p><b>${common.escapeHTML(this._config.projectShorthand)} Basic Resource Type CodeSystem</b></p>
+<p>Codes representing profiles on the Basic resource.</p>
+</div>`;
+      fhirCS.url = `${this._config.fhirURL}/CodeSystem/${this._config.projectShorthand}-basic-resource-type`;
+      fhirCS.identifier.system = this._config.projectURL;
+      fhirCS.identifier.value = `${this._config.projectShorthand}-basic-resource-type`;
+      fhirCS.name = 'BasicResourceType';
+      fhirCS.title = `${this._config.projectShorthand} Basic Resource Type CodeSystem`;
+      fhirCS.date = this._config.publishDate || common.todayString();
+      fhirCS.publisher = this._config.publisher;
+      fhirCS.contact = this._config.contact;
+      fhirCS.description = 'Codes representing profiles on the Basic resource.';
+      fhirCS.count = 0;
+      this._basicResourceTypeCodeSystem = fhirCS;
+    }
+    const fhirCode = { code: typeCode };
+    if (typeDescription != null) {
+      fhirCode.display = typeDescription.trim();
+    }
+    this._basicResourceTypeCodeSystem.concept.push(fhirCode);
+    this._basicResourceTypeCodeSystem.count = this._basicResourceTypeCodeSystem.concept.length;
   }
 }
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -192,6 +192,13 @@ function typeToString(type) {
   return `${type}`;
 }
 
+function trim(text) {
+  if (typeof text === 'string') {
+    return text.trim();
+  }
+  return text;
+}
+
 class ProcessTracker {
   constructor() {
     this._map = {};
@@ -228,4 +235,4 @@ class FHIRExportError extends Error {
   }
 }
 
-module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, valueName, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, lowerFirst, todayString, isCustomProfile, typeToString, ProcessTracker};
+module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, valueName, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, lowerFirst, todayString, isCustomProfile, typeToString, trim, ProcessTracker};

--- a/lib/export.js
+++ b/lib/export.js
@@ -509,11 +509,11 @@ class FHIRExporter {
   getDescription(identifier, defaultText) {
     const def = this._specs.dataElements.findByIdentifier(identifier);
     let description;
-    if (def && def.description) {
-      description = def.description.trim();
+    if (def) {
+      description = common.trim(def.description);
     }
-    if (defaultText && (typeof description === 'undefined' || description == null || description == '')) {
-      description = defaultText.trim();
+    if (description == null || description == '') {
+      description = common.trim(defaultText);
     }
     return description;
   }
@@ -1440,7 +1440,7 @@ class FHIRExporter {
         || (val.identifier && val.getPossibleIdentifiers().some(vid => vid.equals(id)))
         || (val.options && val.aggregateOptions.some(o => id.equals(o.identifier) || id.equals(o.effectiveIdentifier)));
       if (isElementValue) {
-        const desc = `${common.capitalize(common.valueName(val))} representing ${common.lowerFirst(def.description.trim())}`;
+        const desc = `${common.capitalize(common.valueName(val))} representing ${common.lowerFirst(common.trim(def.description))}`;
         snapshotEl.definition = differentialEl.definition = desc;
       }
     }
@@ -1489,7 +1489,7 @@ class FHIRExporter {
       // It's an external value set, so just reference it
       short = `codes from ${vsURL}`;
     }
-    return short;
+    return common.trim(short);
   }
 
   knownMappingIssue(lhs, rhs, sourcePath, value, types) {
@@ -2430,7 +2430,7 @@ class FHIRExporter {
           fixedX.code = code.code;
           differentialEl[fixedPropName] = common.cloneJSON(fixedX);
           if (code.display) {
-            snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
+            snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = common.trim(code.display);
           }
         }
         return;
@@ -2450,7 +2450,7 @@ class FHIRExporter {
       codeEl.fixedCode = codeDf.fixedCode = code.code;
 
       if (code.display) {
-        snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
+        snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = common.trim(code.display);
       }
 
       if (REPORT_PROFILE_INDICATORS) {
@@ -2484,7 +2484,7 @@ class FHIRExporter {
           fixedX.coding[0].code = code.code;
           differentialEl[fixedPropName] = common.cloneJSON(fixedX);
           if (code.display) {
-            snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = code.display;
+            snapshotEl.short = snapshotEl.definition = differentialEl.short = differentialEl.definition = common.trim(code.display);
           }
         }
         return;
@@ -2505,7 +2505,7 @@ class FHIRExporter {
           codeEl.fixedCode = codeDf.fixedCode = code.code;
           if (code.display) {
             const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
-            slice.short = slice.definition = sliceDf.short = sliceDf.definition = code.display;
+            slice.short = slice.definition = sliceDf.short = sliceDf.definition = common.trim(code.display);
           }
           return;
         } else if (systemEl.fixedUri && systemEl.fixedUri == code.system && typeof codeEl.fixedCode === 'undefined') {
@@ -2513,7 +2513,7 @@ class FHIRExporter {
           codeEl.fixedCode = codeDf.fixedCode = code.code;
           if (code.display) {
             const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
-            slice.short = slice.definition = sliceDf.short = sliceDf.definition = code.display;
+            slice.short = slice.definition = sliceDf.short = sliceDf.definition = common.trim(code.display);
           }
           return;
         } else if (systemEl.fixedUri && systemEl.fixedUri == code.system && typeof codeEl.fixedCode && codeEl.fixedCode == code.code) {
@@ -2536,8 +2536,8 @@ class FHIRExporter {
         id: `${baseCoding.id}:${sliceName}`,
         path: baseCoding.path,
         sliceName: sliceName,
-        short: code.display,
-        definition: code.display ? code.display : baseCoding.definition,
+        short: common.trim(code.display),
+        definition: code.display ? common.trim(code.display) : common.trim(baseCoding.definition),
         min: 1, // We're fixing the coding, so make it 1..1
         max: '1', // We're fixing the coding, so make it 1..1
         type: common.cloneJSON(baseCoding.type),

--- a/lib/export.js
+++ b/lib/export.js
@@ -354,20 +354,7 @@ class FHIRExporter {
       for (let i=0; i < profile.snapshot.element.length; i++) {
         const baseEl = profile.snapshot.element[i];
         if (baseEl.slicing != null) {
-          // it's a base slice, so look through its children for slices with min > 1 and add to totalMin
-          let totalMin = 0;
-          const isChild = function(idx) {
-            return profile.snapshot.element[idx].id.indexOf(`${baseEl.id}:`) === 0
-              || profile.snapshot.element[idx].id.indexOf(`${baseEl.id}.`) === 0;
-          };
-          const baseIdLastDot = baseEl.id.lastIndexOf('.');
-          for (let j=i+1; j < profile.snapshot.element.length && isChild(j); j++) {
-            const childEl = profile.snapshot.element[j];
-            // Check if it's a direct child slice
-            if (childEl.sliceName && childEl.id.lastIndexOf('.') === baseIdLastDot) {
-              totalMin += childEl.min;
-            }
-          }
+          const totalMin = this.getBaseSliceMinCard(profile, baseEl);
           if (totalMin > baseEl.min) {
             if (baseEl.max !== '*' && totalMin > parseInt(baseEl.max)) {
               logger.error('Cumulative slice min cardinalities (%s) exceed the max cardinality (%s) for the containing array at %s.', totalMin, baseEl.max, baseEl.id);
@@ -433,6 +420,33 @@ class FHIRExporter {
       logger.debug('Done mapping element');
       logger = lastLogger;
     }
+  }
+
+  getBaseSliceMinCard(profile, ssEl) {
+    if (ssEl.slicing == null) {
+      return ssEl.min;
+    }
+    // it's a base slice, so look through its children for slices with min > 1 and add to totalMin
+    let totalMin = 0;
+    const isChild = function(idx) {
+      return profile.snapshot.element[idx].id.indexOf(`${ssEl.id}:`) === 0
+        || profile.snapshot.element[idx].id.indexOf(`${ssEl.id}.`) === 0;
+    };
+    const baseIdLastDot = ssEl.id.lastIndexOf('.');
+    const sliceLastColon = ssEl.id.length; // colon will be after the baseId
+    const ssElIdx = profile.snapshot.element.findIndex(e => e === ssEl);
+    for (let i=ssElIdx+1; i < profile.snapshot.element.length && isChild(i); i++) {
+      const childEl = profile.snapshot.element[i];
+      // Check if it's a direct child slice
+      if (childEl.sliceName && childEl.id.lastIndexOf('.') === baseIdLastDot && childEl.id.lastIndexOf(':') === sliceLastColon) {
+        if (childEl.slicing != null) {
+          totalMin += this.getBaseSliceMinCard(profile, childEl);
+        } else {
+          totalMin += childEl.min;
+        }
+      }
+    }
+    return totalMin;
   }
 
   // NOTE: This function only called if TRACK_UNMAPPED_PATHS is set to true
@@ -1840,6 +1854,9 @@ class FHIRExporter {
     this.applyOwnCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnIncludesCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnBooleanConstraints(sourceValue, profile, snapshotEl, differentialEl);
+    if (isExtension) {
+      this.applyOwnIncludesTypeConstraintsOnExtension(sourceValue, profile, snapshotEl, differentialEl);
+    }
 
     // Handle child constraints if necessary -- this will require "unrolling" the element
     if (sourceValue.constraintsFilter.child.hasConstraints) {
@@ -1880,6 +1897,9 @@ class FHIRExporter {
           this.applyOwnCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnIncludesCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnBooleanConstraints(childSourceValue, profile, element, diffElement);
+          if (childSourceValue.constraintsFilter.includesType.hasConstraints) {
+            logger.warn('Nested include types are currently not supported when applied to extensions');
+          }
           // TODO: Do we need to do anything special for IncludesTypeConstraints?
           if (dfIsNew && Object.keys(diffElement).length > 2) {
             profile.differential.element.push(diffElement);
@@ -1971,7 +1991,9 @@ class FHIRExporter {
           // It's trying to map a different element than the one that was previously mapped.  Conflict!
           logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
         } else {
-          // We successfully mapped the type, so we need to apply the differential and constraints
+          // We successfully mapped the type, so we need to apply the definition and update the differential
+          snapshotEl.short = differentialEl.short = sourceValue.effectiveIdentifier.name;
+          snapshotEl.definition = differentialEl.definition = this.getDescription(sourceValue.effectiveIdentifier, sourceValue.effectiveIdentifier.name);
           if (typeof mappedProfile !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
             differentialEl.type = snapshotEl.type;
           }
@@ -1986,6 +2008,42 @@ class FHIRExporter {
       }
 
       // TODO: Do we need to consider mapping based on values (like in processValueToFieldType?)
+    }
+  }
+
+  // In the profiles, includes type constraints are applied as slicing directives to the mapping statements, but since
+  // extensions don't have mapping statements (by definition), we can't really take this approach for extensions.
+  // Instead, we must apply the type constraints separately.
+  applyOwnIncludesTypeConstraintsOnExtension(sourceValue, profile, snapshotEl, differentialEl) {
+
+    // NOTE: Very similar (but slightly different) code exists in #processValueToFieldType.  At some point these could
+    // potentially be refactored, but to do it in a non-hacky way will require some work.  Until then, if something
+    // changes in this function, check to see if it should also change in #processValueToFieldType.
+
+    const ictConstraints = sourceValue.constraintsFilter.own.includesType.constraints;
+    if (ictConstraints.length === 0) {
+      return;
+    }
+
+    // To apply IncludesType constraints to extensions, we need to slice them.  So apply the slicing and discriminator
+    for (const ictConstraint of ictConstraints) {
+      const fieldTarget = new FieldTarget(snapshotEl.id.substr(snapshotEl.id.indexOf('.')+1));
+      fieldTarget.addSliceOnCommand('valueReference.reference.resolve()');
+      fieldTarget.addSliceOnTypeCommand('profile');
+      fieldTarget.addSliceStrategyCommand('includes');
+      const slice = this.createSliceFromBase(profile, snapshotEl, ictConstraint.isA.name, fieldTarget, sourceValue, ictConstraint.card);
+      const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
+      slice.short = sliceDf.short = ictConstraint.isA.name;
+      slice.definition = sliceDf.definition = this.getDescription(ictConstraint.isA, ictConstraint.isA.name);
+      let [valueSnapshotEl, valueDifferentialEl] = this.findConstrainableElement(sourceValue, profile, slice);
+
+      const type = this.findMatchingType(new mdls.IdentifiableValue(ictConstraint.isA), valueSnapshotEl.type);
+      if (type != null) {
+        if (valueDifferentialEl == null) {
+          valueDifferentialEl = common.getDifferentialElementById(profile, valueSnapshotEl.id, true);
+        }
+        valueDifferentialEl.type = valueSnapshotEl.type;
+      }
     }
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -2992,7 +2992,8 @@ class FHIRExporter {
       if (sd.snapshot.element.some(e => e.path == `${sd.type}.${pathPart}`)) {
         this.unrollElement(type, profile, parentEl);
         // Now that we unrolled, we want to run this cycle of the loop again with the new elements
-        elements = elements.filter(e => e.id === parentEl.id || e.id.startsWith(`${parentEl.id}.`));
+        // Since we added/replaced new elements, we'll need to filter on the whole profile again
+        elements = profile.snapshot.element.filter(e => e.id === parentEl.id || e.id.startsWith(`${parentEl.id}.`));
         // Trim back the cumulative path and decrement i so we run this cycle of the loop through again
         cumulativePath = cumulativePath.substring(0, cumulativePath.lastIndexOf('.'));
         i--;

--- a/lib/export.js
+++ b/lib/export.js
@@ -1627,19 +1627,46 @@ class FHIRExporter {
         }
       }
 
+      let sourceElValue = sourceEl.value;
+      // If it's a choice, but it has a type constraint, we need to re-model it appropriately
+      if (sourceElValue instanceof mdls.ChoiceValue) {
+        const typeCst = sourceValue.constraintsFilter.type.constraints.filter(c => c.onValue);
+        typeCst.push(...sourceElValue.constraintsFilter.type.own.constraints);
+        if (typeCst.length === 1) {
+          // Find the IdentifierValue in the choices by first trying to get an exact match
+          let matchingOption = sourceElValue.aggregateOptions.find(o => typeCst[0].isA.equals(o.effectiveIdentifier));
+          // If not found, look based on base types as well
+          if (matchingOption == null) {
+            matchingOption = sourceElValue.aggregateOptions.find(o => o.getPossibleIdentifiers().some(id => id.equals(typeCst[0].isA)));
+          }
+
+          if (matchingOption != null) {
+            const origConstraints = sourceElValue.constraints.length > 0 ? sourceElValue.constraints.map(c => c.clone()) : [];
+            sourceElValue = matchingOption.clone();
+            origConstraints.forEach(c => {
+              if (!c.equals(typeCst)) {
+                sourceElValue.addConstraint(c);
+              }
+            });
+          }
+        } else if (typeCst.length > 1) {
+          // This shouldn't happen
+        }
+      }
+
       // It's potentially appropriate to map the value
-      if (sourceEl.value instanceof mdls.IdentifiableValue) {
-        const mergedValue = this.mergeConstraintsToChild(sourceValue.constraints, sourceEl.value, true);
+      if (sourceElValue instanceof mdls.IdentifiableValue) {
+        const mergedValue = this.mergeConstraintsToChild(sourceValue.constraints, sourceElValue, true);
         const newPath = [...clonedPath, mergedValue.effectiveIdentifier];
         const valMatchedPaths = this.processValueToFieldType(map, newPath, mergedValue, profile, snapshotEl, differentialEl);
         if (typeof valMatchedPaths !== 'undefined') {
           matchedPaths.push(...valMatchedPaths);
         }
-      } else if (sourceEl.value instanceof mdls.ChoiceValue) {
-        for (const opt of sourceEl.value.aggregateOptions) {
+      } else if (sourceElValue instanceof mdls.ChoiceValue) {
+        for (const opt of sourceElValue.aggregateOptions) {
           if (opt instanceof mdls.IdentifiableValue) {
             // First merge the choicevalue onto the option value (TODO: Will this work right w/ aggregate options?)
-            let mergedValue = this.mergeConstraintsToChild(sourceEl.value.constraints, opt);
+            let mergedValue = this.mergeConstraintsToChild(sourceElValue.constraints, opt);
             // Then merge the sourceValue onto the merged option value
             mergedValue = this.mergeConstraintsToChild(sourceValue.constraints, mergedValue);
             const newPath = [...clonedPath, mergedValue.effectiveIdentifier];
@@ -2995,7 +3022,7 @@ class FHIRExporter {
   }
 
   mergeConstraintsToChild(parentConstraints, childValue, childIsElementValue=false) {
-    const constraints = [];
+    let constraints = [];
     for (const cst of parentConstraints) {
       if (childIsElementValue && cst.path.length == 0 && cst.onValue) {
         const transferredCst = cst.clone();
@@ -3007,6 +3034,8 @@ class FHIRExporter {
         constraints.push(transferredCst);
       }
     }
+    // Remove any type constraints that are no-ops
+    constraints = constraints.filter(c => !(c instanceof mdls.TypeConstraint && c.isA.equals(childValue.effectiveIdentifier)));
     if (constraints.length == 0) {
       return childValue;
     }

--- a/lib/export.js
+++ b/lib/export.js
@@ -1529,113 +1529,30 @@ class FHIRExporter {
     const matchedPaths = [];
 
     // Check if the source field has a mapping to a FHIR profile.  If so, and it matches target, apply the profile to the target
-    const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
-    if (typeof sourceMap !== 'undefined') {
-      let matchedType;
-      const originalTargetTypes = common.cloneJSON(targetTypes);
-      const sourceProfile = this.lookupProfile(sourceMap.identifier, true, true);
-      const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
-      const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
-      const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL));
-      for (let i=0; i < targetTypes.length; i++) {
-        const t = targetTypes[i];
-        const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
-        const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
-        // @ts-ignore
-        if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
-          matchedType = t;
-          // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
-          // or if the original type is a supertype (i.e., a profile of one of its basedOn types)
-          if (this.optionIsSelected(t)) {
-            // This type has already been mapped to once.  Determine if we should add another type to represent
-            // additional applicable profiles.  This is done by checking if its part of an includes type slice, and/or
-            // by checking if the new profile fits in the old type / profile.
-            if (common.isCustomProfile(sourceProfile)) {
-              // @ts-ignore
-              if (typeof originalProfile === 'undefined' || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
-                if (sourceValue._derivedFromIncludesTypeConstraint) {
-                  // This is the result of an includes type slicing, so we want the new profile to replace the existing one
-                  // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
-                  t.profile = sourceProfile.url;
-                } else {
-                  // We should represent both the existing and the new profile, so create a new type for the additional
-                  // profile and splice it into the types
-                  const t2 = common.cloneJSON(t);
-                  t2.profile = sourceProfile.url;
-                  targetTypes.splice(i+1, 0, t2);
-                  matchedType = t2;
-                }
-              }
-              // else it wasn't a valid sub-type of the original type, and this will cause an error further down
-            } else {
-              // The existing type narrows it to a profile, but since this new type represents a no-profile type,
-              // remove the profile from the existing type
-              delete(t.profile);
-            }
-            break;
-          } else {
-            // This is the first time mapping to this type, so overwrite profile if applicable, and mark as selected
-            if (common.isCustomProfile(sourceProfile)) {
-              if (typeof t.profile !== 'undefined') {
-                // keep track of the original profile so we can check on other options in the future
-                t._originalProfile = t.profile;
-              }
-              t.profile = sourceProfile.url;
-            }
-            this.markSelectedOptionsInChoice(targetTypes, [t]);
-          }
-          break;
-        // @ts-ignore
-        } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(originalTargetProfile) || basedOnTargetProfiles.includes(originalTargetProfile))) {
-          matchedType = t;
-          // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
-          // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
-          if (this.optionIsSelected(t)) {
-            // This type has already been mapped to once, and we've already determined that the new profile is a match.
-            if (sourceValue._derivedFromIncludesTypeConstraint) {
-              // This is the result of an includes type slicing, so we want the new profile to replace the existing one
-              // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
-              t.targetProfile = sourceProfile.url;
-            } else {
-              // We should represent both the existing and the new profile, so create a new type for the additional
-              // target profile and splice it into the types
-              const t2 = common.cloneJSON(t);
-              t2.targetProfile = sourceProfile.url;
-              targetTypes.splice(i+1, 0, t2);
-              matchedType = t2;
-            }
-          } else {
-            // This is the first time mapping to this type, so overwrite targetProfile and mark as selected
-            t._originalTargetProfile = t.targetProfile;
-            t.targetProfile = sourceProfile.url;
-            this.markSelectedOptionsInChoice(targetTypes, [t]);
-          }
-          break;
-        }
-      }
-
-      if (typeof matchedType !== 'undefined') {
-        // We got a match!
-        // Check to see if this is trying to map a different element than the one that was previously mapped.
-        const mappedProfile = typeof matchedType.profile !== 'undefined' ? matchedType.profile : matchedType.targetProfile;
-        if (typeof mappedProfile !== 'undefined' && mappedProfile != sourceProfile.url) {
-          // It's trying to map a different element than the one that was previously mapped.  Conflict!
-          logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
-        } else {
-          // We successfully mapped the type, so we need to apply the differential and constraints
-          if (typeof mappedProfile !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
-            differentialEl.type = snapshotEl.type;
-          }
-          this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false, sourcePath);
-          matchedPaths.push(clonedPath);
-        }
+    const originalTargetTypes = common.cloneJSON(targetTypes);
+    const matchedType = this.findMatchingType(sourceValue, targetTypes);
+    if (typeof matchedType !== 'undefined') {
+      // We got a match!
+      const sourceProfile = this.lookupProfile(sourceIdentifier, true, false);
+      // Check to see if this is trying to map a different element than the one that was previously mapped.
+      const mappedProfile = typeof matchedType.profile !== 'undefined' ? matchedType.profile : matchedType.targetProfile;
+      if (typeof mappedProfile !== 'undefined' && mappedProfile != sourceProfile.url) {
+        // It's trying to map a different element than the one that was previously mapped.  Conflict!
+        logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
       } else {
-        const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
-        if (allowedConvertedTypes.length > 0) {
-          this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
-          this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
-          matchedPaths.push(clonedPath);
+        // We successfully mapped the type, so we need to apply the differential and constraints
+        if (typeof mappedProfile !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
+          differentialEl.type = snapshotEl.type;
         }
+        this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false, sourcePath);
+        matchedPaths.push(clonedPath);
+      }
+    } else {
+      const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
+      if (allowedConvertedTypes.length > 0) {
+        this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
+        this.applyConstraintsForConversion(sourceValue, profile, snapshotEl, differentialEl, sourcePath);
+        matchedPaths.push(clonedPath);
       }
     }
 
@@ -1726,6 +1643,97 @@ class FHIRExporter {
     }
 
     return matchedPaths.length > 0 ? matchedPaths : undefined;
+  }
+
+  findMatchingType(sourceValue, targetTypes) {
+    const sourceIdentifier = sourceValue.effectiveIdentifier;
+    const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
+    if (sourceMap == null) {
+      return;
+    }
+
+    let matchedType;
+    const sourceProfile = this.lookupProfile(sourceIdentifier, true, true);
+    const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
+    const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
+    const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL));
+    for (let i=0; i < targetTypes.length; i++) {
+      const t = targetTypes[i];
+      const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
+      const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
+      // @ts-ignore
+      if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
+        matchedType = t;
+        // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
+        // or if the original type is a supertype (i.e., a profile of one of its basedOn types)
+        if (this.optionIsSelected(t)) {
+          // This type has already been mapped to once.  Determine if we should add another type to represent
+          // additional applicable profiles.  This is done by checking if its part of an includes type slice, and/or
+          // by checking if the new profile fits in the old type / profile.
+          if (common.isCustomProfile(sourceProfile)) {
+            // @ts-ignore
+            if (typeof originalProfile === 'undefined' || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
+              if (sourceValue._derivedFromIncludesTypeConstraint) {
+                // This is the result of an includes type slicing, so we want the new profile to replace the existing one
+                // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
+                t.profile = sourceProfile.url;
+              } else {
+                // We should represent both the existing and the new profile, so create a new type for the additional
+                // profile and splice it into the types
+                const t2 = common.cloneJSON(t);
+                t2.profile = sourceProfile.url;
+                targetTypes.splice(i+1, 0, t2);
+                matchedType = t2;
+              }
+            }
+            // else it wasn't a valid sub-type of the original type, and this will cause an error further down
+          } else {
+            // The existing type narrows it to a profile, but since this new type represents a no-profile type,
+            // remove the profile from the existing type
+            delete(t.profile);
+          }
+          break;
+        } else {
+          // This is the first time mapping to this type, so overwrite profile if applicable, and mark as selected
+          if (common.isCustomProfile(sourceProfile)) {
+            if (typeof t.profile !== 'undefined') {
+              // keep track of the original profile so we can check on other options in the future
+              t._originalProfile = t.profile;
+            }
+            t.profile = sourceProfile.url;
+          }
+          this.markSelectedOptionsInChoice(targetTypes, [t]);
+        }
+        break;
+      // @ts-ignore
+      } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(originalTargetProfile) || basedOnTargetProfiles.includes(originalTargetProfile))) {
+        matchedType = t;
+        // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
+        // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
+        if (this.optionIsSelected(t)) {
+          // This type has already been mapped to once, and we've already determined that the new profile is a match.
+          if (sourceValue._derivedFromIncludesTypeConstraint) {
+            // This is the result of an includes type slicing, so we want the new profile to replace the existing one
+            // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
+            t.targetProfile = sourceProfile.url;
+          } else {
+            // We should represent both the existing and the new profile, so create a new type for the additional
+            // target profile and splice it into the types
+            const t2 = common.cloneJSON(t);
+            t2.targetProfile = sourceProfile.url;
+            targetTypes.splice(i+1, 0, t2);
+            matchedType = t2;
+          }
+        } else {
+          // This is the first time mapping to this type, so overwrite targetProfile and mark as selected
+          t._originalTargetProfile = t.targetProfile;
+          t.targetProfile = sourceProfile.url;
+          this.markSelectedOptionsInChoice(targetTypes, [t]);
+        }
+        break;
+      }
+    }
+    return matchedType;
   }
 
   // NOTE: This function "borrowed" from shr-expand
@@ -1924,111 +1932,28 @@ class FHIRExporter {
       }
 
       // Check if the source field has a mapping to a FHIR profile.  If so, and it matches target, apply the profile to the target
-      const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
-      if (typeof sourceMap !== 'undefined') {
-        let matchedType;
-        const originalTargetTypes = common.cloneJSON(targetTypes);
-        const sourceProfile = this.lookupProfile(sourceMap.identifier, true, true);
-        const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
-        const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
-        const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL));
-        for (let i=0; i < targetTypes.length; i++) {
-          const t = targetTypes[i];
-          const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
-          const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
-          // @ts-ignore
-          if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
-            matchedType = t;
-            // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
-            // or if the original type is a supertype (i.e., a profile of one of its basedOn types)
-            if (this.optionIsSelected(t)) {
-              // This type has already been mapped to once.  Determine if we should add another type to represent
-              // additional applicable profiles.  This is done by checking if its part of an includes type slice, and/or
-              // by checking if the new profile fits in the old type / profile.
-              if (common.isCustomProfile(sourceProfile)) {
-                // @ts-ignore
-                if (typeof originalProfile === 'undefined' || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
-                  if (sourceValue._derivedFromIncludesTypeConstraint) {
-                    // This is the result of an includes type slicing, so we want the new profile to replace the existing one
-                    // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
-                    t.profile = sourceProfile.url;
-                  } else {
-                    // We should represent both the existing and the new profile, so create a new type for the additional
-                    // profile and splice it into the types
-                    const t2 = common.cloneJSON(t);
-                    t2.profile = sourceProfile.url;
-                    targetTypes.splice(i+1, 0, t2);
-                    matchedType = t2;
-                  }
-                }
-                // else it wasn't a valid sub-type of the original type, and this will cause an error further down
-              } else {
-                // The existing type narrows it to a profile, but since this new type represents a no-profile type,
-                // remove the profile from the existing type
-                delete(t.profile);
-              }
-              break;
-            } else {
-              // This is the first time mapping to this type, so overwrite profile if applicable, and mark as selected
-              if (common.isCustomProfile(sourceProfile)) {
-                if (typeof t.profile !== 'undefined') {
-                  // keep track of the original profile so we can check on other options in the future
-                  t._originalProfile = t.profile;
-                }
-                t.profile = sourceProfile.url;
-              }
-              this.markSelectedOptionsInChoice(targetTypes, [t]);
-            }
-            break;
-          // @ts-ignore
-          } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(originalTargetProfile) || basedOnTargetProfiles.includes(originalTargetProfile))) {
-            matchedType = t;
-            // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
-            // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
-            if (this.optionIsSelected(t)) {
-              // This type has already been mapped to once, and we've already determined that the new profile is a match.
-              if (sourceValue._derivedFromIncludesTypeConstraint) {
-                // This is the result of an includes type slicing, so we want the new profile to replace the existing one
-                // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
-                t.targetProfile = sourceProfile.url;
-              } else {
-                // We should represent both the existing and the new profile, so create a new type for the additional
-                // target profile and splice it into the types
-                const t2 = common.cloneJSON(t);
-                t2.targetProfile = sourceProfile.url;
-                targetTypes.splice(i+1, 0, t2);
-                matchedType = t2;
-              }
-            } else {
-              // This is the first time mapping to this type, so overwrite targetProfile and mark as selected
-              t._originalTargetProfile = t.targetProfile;
-              t.targetProfile = sourceProfile.url;
-              this.markSelectedOptionsInChoice(targetTypes, [t]);
-            }
-            break;
-          }
-        }
-
-        if (typeof matchedType !== 'undefined') {
-          // We got a match!
-          // Check to see if this is trying to map a different element than the one that was previously mapped.
-          const mappedProfile = typeof matchedType.profile !== 'undefined' ? matchedType.profile : matchedType.targetProfile;
-          if (typeof mappedProfile !== 'undefined' && mappedProfile != sourceProfile.url) {
-            // It's trying to map a different element than the one that was previously mapped.  Conflict!
-            logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
-          } else {
-            // We successfully mapped the type, so we need to apply the differential and constraints
-            if (typeof mappedProfile !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
-              differentialEl.type = snapshotEl.type;
-            }
-            return;
-          }
+      const originalTargetTypes = common.cloneJSON(targetTypes);
+      const matchedType = this.findMatchingType(sourceValue, targetTypes);
+      if (typeof matchedType !== 'undefined') {
+        // We got a match!
+        const sourceProfile = this.lookupProfile(sourceIdentifier, true, false);
+        // Check to see if this is trying to map a different element than the one that was previously mapped.
+        const mappedProfile = typeof matchedType.profile !== 'undefined' ? matchedType.profile : matchedType.targetProfile;
+        if (typeof mappedProfile !== 'undefined' && mappedProfile != sourceProfile.url) {
+          // It's trying to map a different element than the one that was previously mapped.  Conflict!
+          logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
         } else {
-          const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
-          if (allowedConvertedTypes.length > 0) {
-            this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
-            return;
+          // We successfully mapped the type, so we need to apply the differential and constraints
+          if (typeof mappedProfile !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
+            differentialEl.type = snapshotEl.type;
           }
+          return;
+        }
+      } else {
+        const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
+        if (allowedConvertedTypes.length > 0) {
+          this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
+          return;
         }
       }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -194,6 +194,9 @@ class FHIRExporter {
       // Modify the snapshot elements as appropriate
       for (const ssEl of profile.snapshot.element) {
         ssEl.id = ssEl.id.replace(new RegExp(`^${profile.type}(:[^\.]+)?`), `${profile.type}:${profileID}`);
+        // Don't carry over the examples since they might be irrelevant to the specific profile use case.
+        // (Also, some of the examples in STU 3.0.1 cause invariant violations!)
+        delete(ssEl.example);
       }
       const rootSS = profile.snapshot.element[0];
       rootSS.short = profile.title;
@@ -906,7 +909,6 @@ class FHIRExporter {
           snapshotEl.defaultValue = ss.defaultValue;
           snapshotEl.fixed = ss.fixed;
           snapshotEl.pattern = ss.pattern;
-          snapshotEl.example = ss.example;
           snapshotEl.minValue = ss.minValue;
           snapshotEl.maxValue = ss.maxValue;
           snapshotEl.maxLength = ss.maxLength;

--- a/lib/export.js
+++ b/lib/export.js
@@ -1496,6 +1496,7 @@ class FHIRExporter {
     const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
     if (typeof sourceMap !== 'undefined') {
       let matchedType;
+      const originalTargetTypes = common.cloneJSON(targetTypes);
       const sourceProfile = this.lookupProfile(sourceMap.identifier, true, true);
       const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
       const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
@@ -1586,7 +1587,7 @@ class FHIRExporter {
           logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
         } else {
           // We successfully mapped the type, so we need to apply the differential and constraints
-          if (typeof mappedProfile !== 'undefined') {
+          if (typeof mappedProfile !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
             differentialEl.type = snapshotEl.type;
           }
           this.applyConstraints(sourceValue, profile, snapshotEl, differentialEl, false, sourcePath);
@@ -3543,6 +3544,18 @@ function isTargetBasedOn(target, baseTarget) {
   }
 
   return false;
+}
+
+function typesHaveSameCodesProfilesAndTargetProfiles(t1, t2) {
+  if (t1.length !== t2.length) {
+    return false;
+  }
+  for (let i=0; i < t1.length; i++) {
+    if (t1[i].code !== t2[i].code || t1[i].profile !== t2[i].profile || t1[i].targetProfile !== t2[i].targetProfile) {
+      return false;
+    }
+  }
+  return true;
 }
 
 // NOTE: This class only used if REPORT_PROFILE_INDICATORS is set to true

--- a/lib/export.js
+++ b/lib/export.js
@@ -1009,15 +1009,43 @@ class FHIRExporter {
     }
 
     // Mark the choice as selected, so we can filter down the choice to selected types only later
-    for (const type of snapshotEl.type) {
-      if (type.code === sdToAdd.type) {
-        this.markSelectedOptionsInChoice(snapshotEl.type, [type]);
+    const allowableTargetTypes = this.getTypeHierarchy(sdToAdd.id);
+    const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
+    const basedOnTargetProfiles = this.getRecursiveBasedOns(identifier).map(b => common.fhirURL(b, this._config.fhirURL));
+    let matchedType;
+    // First try to find the most direct matched type
+    for (const t of snapshotEl.type) {
+      if (t.code === sdToAdd.type) {
+        matchedType = t;
+        this.markSelectedOptionsInChoice(snapshotEl.type, [t]);
+        break;
       }
     }
+    // If we didn't find a direct one, do a more thorough search
+    if (matchedType == null) {
+      for (const t of snapshotEl.type) {
+        const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
+        const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
+        if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
+          matchedType = t;
+          break;
+        } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(originalTargetProfile) || basedOnTargetProfiles.includes(originalTargetProfile))) {
+          matchedType = t;
+          break;
+        }
+      }
+    }
+    // If we didn't find the matched type, it is an error.
+    if (matchedType == null) {
+      logger.error('Cannot make choice element explicit at %s. Could not find compatible type match for: %s. ERROR_CODE:?????', snapshotEl.id, sdToAdd.type);
+      return [];
+    }
+
+    this.markSelectedOptionsInChoice(snapshotEl.type, [matchedType]);
 
     // Check to be sure we don't already have one
     const sliceName = sdToAdd.id;
-    const baseId = `${snapshotEl.id.replace(/\[x\]$/, common.capitalize(sdToAdd.type))}:${sliceName}`;
+    const baseId = `${snapshotEl.id.replace(/\[x\]$/, common.capitalize(matchedType.code))}:${sliceName}`;
     const existing = profile.snapshot.element.find(e => e.id == baseId);
     if (existing) {
       const dfExisting = common.getDifferentialElementById(profile, existing.id, true);
@@ -1029,16 +1057,16 @@ class FHIRExporter {
     common.addSlicingToBaseElement(profile, snapshotEl, differentialEl, 'type', '$this');
 
     // Build the new choice element
-    const newType = { code: sdToAdd.type };
-    if (sdToAdd.type === 'Reference') {
+    const newType = { code: matchedType.code };
+    if (matchedType.code === 'Reference') {
       newType.targetProfile = sdToAdd.url;
     }
-    if (sdToAdd.type === 'Extension' || common.isCustomProfile(sdToAdd)) {
+    if (matchedType.code === 'Extension' || common.isCustomProfile(sdToAdd)) {
       newType.profile = sdToAdd.url;
     }
     const ssChoiceEl = {
       id: baseId,
-      path: snapshotEl.path.replace(/\[x\]$/, common.capitalize(sdToAdd.type)),
+      path: snapshotEl.path.replace(/\[x\]$/, common.capitalize(matchedType.code)),
       sliceName,
       short: snapshotEl.short,
       definition: snapshotEl.definition,

--- a/lib/export.js
+++ b/lib/export.js
@@ -1492,6 +1492,11 @@ class FHIRExporter {
   }
 
   processValueToFieldType(map, sourcePath, sourceValue, profile, snapshotEl, differentialEl) {
+
+    // NOTE: Very similar (but slightly different) code exists in #applyOwnTypeConstraintsOnExtension.  At some point
+    // these could potentially be refactored, but to do it in a non-hacky way will require some work.  Until then, if
+    // something changes in this function, check to see if it should also change in #applyOwnTypeConstraintsOnExtension.
+
     const clonedPath = sourcePath.map(p => p.clone());
     const sourceIdentifier = sourceValue.effectiveIdentifier;
     const targetTypes = snapshotEl.type;
@@ -1834,10 +1839,12 @@ class FHIRExporter {
           if (dfIsNew) {
             diffElement = { id: element.id, path: element.path };
           }
+          this.applyOwnTypeConstraintsOnExtension(childSourceValue, profile, element, diffElement);
           this.applyOwnValueSetConstraints(childSourceValue, profile, element, diffElement, sourcePath);
           this.applyOwnCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnIncludesCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnBooleanConstraints(childSourceValue, profile, element, diffElement);
+          // TODO: Do we need to do anything special for IncludesTypeConstraints?
           if (dfIsNew && Object.keys(diffElement).length > 2) {
             profile.differential.element.push(diffElement);
           }
@@ -1877,6 +1884,155 @@ class FHIRExporter {
           }
         }
       }
+    }
+  }
+
+  // In the profiles, type constraints are applied as we traverse the path, but this is not so in extensions since we
+  // traverse extensions in a different way (by necessity).  Instead, we must apply the type constraints separately.
+  applyOwnTypeConstraintsOnExtension(sourceValue, profile, snapshotEl, differentialEl) {
+
+    // NOTE: Very similar (but slightly different) code exists in #processValueToFieldType.  At some point these could
+    // potentially be refactored, but to do it in a non-hacky way will require some work.  Until then, if something
+    // changes in this function, check to see if it should also change in #processValueToFieldType.
+
+    const typeConstraints = sourceValue.constraintsFilter.own.type.constraints;
+    if (typeConstraints.length > 0) {
+      [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
+
+      const sourceIdentifier = sourceValue.effectiveIdentifier;
+      const targetTypes = snapshotEl.type;
+
+      // If the source is a primitive, then the target must be the same primitive!
+      if (sourceIdentifier.isPrimitive) {
+        const matchedTypes = targetTypes.filter(t => sourceIdentifier.name == t.code);
+        if (matchedTypes.length > 0) {
+          this.markSelectedOptionsInChoice(targetTypes, matchedTypes);
+          return;
+        }
+        const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
+        if (allowedConvertedTypes.length > 0) {
+          this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
+          return;
+        }
+        return;
+      }
+
+      // It's a non-primitive source type.  First check if the field is mapped to a BackboneElement.
+      if (targetTypes.length == 1 && targetTypes[0].code == 'BackboneElement') {
+        // TODO: Determine what to do with backbone elements.
+        return;
+      }
+
+      // Check if the source field has a mapping to a FHIR profile.  If so, and it matches target, apply the profile to the target
+      const sourceMap = this._specs.maps.findByTargetAndIdentifier(TARGET, sourceIdentifier);
+      if (typeof sourceMap !== 'undefined') {
+        let matchedType;
+        const originalTargetTypes = common.cloneJSON(targetTypes);
+        const sourceProfile = this.lookupProfile(sourceMap.identifier, true, true);
+        const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
+        const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
+        const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL));
+        for (let i=0; i < targetTypes.length; i++) {
+          const t = targetTypes[i];
+          const originalProfile = this.optionIsSelected(t) ? t._originalProfile : t.profile;
+          const originalTargetProfile = this.optionIsSelected(t) ? t._originalTargetProfile : t.targetProfile;
+          // @ts-ignore
+          if (allowableTargetTypes.includes(t.code) || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
+            matchedType = t;
+            // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
+            // or if the original type is a supertype (i.e., a profile of one of its basedOn types)
+            if (this.optionIsSelected(t)) {
+              // This type has already been mapped to once.  Determine if we should add another type to represent
+              // additional applicable profiles.  This is done by checking if its part of an includes type slice, and/or
+              // by checking if the new profile fits in the old type / profile.
+              if (common.isCustomProfile(sourceProfile)) {
+                // @ts-ignore
+                if (typeof originalProfile === 'undefined' || allowableTargetProfiles.includes(originalProfile) || basedOnTargetProfiles.includes(originalProfile)) {
+                  if (sourceValue._derivedFromIncludesTypeConstraint) {
+                    // This is the result of an includes type slicing, so we want the new profile to replace the existing one
+                    // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
+                    t.profile = sourceProfile.url;
+                  } else {
+                    // We should represent both the existing and the new profile, so create a new type for the additional
+                    // profile and splice it into the types
+                    const t2 = common.cloneJSON(t);
+                    t2.profile = sourceProfile.url;
+                    targetTypes.splice(i+1, 0, t2);
+                    matchedType = t2;
+                  }
+                }
+                // else it wasn't a valid sub-type of the original type, and this will cause an error further down
+              } else {
+                // The existing type narrows it to a profile, but since this new type represents a no-profile type,
+                // remove the profile from the existing type
+                delete(t.profile);
+              }
+              break;
+            } else {
+              // This is the first time mapping to this type, so overwrite profile if applicable, and mark as selected
+              if (common.isCustomProfile(sourceProfile)) {
+                if (typeof t.profile !== 'undefined') {
+                  // keep track of the original profile so we can check on other options in the future
+                  t._originalProfile = t.profile;
+                }
+                t.profile = sourceProfile.url;
+              }
+              this.markSelectedOptionsInChoice(targetTypes, [t]);
+            }
+            break;
+          // @ts-ignore
+          } else if (t.code == 'Reference' && (allowableTargetProfiles.includes(originalTargetProfile) || basedOnTargetProfiles.includes(originalTargetProfile))) {
+            matchedType = t;
+            // Only change the type if it hasn't already been selected (e.g. changed) by the mapper
+            // or if the previous is a supertype (i.e., a profile of one of its basedOn types)
+            if (this.optionIsSelected(t)) {
+              // This type has already been mapped to once, and we've already determined that the new profile is a match.
+              if (sourceValue._derivedFromIncludesTypeConstraint) {
+                // This is the result of an includes type slicing, so we want the new profile to replace the existing one
+                // (which was copied over in the slicing operation), since it's a sub-type of the existing profile
+                t.targetProfile = sourceProfile.url;
+              } else {
+                // We should represent both the existing and the new profile, so create a new type for the additional
+                // target profile and splice it into the types
+                const t2 = common.cloneJSON(t);
+                t2.targetProfile = sourceProfile.url;
+                targetTypes.splice(i+1, 0, t2);
+                matchedType = t2;
+              }
+            } else {
+              // This is the first time mapping to this type, so overwrite targetProfile and mark as selected
+              t._originalTargetProfile = t.targetProfile;
+              t.targetProfile = sourceProfile.url;
+              this.markSelectedOptionsInChoice(targetTypes, [t]);
+            }
+            break;
+          }
+        }
+
+        if (typeof matchedType !== 'undefined') {
+          // We got a match!
+          // Check to see if this is trying to map a different element than the one that was previously mapped.
+          const mappedProfile = typeof matchedType.profile !== 'undefined' ? matchedType.profile : matchedType.targetProfile;
+          if (typeof mappedProfile !== 'undefined' && mappedProfile != sourceProfile.url) {
+            // It's trying to map a different element than the one that was previously mapped.  Conflict!
+            logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfile);
+          } else {
+            // We successfully mapped the type, so we need to apply the differential and constraints
+            if (typeof mappedProfile !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
+              differentialEl.type = snapshotEl.type;
+            }
+            return;
+          }
+        } else {
+          const allowedConvertedTypes = this.findAllowedConversionTargetTypes(sourceIdentifier, targetTypes);
+          if (allowedConvertedTypes.length > 0) {
+            this.markSelectedOptionsInChoice(targetTypes, allowedConvertedTypes);
+            return;
+          }
+        }
+      }
+
+      // TODO: Do we need to consider mapping based on values (like in processValueToFieldType?)
     }
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -530,8 +530,9 @@ class FHIRExporter {
         profile.differential.element.push(dfEl);
       }
       ssEl.patternCodeableConcept = dfEl.patternCodeableConcept = {
-        coding: [ { system: `${this._config.fhirURL}/basic-resource-type`, code: profile.id }]
+        coding: [ { system: `${this._config.fhirURL}/CodeSystem/${this._config.projectShorthand}-basic-resource-type`, code: profile.id }]
       };
+      this._codeSystemExporter.addTypeToBasicResourceTypeCodeSystem(profile.id, profile.title);
       if (REPORT_PROFILE_INDICATORS) {
         this.addFixedValueIndicator(profile, ssEl.path, ssEl.patternCodeableConcept);
       }

--- a/lib/export.js
+++ b/lib/export.js
@@ -3024,7 +3024,7 @@ class FHIRExporter {
     // Still haven't found it, so traverse the rest
     const subValue = this.findValueByPath(path.slice(1), def, false, value.constraints);
     if (typeof subValue !== 'undefined') {
-      return this.mergeConstraintsToChild(value.constraints, subValue);
+      return subValue;
     }
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -347,6 +347,36 @@ class FHIRExporter {
         }
       }
 
+      // Fix any minimum cardinalities that should be bumped up due to slicing.
+      for (let i=0; i < profile.snapshot.element.length; i++) {
+        const baseEl = profile.snapshot.element[i];
+        if (baseEl.slicing != null) {
+          // it's a base slice, so look through its children for slices with min > 1 and add to totalMin
+          let totalMin = 0;
+          const isChild = function(idx) {
+            return profile.snapshot.element[idx].id.indexOf(`${baseEl.id}:`) === 0
+              || profile.snapshot.element[idx].id.indexOf(`${baseEl.id}.`) === 0;
+          };
+          const baseIdLastDot = baseEl.id.lastIndexOf('.');
+          for (let j=i+1; j < profile.snapshot.element.length && isChild(j); j++) {
+            const childEl = profile.snapshot.element[j];
+            // Check if it's a direct child slice
+            if (childEl.sliceName && childEl.id.lastIndexOf('.') === baseIdLastDot) {
+              totalMin += childEl.min;
+            }
+          }
+          if (totalMin > baseEl.min) {
+            if (baseEl.max !== '*' && totalMin > parseInt(baseEl.max)) {
+              logger.error('Cumulative slice min cardinalities (%s) exceed the max cardinality (%s) for the containing array at %s.', totalMin, baseEl.max, baseEl.id);
+            }
+            const dfEl = common.getDifferentialElementById(profile, baseEl.id, true);
+            baseEl.min = dfEl.min = totalMin;
+            // Whenever we set a min in a differential, we always set the max too.  It looks better that way.
+            dfEl.max = baseEl.max;
+          }
+        }
+      }
+
       // Sort the differentials to be in the same order as the snapshots
       profile.differential.element.sort((a, b) => {
         const aI = profile.snapshot.element.findIndex(e => e.id == a.id);
@@ -542,24 +572,17 @@ class FHIRExporter {
         }
         const includes = sourceValue.constraintsFilter.includesType.constraints;
         if (includes.length > 0) {
-          // We'll keep track of the lower cardinalities so we can update the containing array's cardinality as
-          // necessary.  For example, if PanelMembers.Observations includes 1..1 BRAC1Variant and 1..1 BRAC2Variant,
-          // then we know the array it maps two must have at least a lower cardinality of 2 (1 + 1 = 2).
-          let minCard = 0;
           // We need to keep track of the index where to insert extra includes type elements (if applicable)
           let includesInsertIdx;
           const includesTypeRules = [];
           for (const incl of includes) {
             if (incl.path.length > 0) {
-              logger.error('Splicing on include type constraints with paths is not supported. ERROR_CODE:13003');
+              logger.error('Slicing on include type constraints with paths is not supported. ERROR_CODE:13003');
               continue;
             }
             // Substitute the original identifier in the path with the includesType identifier instead
             const newSourcePath = rule.sourcePath.slice();
             newSourcePath[newSourcePath.length-1] = incl.isA;
-            if (incl.card && incl.card.min) {
-              minCard += incl.card.min;
-            }
             // Create and store a new rule, but remove "slice strategy" from the commands since it only applies to parent
             includesTypeRules.push(new mdls.FieldMappingRule(newSourcePath, new FieldTarget(t.target, t.commands.filter(c => c.key != 'slice strategy')).toRuleTarget()));
             // Copy, update, and add specific child rules within the slice
@@ -589,22 +612,6 @@ class FHIRExporter {
           // When we slice on something that has IncludesType constraints, the intention is not to make the base
           // type a slice.  Only the includes types should be slices.  So, *remove* the slice commands from the base.
           map.rules[i] = new mdls.FieldMappingRule(rule.sourcePath, t.target);
-          // Now we modify the cardinality of what we're slicing (if necessary) to ensure the slices all fit
-          if (minCard > 0) {
-            let cardTarget = t.target;
-            // If we said to slice *at* a different level than the target, then that's where the card should be applied
-            if (t.hasSliceAtCommand()) {
-              cardTarget = t.findSliceAtCommand().value;
-            }
-            // Now we need to find the original cardinality in the FHIR definition so we can modify as appropriate
-            const fhirDef = this._fhir.find(map.targetItem);
-            const ss = common.getSnapshotElement(fhirDef, cardTarget);
-            let fhirCard = getFHIRElementCardinality(ss);
-            if (fhirCard.min < minCard) {
-              // Insert the new CardinalityMappingRule above the base rule so it is applied first
-              map.rules.splice(i, 0, new mdls.CardinalityMappingRule(cardTarget, new mdls.Cardinality(minCard, fhirCard.max)));
-            }
-          }
           // Now add the new rules we just created based on the includes types!
           map.rules.splice(includesInsertIdx, 0, ...includesTypeRules);
         } else {
@@ -619,6 +626,27 @@ class FHIRExporter {
     const sliceAtMap = new Map();
     const sliceTargetStack = new Stack();
     const sliceNameStack = new Stack();
+    const getInSliceValue = function() {
+      // Use the stack of slice targets and names to build up the slice-aware path, supporting nested slices.
+      // E.g., 'foo:sliceA.bar:sliceB' represents sliceB of bar inside sliceA of foo.
+      const [targetStack, nameStack] = [sliceTargetStack.clone(), sliceNameStack.clone()];
+      let value = targetStack.peekLast();
+      while (!targetStack.isEmpty()) {
+        const [target, sliceName] = [targetStack.pop(), nameStack.pop()];
+        let slicedReplacement;
+        if (sliceAtMap.has(target)) {
+          // If there is a slice at (meaning slice is higher up the path), we need to put the slice annotation
+          // at the right place in the middle of the target path
+          const sliceAt = sliceAtMap.get(target);
+          slicedReplacement = target.replace(sliceAt, `${sliceAt}:${sliceName}`);
+        } else {
+          // No slice at, so we can put the slice annotation at the end of the target path
+          slicedReplacement = `${target}:${sliceName}`;
+        }
+        value = value.replace(target, slicedReplacement);
+      }
+      return value;
+    };
     let i=0;
     for (const rule of map.rules) {
       rule._i = i++; // Helps maintain original order of "equivalent" rules when sorting
@@ -645,8 +673,8 @@ class FHIRExporter {
           sliceNameStack.pop();
         }
         const sliceName = ss.sliceName;
-        t.addInSliceCommand(`${sliceTargetStack.peekLast()}[${sliceName}]`);
         sliceNameStack.push(sliceName);
+        t.addInSliceCommand(getInSliceValue());
       } else if (t.hasSliceOnCommand()) {
         // Start a new slice group (or continue if it's the same as the last slice group)
         const sliceOn = t.findSliceOnCommand().value;
@@ -664,8 +692,8 @@ class FHIRExporter {
 
         // Start a new slice!
         const sliceName = common.fhirID(rule.sourcePath[rule.sourcePath.length-1]);
-        t.addInSliceCommand(`${sliceTargetStack.peekLast()}[${sliceName}]`);
         sliceNameStack.push(sliceName);
+        t.addInSliceCommand(getInSliceValue());
       } else if (!sliceTargetStack.isEmpty() && t.target == sliceTargetStack.peekLast()) {
         // Associate with current slice group
         t.addSliceOnCommand(sliceOnMap.get(t.target));
@@ -676,13 +704,13 @@ class FHIRExporter {
         }
 
         // Start a new slice in the slice group!
-        const sliceName = common.fhirID(rule.sourcePath[rule.sourcePath.length-1]);
-        t.addInSliceCommand(`${sliceTargetStack.peekLast()}[${sliceName}]`);
         sliceNameStack.pop();
+        const sliceName = common.fhirID(rule.sourcePath[rule.sourcePath.length-1]);
         sliceNameStack.push(sliceName);
+        t.addInSliceCommand(getInSliceValue());
       } else if (!sliceTargetStack.isEmpty() && t.target.startsWith(sliceTargetStack.peekLast())) {
         // Put it in the slice
-        t.addInSliceCommand(`${sliceTargetStack.peekLast()}[${sliceNameStack.peekLast()}]`);
+        t.addInSliceCommand(getInSliceValue());
       }
       rule._target = t.toRuleTarget(); // BAD BAD BAD
     }
@@ -2708,61 +2736,125 @@ class FHIRExporter {
   }
 
   getSnapshotElementForFieldTarget(profile, fieldTarget, sourceValue, sliceCard) {
-    // Unroll paths as necessary to support drilling into types
-    let parts = [profile.type, ...fieldTarget.target.split('.')];
-    for (let i=0; i < parts.length; i++) {
-      let path = parts.slice(0, i+1).join('.');
-      if (profile.snapshot.element.some(e => e.path == path)) {
+    // Get the slice-aware path (by combining in-slice value with the target)
+    const targetPathArray = fieldTarget.target.split('.');
+    if (fieldTarget.hasInSliceCommand()) {
+      const slicePathArray = fieldTarget.findInSliceCommand().value.split('.');
+      for (let i=0; i < slicePathArray.length; i++) {
+        if (targetPathArray[i] != slicePathArray[i].split(':')[0]) {
+          logger.error('Target path (%s) and slice path (%s) are not compatible.  ERROR_CODE:TBD', fieldTarget.target, fieldTarget.findInSliceCommand().value);
+          return;
+        }
+        targetPathArray[i] = slicePathArray[i];
+      }
+    }
+    // Try to find the path one segment as a time, unrolling child elements and creating slices as necessary
+    let elements = profile.snapshot.element;
+    let parentEl = profile.snapshot.element[0];
+    let cumulativePath = profile.type;
+    for (let i=0; i < targetPathArray.length; i++) {
+      // First, find the element that matches the path and slice name.  This is the root of all elements at this path.
+      const [pathPart, sliceName] = targetPathArray[i].split(':', 2);
+      cumulativePath += `.${pathPart}`;
+      let root = elements.find(e => e.sliceName == sliceName && e.path === cumulativePath);
+      if (root != null) {
+        // Re-set the parent and narrow elements to only those under this path/slice (including the root)
+        parentEl = root;
+        elements = elements.filter(e => e.id === root.id || e.id.startsWith(`${root.id}.`));
         continue;
       }
-      // The path doesn't exist.  We may need to unroll a nested data type in the path's parent
-      const parentEl = profile.snapshot.element.find(e => e.path == parts.slice(0, i).join('.'));
-      if (typeof parentEl !== 'undefined' && parentEl.path.endsWith('[x]') && parentEl.type.some(t => t.code === parts[i])) {
+
+      // The path doesn't exist.  We may need to "create" it.
+
+      // If this is a path pointing to a slice, then we may need to create the slice from the base (if the base exists)
+      if (sliceName != null) {
+        const isDeepestSlice = targetPathArray.every((tp, j) => (j <= i) || tp.indexOf(':') === -1);
+        if (!isDeepestSlice) {
+          // We couldn't find the slice, BUT the missing slice is a parent slice to the slice the slice this target
+          // is actually associated to (e.g., nested slices and we can't find one of the higher containing slices).
+          // We don't have enough info to create the parent slice, so this is a problem. Technically, this parent slice
+          // should have already been created by the time we got here, so it's probably a bug in tooling.
+          logger.error('Could not resolve sliced path: %s (likely a tooling issue).  ERROR_CODE:TBD', targetPathArray.slice(0, i+1).join('.'));
+          return;
+        }
+        const base = elements.find(e => e.sliceName == null && e.path === cumulativePath);
+        if (base != null) {
+          root = this.createSliceFromBase(profile, base, sliceName, fieldTarget, sourceValue, sliceCard);
+          // Re-set the parent and narrow elements to only those under this path/slice (including the root)
+          parentEl = root;
+          // Since we added new elements (when we sliced), we need to filter on the whole profile again
+          elements = profile.snapshot.element.filter(e => e.id === root.id || e.id.startsWith(`${root.id}.`));
+          continue;
+        }
+      }
+
+      // If we still haven't found it, but the parent is a choice, and the path is an option, make the choice explicit
+      if (parentEl.path.endsWith('[x]') && parentEl.type.some(t => t.code === pathPart)) {
         // The target path references a type in a choice (e.g., value[x].Quantity), so we need to make an explicit
         // choice element for that type, and then update the path to reference it
         const parentDfEl = common.getDifferentialElementById(profile, parentEl.id, true);
-        const [ssEl] = this.addExplicitChoiceElement(parts[i], profile, parentEl, parentDfEl);
-        // Clone the target with the new path and try again
-        const newTarget = fieldTarget.target.replace(`${parts[i-1]}.${parts[i]}`, ssEl.path.split('.').pop());
-        const newFieldTarget = new FieldTarget(newTarget, fieldTarget.commands, fieldTarget.comments);
-        return this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sourceValue, sliceCard);
-      } else if (typeof parentEl === 'undefined' || !Array.isArray(parentEl.type) || parentEl.type.length != 1) {
+        [root] = this.addExplicitChoiceElement(pathPart, profile, parentEl, parentDfEl);
+        // If this had a slice name, we know we need to create the slice too
+        if (sliceName != null) {
+          root = this.createSliceFromBase(profile, root, sliceName, fieldTarget, sourceValue, sliceCard);
+        }
+        // Re-set the parent and narrow elements to only those under this path/slice (including the root)
+        parentEl = root;
+        // Since we added/replaced new elements, we'll need to filter on the whole profile again
+        elements = profile.snapshot.element.filter(e => e.id === root.id || e.id.startsWith(`${root.id}.`));
+        continue;
+      }
+
+      // Still here?  If the parent isn't drillable just return (undefined)
+      if (!Array.isArray(parentEl.type) || parentEl.type.length != 1) {
         // The parent isn't a drillable element
         return;
       } else if (typeof parentEl.type[0].code === 'undefined' || parentEl.type[0].code == 'Reference') {
         // The parent type isn't drillable (it's a reference or unspecified type)
         return;
       }
+
+      // At this point, it looks like we may need to "unroll" the parent to get to this part of the path
       const type = parentEl.type[0].code;
       const sd = this.lookupStructureDefinition(type, true);
       // Before we unroll it, check to be sure the sub-element exists (otherwise we needlessly unroll it)
-      if (sd.snapshot.element.some(e => e.path == `${sd.type}.${parts[i]}`)) {
+      if (sd.snapshot.element.some(e => e.path == `${sd.type}.${pathPart}`)) {
         this.unrollElement(type, profile, parentEl);
+        // Now that we unrolled, we want to run this cycle of the loop again with the new elements
+        elements = elements.filter(e => e.id === parentEl.id || e.id.startsWith(`${parentEl.id}.`));
+        // Trim back the cumulative path and decrement i so we run this cycle of the loop through again
+        cumulativePath = cumulativePath.substring(0, cumulativePath.lastIndexOf('.'));
+        i--;
       } else {
+        // The sub-element doesn't exist in the type
         return;
       }
     }
 
-    const path = parts.join('.');
-    let elements = profile.snapshot.element.filter(e => e.path == path);
-    if (elements.length == 0) {
-      return;
-    }
+    // The root (which is what we want) is the first in the array
+    return elements[0];
+  }
 
-    let element;
-    // If this field target requests a new slice section or indicates it's in a slice, we need to do some magic
-    // TODO: Figure out how this works / should work when mapping to a profile that ALREADY has slices!
+  createSliceFromBase(profile, baseElement, sliceName, fieldTarget, sourceValue, sliceCard) {
     if (fieldTarget.hasSliceOnCommand()) {
-      let baseElement = elements[0];
       // If the mapping has a slice at command, then that's where we need to set the base element to apply slicing info
       if (fieldTarget.hasSliceAtCommand()) {
-        const sliceAt =  [profile.type, ...fieldTarget.findSliceAtCommand().value.split('.')].join('.');
-        const atElements = profile.snapshot.element.filter(e => e.path == sliceAt);
-        if (atElements.length == 0) {
+        const sliceAtPath = `${profile.type}.${fieldTarget.findSliceAtCommand().value}`;
+        let sliceAtElement;
+        for (const idParts = baseElement.id.split('.'); idParts.length > 0; idParts.pop()) {
+          const element = profile.snapshot.element.find(e => e.id === idParts.join('.'));
+          if (element && element.path === sliceAtPath) {
+            sliceAtElement = element;
+            break;
+          }
+        }
+        if (sliceAtElement == null) {
+          logger.error('Could not find element to slice at: %s.  ERROR_CODE:TBD', sliceAtPath);
           return;
         }
-        baseElement = atElements[0];
+        baseElement = sliceAtElement;
       }
+
 
       // Apply the discriminator to the base element in the snapshot and the differential
       const discType = fieldTarget.hasSliceOnTypeCommand() ? fieldTarget.findSliceOnTypeCommand().value : 'value';
@@ -2773,15 +2865,6 @@ class FHIRExporter {
         profile.differential.element.push(df);
       }
       df.slicing = baseElement.slicing;
-
-      let sliceName;
-      if (fieldTarget.hasInSliceCommand()) {
-        [/*match*/,/*path*/,sliceName] = /(.*)\s*\[(.*)\]/.exec(fieldTarget.findInSliceCommand());
-      } else {
-        // this shouldn't ever happen, but just in case
-        logger.error('No slice name supplied for target. This should never happen and is probably a bug in the tool. ERROR_CODE:13042');
-        sliceName = `gen-${elements.length+1}`;
-      }
 
       // Now add the snapshot and differential sections for the slice!
       const ssSection = profile.snapshot.element.filter(e => {
@@ -2824,7 +2907,7 @@ class FHIRExporter {
 
       // If a sliceCard was passed in, set it
       if (typeof sliceCard !== 'undefined') {
-        setCardinalityOnFHIRElements(sliceCard, ssSliceSection[0], dfSliceSection[0], true);
+        setCardinalityOnFHIRElements(sliceCard, ssSliceSection[0], dfSliceSection[0], false);
       }
 
       // Add the differentials
@@ -2835,40 +2918,10 @@ class FHIRExporter {
       for ( ; i < profile.snapshot.element.length && profile.snapshot.element[i].path.startsWith(baseElement.path); i++);
       // Insert the section
       profile.snapshot.element.splice(i, 0, ...ssSliceSection);
-    }
 
-    if (fieldTarget.hasSliceOnCommand()) {
-      // We added new slice elements, so we need to refilter for the target elements again
-      elements = profile.snapshot.element.filter(e => e.path == path);
+      return ssSliceSection[0];
     }
-    if (elements.length > 1) {
-      if (fieldTarget.hasInSliceCommand()) {
-        // It's in a slice, so try to find the element in the specific slice
-        const [/*match*/,/*path*/,sliceName] = /(.*)\s*\[(.*)\]/.exec(fieldTarget.findInSliceCommand());
-        element = elements.find(s => {
-          return profile.snapshot.element.some(e => s.id.startsWith(e.id) && e.sliceName == sliceName);
-        });
-        if (typeof element === 'undefined') {
-          logger.error('Couldn\'t find target in slice %s. ERROR_CODE:13043', sliceName);
-          element = elements[0];
-        }
-      } else {
-        // It's not in a slice, so try to find the non-sliced path (for constraints on the base elements)
-        const nonSlices = elements.filter(s => {
-          return ! profile.snapshot.element.some(e => s.id.startsWith(e.id) && typeof e.sliceName !== 'undefined');
-        });
-        if (nonSlices.length === 1) {
-          element = nonSlices[0];
-        } else {
-          logger.error('Target resolves to multiple elements but is not sliced. ERROR_CODE:13044');
-          element = elements[0];
-        }
-      }
-    } else {
-      element = elements[0];
-    }
-
-    return element;
+    logger.error('Cannot create slice since there is no "slice on" command.  ERROR_CODE:');
   }
 
   // Given a path (identifier array) and a SHR data element definition, it will return the matching value at the tail
@@ -3443,7 +3496,7 @@ function setCardinalityOnFHIRElements(card, snapshotEl, differentialEl, skipIfEq
       if (typeof differentialEl._originalProperties === 'undefined') {
         differentialEl._originalProperties = originalProperties;
       }
-      if (snapshotEl.min !== differentialEl._originalProperties.min || snapshotEl.max !== differentialEl._originalProperties.max) {
+      if (!skipIfEqual || snapshotEl.min !== differentialEl._originalProperties.min || snapshotEl.max !== differentialEl._originalProperties.max) {
         differentialEl.min = snapshotEl.min;
         differentialEl.max = snapshotEl.max;
       } else {
@@ -3647,6 +3700,12 @@ class Stack {
 
   isEmpty() {
     return this._a.length == 0;
+  }
+
+  clone() {
+    const clone = new Stack();
+    clone._a = this._a.slice();
+    return clone;
   }
 }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -2736,6 +2736,7 @@ class FHIRExporter {
       delete(ssEl.comment);
       delete(ssEl.alias);
       delete(ssEl.mapping);
+      delete(ssEl.slicing);
       this.insertExtensionElementInList(ssEl, profile.snapshot.element);
 
       dfEl = common.cloneJSON(ssEl);

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -15,6 +15,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
 
   const igControlPath = path.join(outDir, 'ig.json');
   const igControl = fs.readJsonSync(igControlPath);
+  const primaryExtensionUrls = new Set();
   const xmlResources = [];
   const htmlPrimaryProfiles = [];
   const htmlSupportProfiles = [];
@@ -124,6 +125,17 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     `;
     if (isPrimaryFn(profile.id)) {
       htmlPrimaryProfiles.push(htmlSnippet);
+
+      for (const element of profile.snapshot.element) {
+        if (element.path === `${profile.type}.extension`
+        || element.path === `${profile.type}.modifierExtension`) {
+          for (const type of element.type) {
+            if (type.profile) {
+              primaryExtensionUrls.add(type.profile);
+            }
+          }
+        }
+      }
     } else {
       htmlSupportProfiles.push(htmlSnippet);
     }
@@ -159,8 +171,14 @@ ${match[1]}
   };
   fs.copySync(patchPath, sdPath, { filter: filterFunc });
 
-  fhirResults.extensions.sort(byName);
-  for (const extension of fhirResults.extensions) {
+  const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
+  && config.implementationGuide.primarySelectionStrategy.hideSupporting;
+
+  let fhirExtensions = fhirResults.extensions.sort(byName);
+  if (hideSupporting) {
+    fhirExtensions = fhirExtensions.filter(ext => primaryExtensionUrls.has(ext.url));
+  }
+  for (const extension of fhirExtensions) {
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${extension.id}.json`), JSON.stringify(extension, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${extension.id}`] = {
       'base': `StructureDefinition-${extension.id}.html`,
@@ -338,8 +356,6 @@ ${match[1]}
   let updatedProfilesHtml = profilesHtml.replace('<primary-profiles-go-here/>', htmlPrimaryProfiles.join(''))
     .replace('<support-profiles-go-here/>', htmlSupportProfiles.join(''))
     .replace('<project-shorthand-go-here/>', config.projectShorthand);
-  const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
-    && config.implementationGuide.primarySelectionStrategy.hideSupporting;
   if (hideSupporting) {
     updatedProfilesHtml = updatedProfilesHtml
       .replace('<h2 id="supporting-profiles-header">', '<h2 id="supporting-profiles-header" style="display: none">')

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -445,6 +445,10 @@ ${match[1]}
   const extensionsHtml = fs.readFileSync(extensionsHtmlPath, 'utf8');
   let updatedExtensionsHtml = extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
     .replace('<project-shorthand-go-here/>', config.projectShorthand);
+  if (htmlExtensions.length === 0) {
+    updatedExtensionsHtml = updatedExtensionsHtml
+      .replace('<table class="codes">', 'None\n<table class="codes" style="display: none">');
+  }
   if (hideSupporting) {
     updatedExtensionsHtml = updatedExtensionsHtml
       .replace('<extensions-header/>', '<h2>Primary extensions defined as part of this Implementation Guide</h2>');
@@ -460,12 +464,16 @@ ${match[1]}
   const valueSetsHtml = fs.readFileSync(valueSetsHtmlPath, 'utf8');
   let updatedValueSetsHtml = valueSetsHtml.replace('<valueSets-go-here/>', htmlValueSets.join(''))
     .replace('<project-shorthand-go-here/>', config.projectShorthand);
+  if (htmlValueSets.length === 0) {
+    updatedValueSetsHtml = updatedValueSetsHtml
+      .replace('<table class="codes">', 'None\n<table class="codes" style="display: none">');
+  }
   if (hideSupporting) {
     updatedValueSetsHtml = updatedValueSetsHtml
-      .replace('<value-sets-header/>', '<h2>Primary Value Sets defined as part of this Implementation Guide</h2>');
+      .replace('<value-sets-header/>', '<h2>Primary value sets defined as part of this Implementation Guide</h2>');
   } else {
     updatedValueSetsHtml = updatedValueSetsHtml
-      .replace('<value-sets-header/>', '<h2>Value Sets defined as part of this Implementation Guide</h2>');
+      .replace('<value-sets-header/>', '<h2>Value sets defined as part of this Implementation Guide</h2>');
   }
 
   fs.writeFileSync(valueSetsHtmlPath, updatedValueSetsHtml, 'utf8');
@@ -475,13 +483,16 @@ ${match[1]}
   const codeSystemsHtml = fs.readFileSync(codeSystemsHtmlPath, 'utf8');
   let updatedCodeSystemsHtml = codeSystemsHtml.replace('<codeSystems-go-here/>', htmlCodeSystems.join(''))
     .replace('<project-shorthand-go-here/>', config.projectShorthand);
-
+  if (htmlCodeSystems.length === 0) {
+    updatedCodeSystemsHtml = updatedCodeSystemsHtml
+      .replace('<table class="codes">', 'None\n<table class="codes" style="display: none">');
+  }
   if (hideSupporting) {
     updatedCodeSystemsHtml = updatedCodeSystemsHtml
-      .replace('<code-systems-header/>', '<h2>Primary Code Systems defined as part of this Implementation Guide</h2>');
+      .replace('<code-systems-header/>', '<h2>Primary code systems defined as part of this Implementation Guide</h2>');
   } else {
     updatedCodeSystemsHtml = updatedCodeSystemsHtml
-      .replace('<code-systems-header/>', '<h2>Code Systems defined as part of this Implementation Guide</h2>');
+      .replace('<code-systems-header/>', '<h2>Code systems defined as part of this Implementation Guide</h2>');
   }
 
   fs.writeFileSync(codeSystemsHtmlPath, updatedCodeSystemsHtml, 'utf8');

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -43,23 +43,36 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   }
 
   // Rewrite base files to use project names
-  const igIndexHtmlPath = path.join(outDir, 'pages','index.html');
-  const igIndexHtml = fs.readFileSync(igIndexHtmlPath, 'utf8');
-  const igIndexContentPath = path.join(specPath, config.implementationGuide.indexContent);
-  var igIndexContent;
-  try {
-    igIndexContent = fs.readFileSync(igIndexContentPath, 'utf8');
-  } catch (error) {
-    igIndexContent =
-`<p> This is a ${config.projectName} FHIR implementation guide. </p>`;
-    fs.writeFileSync(igIndexContentPath, igIndexContent, 'utf8');
-  }
+  const igIndexHtmlPath = path.join(outDir, 'pages');
+  const igIndexHtml = fs.readFileSync(path.join(igIndexHtmlPath, 'index.html'), 'utf8');
+  let igIndexContentPath = path.join(specPath, config.implementationGuide.indexContent);
 
-  fs.writeFileSync(igIndexHtmlPath, igIndexHtml.replace('<igIndexContent-go-here>', igIndexContent), 'utf8');
+  if (fs.lstatSync(igIndexContentPath).isDirectory()) {
+    const files = fs.readdirSync(igIndexContentPath, 'utf8');
+    for (const file of files) {
+      if (file.endsWith('.html')) {
+        let fileContent = fs.readFileSync(path.join(igIndexContentPath, file), 'utf8');
+        fs.writeFileSync(path.join(igIndexHtmlPath, file), igIndexHtml.replace('<igIndexContent-go-here>', fileContent), 'utf8');
+      } else {
+        let readStream = fs.createReadStream(path.join(igIndexContentPath, file));
+        readStream.pipe(fs.createWriteStream(path.join(igIndexHtmlPath, file)));
+      }
+    }
+  } else {
+    let igIndexContent;
+    try {
+      igIndexContent = fs.readFileSync(igIndexContentPath, 'utf8');
+    } catch (error) {
+      igIndexContent =
+  `<p> This is a ${config.projectName} FHIR implementation guide. </p>`;
+      fs.writeFileSync(igIndexContentPath, igIndexContent, 'utf8');
+    }
+    fs.writeFileSync(path.join(igIndexHtmlPath, 'index.html'), igIndexHtml.replace('<igIndexContent-go-here>', igIndexContent), 'utf8');
+  }
 
   // For each profile, extension, value set, and code system
   // 1. Copy it into the corresponding resources subfolder
-  // 2. Add it to the IG JSON controle file
+  // 2. Add it to the IG JSON control file
   // 3. Add it to the IG XML file
   // 4. Add it to the corresponding HTML listing file
   // 5. Create the mapping xhtml file (profiles only)

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -201,6 +201,10 @@ ${match[1]}
   && config.implementationGuide.primarySelectionStrategy
   && config.implementationGuide.primarySelectionStrategy.hideSupporting;
 
+  const usingNamespaceStrategy = config.implementationGuide
+  && config.implementationGuide.primarySelectionStrategy
+  && (config.implementationGuide.primarySelectionStrategy.strategy === 'namespace');
+
   for (const extension of fhirResults.extensions.sort(byName)) {
     if (primaryExtensionUrls.has(extension.url)) {
       for (const element of extension.snapshot.element) {
@@ -245,6 +249,17 @@ ${match[1]}
   const vsPath = path.join(outDir, 'resources');
   fs.ensureDirSync(vsPath);
   for (const valueSet of fhirResults.valueSets) {
+    if (usingNamespaceStrategy) {
+      const inNamespace = config.implementationGuide.primarySelectionStrategy.primary.some((p) => {
+        return valueSet.identifier.some((i) => {
+          return i.value.startsWith(p);
+        })  
+      });
+      if (inNamespace) {
+        primaryValueSetUrls.add(valueSet.url);
+      }
+    }
+
     if (primaryValueSetUrls.has(valueSet.url)) {
       for (const include of valueSet.compose.include) {
         if (include.system) {
@@ -284,6 +299,15 @@ ${match[1]}
   const csPath = path.join(outDir, 'resources');
   fs.ensureDirSync(csPath);
   for (const codeSystem of fhirResults.codeSystems) {
+    if (usingNamespaceStrategy) {
+      const inNamespace = config.implementationGuide.primarySelectionStrategy.primary.some((p) => {
+        return codeSystem.identifier.value.startsWith(p);
+      });
+      if (inNamespace) {
+        primaryCodeSystemUrls.add(codeSystem.url);
+      }
+    }
+
     fs.writeFileSync(path.join(csPath, `codesystem-${codeSystem.id}.json`), JSON.stringify(codeSystem, null, 2), 'utf8');
     igControl.resources[`CodeSystem/${codeSystem.id}`] = {
       'base': `CodeSystem-${codeSystem.id}.html`

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -174,11 +174,7 @@ ${match[1]}
   const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
   && config.implementationGuide.primarySelectionStrategy.hideSupporting;
 
-  let fhirExtensions = fhirResults.extensions.sort(byName);
-  if (hideSupporting) {
-    fhirExtensions = fhirExtensions.filter(ext => primaryExtensionUrls.has(ext.url));
-  }
-  for (const extension of fhirExtensions) {
+  for (const extension of fhirResults.extensions.sort(byName)) {
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${extension.id}.json`), JSON.stringify(extension, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${extension.id}`] = {
       'base': `StructureDefinition-${extension.id}.html`,
@@ -193,12 +189,14 @@ ${match[1]}
         </resource>
         `);
     const name = extension.title.replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ Extension$/, '');
-    htmlExtensions.push(
-    `<tr>
-      <td><a href="StructureDefinition-${extension.id}.html">${name}</a></td>
-      <td>${markdownifiedText(extension.description)}</td>
-    </tr>
-    `);
+    if (!hideSupporting || primaryExtensionUrls.has(extension.url)) {
+      htmlExtensions.push(
+        `<tr>
+          <td><a href="StructureDefinition-${extension.id}.html">${name}</a></td>
+          <td>${markdownifiedText(extension.description)}</td>
+        </tr>
+        `);
+    }
   }
 
   fhirResults.valueSets.sort(byName);
@@ -367,8 +365,17 @@ ${match[1]}
   // Rewrite the updated Extensions HTML file
   const extensionsHtmlPath = path.join(outDir, 'pages', 'extensions.html');
   const extensionsHtml = fs.readFileSync(extensionsHtmlPath, 'utf8');
-  fs.writeFileSync(extensionsHtmlPath, extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
-                                                     .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedExtensionsHtml = extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand)
+  if (hideSupporting) {
+    updatedExtensionsHtml = updatedExtensionsHtml
+      .replace('<extensions-header/>', '<h2>Primary extensions defined as part of this Implementation Guide</h2>');
+  } else {
+    updatedExtensionsHtml = updatedExtensionsHtml
+      .replace('<extensions-header/>', '<h2>Extensions defined as part of this Implementation Guide</h2>');
+    }
+
+  fs.writeFileSync(extensionsHtmlPath, updatedExtensionsHtml, 'utf8');
 
   // Rewrite the updated ValueSets HTML file
   const valueSetsHtmlPath = path.join(outDir, 'pages', 'valuesets.html');

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -24,10 +24,24 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   const htmlPrimaryModels = [];
   const htmlSupportModels = [];
 
-  //Configure igControl to use configuration specifications
-  igControl.canonicalBase = igControl.canonicalBase.replace('<ig-url-go-here>',config.fhirURL);
+  // Update igControl to use configuration specifications
+  igControl.canonicalBase = config.fhirURL;
 
-  //Rewrite base files to use project names
+  // Update igControl to specify npm-name if applicable
+  if (config.implementationGuide && config.implementationGuide.npmName) {
+    igControl['npm-name'] = config.implementationGuide.npmName.trim();
+  } else {
+    delete(igControl['npm-name']);
+  }
+
+  // Update igControl to specify fixed-business-version if applicable
+  if (config.implementationGuide && config.implementationGuide.version) {
+    igControl['fixed-business-version'] = config.implementationGuide.version.trim();
+  } else {
+    delete(igControl['fixed-business-version']);
+  }
+
+  // Rewrite base files to use project names
   const igIndexHtmlPath = path.join(outDir, 'pages','index.html');
   const igIndexHtml = fs.readFileSync(igIndexHtmlPath, 'utf8');
   const igIndexContentPath = path.join(specPath, config.implementationGuide.indexContent);

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -335,9 +335,18 @@ ${match[1]}
   // Rewrite the updated Profiles HTML file
   const profilesHtmlPath = path.join(outDir, 'pages', 'profiles.html');
   const profilesHtml = fs.readFileSync(profilesHtmlPath, 'utf8');
-  fs.writeFileSync(profilesHtmlPath, profilesHtml.replace('<primary-profiles-go-here/>', htmlPrimaryProfiles.join(''))
-                                                 .replace('<support-profiles-go-here/>', htmlSupportProfiles.join(''))
-                                                 .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedProfilesHtml = profilesHtml.replace('<primary-profiles-go-here/>', htmlPrimaryProfiles.join(''))
+    .replace('<support-profiles-go-here/>', htmlSupportProfiles.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+  const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
+    && config.implementationGuide.primarySelectionStrategy.hideSupporting;
+  if (hideSupporting) {
+    updatedProfilesHtml = updatedProfilesHtml
+      .replace('<h2 id="supporting-profiles-header">', '<h2 id="supporting-profiles-header" style="display: none">')
+      .replace('<table id="supporting-profiles-table" class="codes">', '<table id="supporting-profiles-table" class="codes" style="display: none">');
+  }
+
+  fs.writeFileSync(profilesHtmlPath, updatedProfilesHtml, 'utf8');
 
   // Rewrite the updated Extensions HTML file
   const extensionsHtmlPath = path.join(outDir, 'pages', 'extensions.html');
@@ -360,9 +369,16 @@ ${match[1]}
   // Rewrite the updated Models HTML file
   const modelsHtmlPath = path.join(outDir, 'pages', 'logical.html');
   const modelsHtml = fs.readFileSync(modelsHtmlPath, 'utf8');
-  fs.writeFileSync(modelsHtmlPath, modelsHtml.replace('<primary-models-go-here/>', htmlPrimaryModels.join(''))
-                                             .replace('<support-models-go-here/>', htmlSupportModels.join(''))
-                                             .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedModelsHtml = modelsHtml.replace('<primary-models-go-here/>', htmlPrimaryModels.join(''))
+    .replace('<support-models-go-here/>', htmlSupportModels.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+  if (hideSupporting) {
+    updatedModelsHtml = updatedModelsHtml
+      .replace('<h2 id="supporting-models-header">', '<h2 id="supporting-models-header" style="display: none">')
+      .replace('<table id="supporting-models-table" class="codes">', '<table id="supporting-models-table" class="codes" style="display: none">');
+  }
+
+  fs.writeFileSync(modelsHtmlPath, updatedModelsHtml, 'utf8');
   const navbarPath = path.join(outDir, 'pages', '_includes', 'navbar.html');
   let navbarHtml = fs.readFileSync(navbarPath, 'utf8');
   if (!config.implementationGuide.includeLogicalModels) {

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -16,6 +16,8 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   const igControlPath = path.join(outDir, 'ig.json');
   const igControl = fs.readJsonSync(igControlPath);
   const primaryExtensionUrls = new Set();
+  const primaryValueSetUrls = new Set();
+  const primaryCodeSystemUrls = new Set();
   const xmlResources = [];
   const htmlPrimaryProfiles = [];
   const htmlSupportProfiles = [];
@@ -148,6 +150,17 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
             }
           }
         }
+
+        if (element.binding
+        && element.binding.valueSetReference
+        && element.binding.valueSetReference.reference) {
+          primaryValueSetUrls.add(element.binding.valueSetReference.reference);
+        }
+
+        if (element.path.endsWith('.system')
+        && element.fixedUri) {
+          primaryCodeSystemUrls.add(element.fixedUri);
+        }
       }
     } else {
       htmlSupportProfiles.push(htmlSnippet);
@@ -184,10 +197,26 @@ ${match[1]}
   };
   fs.copySync(patchPath, sdPath, { filter: filterFunc });
 
-  const hideSupporting = config.implementationGuide && config.implementationGuide.primarySelectionStrategy
+  const hideSupporting = config.implementationGuide
+  && config.implementationGuide.primarySelectionStrategy
   && config.implementationGuide.primarySelectionStrategy.hideSupporting;
 
   for (const extension of fhirResults.extensions.sort(byName)) {
+    if (primaryExtensionUrls.has(extension.url)) {
+      for (const element of extension.snapshot.element) {
+        if (element.binding
+        && element.binding.valueSetReference
+        && element.binding.valueSetReference.reference) {
+          primaryValueSetUrls.add(element.binding.valueSetReference.reference);
+        }
+  
+        if (element.path.endsWith('.system')
+        && element.fixedUri) {
+          primaryCodeSystemUrls.add(element.fixedUri);
+        }
+      }
+    }
+
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${extension.id}.json`), JSON.stringify(extension, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${extension.id}`] = {
       'base': `StructureDefinition-${extension.id}.html`,
@@ -216,6 +245,14 @@ ${match[1]}
   const vsPath = path.join(outDir, 'resources');
   fs.ensureDirSync(vsPath);
   for (const valueSet of fhirResults.valueSets) {
+    if (primaryValueSetUrls.has(valueSet.url)) {
+      for (const include of valueSet.compose.include) {
+        if (include.system) {
+          primaryCodeSystemUrls.add(include.system);
+        }
+      }
+    }
+
     fs.writeFileSync(path.join(vsPath, `valueset-${valueSet.id}.json`), JSON.stringify(valueSet, null, 2), 'utf8');
     igControl.resources[`ValueSet/${valueSet.id}`] = {
       'base': `ValueSet-${valueSet.id}.html`
@@ -233,12 +270,14 @@ ${match[1]}
         `);
 
     const name = valueSet.title.replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ ValueSet$/, '');
-    htmlValueSets.push(
-    `<tr>
-      <td><a href="ValueSet-${valueSet.id}.html">${name}</a></td>
-      <td>${markdownifiedText(valueSet.description)}</td>
-    </tr>
-    `);
+    if (!hideSupporting || primaryValueSetUrls.has(valueSet.url)) {
+      htmlValueSets.push(
+      `<tr>
+        <td><a href="ValueSet-${valueSet.id}.html">${name}</a></td>
+        <td>${markdownifiedText(valueSet.description)}</td>
+      </tr>
+      `);
+    }
   }
 
   fhirResults.codeSystems.sort(byName);
@@ -262,12 +301,14 @@ ${match[1]}
         `);
 
     const name = codeSystem.title.replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ CodeSystem$/, '');
-    htmlCodeSystems.push(
-    `<tr>
-      <td><a href="CodeSystem-${codeSystem.id}.html">${name}</a></td>
-      <td>${markdownifiedText(codeSystem.description)}</td>
-    </tr>
-    `);
+    if (!hideSupporting || primaryCodeSystemUrls.has(codeSystem.url)) {
+      htmlCodeSystems.push(
+      `<tr>
+        <td><a href="CodeSystem-${codeSystem.id}.html">${name}</a></td>
+        <td>${markdownifiedText(codeSystem.description)}</td>
+      </tr>
+      `);
+    }
   }
 
   if (config.implementationGuide.includeLogicalModels) {
@@ -379,28 +420,47 @@ ${match[1]}
   const extensionsHtmlPath = path.join(outDir, 'pages', 'extensions.html');
   const extensionsHtml = fs.readFileSync(extensionsHtmlPath, 'utf8');
   let updatedExtensionsHtml = extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
-    .replace('<project-shorthand-go-here/>', config.projectShorthand)
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
   if (hideSupporting) {
     updatedExtensionsHtml = updatedExtensionsHtml
       .replace('<extensions-header/>', '<h2>Primary extensions defined as part of this Implementation Guide</h2>');
   } else {
     updatedExtensionsHtml = updatedExtensionsHtml
       .replace('<extensions-header/>', '<h2>Extensions defined as part of this Implementation Guide</h2>');
-    }
+  }
 
   fs.writeFileSync(extensionsHtmlPath, updatedExtensionsHtml, 'utf8');
 
   // Rewrite the updated ValueSets HTML file
   const valueSetsHtmlPath = path.join(outDir, 'pages', 'valuesets.html');
   const valueSetsHtml = fs.readFileSync(valueSetsHtmlPath, 'utf8');
-  fs.writeFileSync(valueSetsHtmlPath, valueSetsHtml.replace('<valueSets-go-here/>', htmlValueSets.join(''))
-                                                   .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedValueSetsHtml = valueSetsHtml.replace('<valueSets-go-here/>', htmlValueSets.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+  if (hideSupporting) {
+    updatedValueSetsHtml = updatedValueSetsHtml
+      .replace('<value-sets-header/>', '<h2>Primary Value Sets defined as part of this Implementation Guide</h2>');
+  } else {
+    updatedValueSetsHtml = updatedValueSetsHtml
+      .replace('<value-sets-header/>', '<h2>Value Sets defined as part of this Implementation Guide</h2>');
+  }
+
+  fs.writeFileSync(valueSetsHtmlPath, updatedValueSetsHtml, 'utf8');
 
   // Rewrite the updated CodeSystems HTML file
   const codeSystemsHtmlPath = path.join(outDir, 'pages', 'codesystems.html');
   const codeSystemsHtml = fs.readFileSync(codeSystemsHtmlPath, 'utf8');
-  fs.writeFileSync(codeSystemsHtmlPath, codeSystemsHtml.replace('<codeSystems-go-here/>', htmlCodeSystems.join(''))
-                                                       .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
+  let updatedCodeSystemsHtml = codeSystemsHtml.replace('<codeSystems-go-here/>', htmlCodeSystems.join(''))
+    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+
+  if (hideSupporting) {
+    updatedCodeSystemsHtml = updatedCodeSystemsHtml
+      .replace('<code-systems-header/>', '<h2>Primary Code Systems defined as part of this Implementation Guide</h2>');
+  } else {
+    updatedCodeSystemsHtml = updatedCodeSystemsHtml
+      .replace('<code-systems-header/>', '<h2>Code Systems defined as part of this Implementation Guide</h2>');
+  }
+
+  fs.writeFileSync(codeSystemsHtmlPath, updatedCodeSystemsHtml, 'utf8');
 
   // Rewrite the updated Models HTML file
   const modelsHtmlPath = path.join(outDir, 'pages', 'logical.html');

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -363,19 +363,23 @@ ${match[1]}
   fs.writeFileSync(modelsHtmlPath, modelsHtml.replace('<primary-models-go-here/>', htmlPrimaryModels.join(''))
                                              .replace('<support-models-go-here/>', htmlSupportModels.join(''))
                                              .replace('<project-shorthand-go-here/>', config.projectShorthand), 'utf8');
-  if (!config.implementationGuide.includeLogicalModels || !config.implementationGuide.includeModelDoc) {
-    const navbarPath = path.join(outDir, 'pages', '_includes', 'navbar.html');
-    let navbarHtml = fs.readFileSync(navbarPath, 'utf8');
-    if (!config.implementationGuide.includeLogicalModels) {
-      const modelsItem = '<li><a href="logical.html">Logical Models</a></li>';
-      navbarHtml = navbarHtml.replace(modelsItem, '<!-- no logical models -->');
-    }
-    if (!config.implementationGuide.includeModelDoc) {
-      const browserItem = '<li><a href="modeldoc/index.html" target="_blank">Reference Model</a></li>';
-      navbarHtml = navbarHtml.replace(browserItem, '<!-- no reference model -->');
-    }
-    fs.writeFileSync(navbarPath, navbarHtml);
+  const navbarPath = path.join(outDir, 'pages', '_includes', 'navbar.html');
+  let navbarHtml = fs.readFileSync(navbarPath, 'utf8');
+  if (!config.implementationGuide.includeLogicalModels) {
+    const modelsItem = '<li><a href="logical.html">Logical Models</a></li>';
+    navbarHtml = navbarHtml.replace(modelsItem, '<!-- no logical models -->');
   }
+  if (!config.implementationGuide.includeModelDoc) {
+    const browserItem = '<li><a href="modeldoc/index.html" target="_blank">Reference Model</a></li>';
+    navbarHtml = navbarHtml.replace(browserItem, '<!-- no reference model -->');
+  }
+  const historyItem = '<history-link-goes-here/>';
+  if (config.implementationGuide.historyLink && config.implementationGuide.historyLink.trim().length > 0) {
+    navbarHtml = navbarHtml.replace(historyItem, `<li><a href="${config.implementationGuide.historyLink.trim()}">History</a></li>`);
+  } else {
+    navbarHtml = navbarHtml.replace(historyItem, '');
+  }
+  fs.writeFileSync(navbarPath, navbarHtml);
 }
 
 function markdownifiedText(text) {

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -213,7 +213,7 @@ ${match[1]}
         && element.binding.valueSetReference.reference) {
           primaryValueSetUrls.add(element.binding.valueSetReference.reference);
         }
-  
+
         if (element.path.endsWith('.system')
         && element.fixedUri) {
           primaryCodeSystemUrls.add(element.fixedUri);
@@ -253,7 +253,7 @@ ${match[1]}
       const inNamespace = config.implementationGuide.primarySelectionStrategy.primary.some((p) => {
         return valueSet.identifier.some((i) => {
           return i.value.startsWith(p);
-        })  
+        })
       });
       if (inNamespace) {
         primaryValueSetUrls.add(valueSet.url);
@@ -519,39 +519,11 @@ ${match[1]}
 }
 
 function markdownifiedText(text) {
-  return `{% capture md_text %}${text}{% endcapture %}{{ md_text | markdownify }}`;
-}
-
-/* COMMENTED OUT BECAUSE WE MAY INTRODUCE IN NEAR-FUTURE.  IF IT'S AFTER JUL 1 2018 AND YOU STILL SEE THIS, DELETE IT!
-
-function getNamespaceFromID(id, config) {
-  const matches = /^(([a-z][^-]*-)+)([A-Z].*)$/.exec(id);
-  if (matches) {
-    let parts = matches[1].split('-').filter(s => s.length);
-    if (parts[0].toLowerCase() === config.projectShorthand) {
-      parts = parts.slice(1);
-    } else if (parts[0] === 'shr') {
-      parts[0] = 'SHR';
-    }
-    return parts.map(s => common.capitalize(s)).join(' ');
+  if (text != null) {
+    return `{% capture md_text %}${text}{% endcapture %}{{ md_text | markdownify }}`;
   }
   return '';
 }
-
-const PRIMITIVE_PREFIX = 'primitive-';
-
-function byID(a, b) {
-  if (a.id.startsWith(PRIMITIVE_PREFIX) !== b.id.startsWith(PRIMITIVE_PREFIX)) {
-    return a.id.startsWith(PRIMITIVE_PREFIX) ? 1 : -1;
-  } else if (a.id < b.id) {
-    return -1;
-  } else if (a.id > b.id) {
-    return 1;
-  }
-  return 0;
-}
-
-*/
 
 function byName(a, b) {
   if (a.name < b.name) {

--- a/lib/ig_files/ig.json
+++ b/lib/ig_files/ig.json
@@ -1,8 +1,8 @@
 {
   "source": "ig.xml",
   "version": "3.0.1",
-  "fixed-business-version": "0.1.0",
-  "license" :  "cc0-1.0",
+  "fixed-business-version": "TBD",
+  "license" :  "CC0-1.0",
   "paths": {
     "resources": [
       "resources"
@@ -14,16 +14,17 @@
     "qa": "qa",
     "specification": "http://hl7.org/fhir/STU3/"
   },
-  "npm-name": "us-breastcancer",
+  "npm-name": "TBD",
   "sct-edition": "http://snomed.info/sct/731000124108",
   "gen-examples": "false",
   "do-transforms": "false",
-  "canonicalBase": "<ig-url-go-here>",
+  "canonicalBase": "TBD",
   "dependencyList": [
     {
-       "name" : "USCore",
-       "location" : "http://hl7.org/fhir/us/core/1.0.1",
-       "source": "uscore"
+       "name" : "uscore",
+       "location" : "http://hl7.org/fhir/us/core",
+       "source": "uscore",
+       "version": "1.0.1"
     }
   ],
   "defaults": {

--- a/lib/ig_files/pages/_includes/footer.html
+++ b/lib/ig_files/pages/_includes/footer.html
@@ -10,8 +10,8 @@
    <div class="inner-wrapper">
     <p>
       {% comment %}strip "FHIR Profiles" off end{% endcomment %}
-      {{site.data.fhir.igName | append: "EOS" | remove: " FHIR ProfilesEOS"}}, Version: {{ site.data.fhir.ig.version }} &copy;
-      ; <a style="color: #81BEF7" href="{{ site.data.fhir.path }}">FHIR Version: {{ site.data.fhir.version }}</a> (IG Publisher v{{site.data.fhir.versionFull}})
+      {{site.data.fhir.igName | append: "EOS" | remove: " FHIR ProfilesEOS"}}, Version: {{ site.data.fhir.ig.version }}
+      ; <a style="color: #81BEF7" href="{{ site.data.fhir.path }}">FHIR &copy; Version: {{ site.data.fhir.version }}</a>
       ; Generated on {{site.data.fhir.genDate}}.
     </p>
    </div>  <!-- /inner-wrapper -->

--- a/lib/ig_files/pages/_includes/navbar.html
+++ b/lib/ig_files/pages/_includes/navbar.html
@@ -47,6 +47,7 @@
             <li><a href="codesystems.html">Code Systems</a></li>
             <li><a href="downloads.html">Downloads</a></li>
             <li><a href="modeldoc/index.html" target="_blank">Reference Model</a></li>
+            <history-link-goes-here/>
           </ul>
 
         </div>

--- a/lib/ig_files/pages/codesystems.html
+++ b/lib/ig_files/pages/codesystems.html
@@ -21,9 +21,7 @@
 
 <!-- ============CONTENT CONTENT=============== -->
 
-<h2>
-  Code Systems defined as part of this Implementation Guide
-</h2>
+<code-systems-header/>
 
 <table class="codes">
   <thead>

--- a/lib/ig_files/pages/downloads.html
+++ b/lib/ig_files/pages/downloads.html
@@ -23,7 +23,6 @@
 
 <h3>Downloads</h3>
 <ul>
-  <li><a href="full-ig.zip">Full IG [ZIP]</a></li>
   <li><a href="definitions.json.zip">JSON Definitions [ZIP]</a></li>
   <li><a href="examples.json.zip">JSON Examples [ZIP]</a></li>
   <li><a href="definitions.xml.zip">XML Definitions [ZIP]</a></li>

--- a/lib/ig_files/pages/extensions.html
+++ b/lib/ig_files/pages/extensions.html
@@ -21,9 +21,7 @@
 
 <!-- ============CONTENT CONTENT=============== -->
 
-<h2>
-  Extensions defined as part of this Implementation Guide
-</h2>
+<extensions-header/>
 <table class="codes">
   <thead>
     <tr>

--- a/lib/ig_files/pages/extensions.html
+++ b/lib/ig_files/pages/extensions.html
@@ -22,6 +22,7 @@
 <!-- ============CONTENT CONTENT=============== -->
 
 <extensions-header/>
+
 <table class="codes">
   <thead>
     <tr>

--- a/lib/ig_files/pages/logical.html
+++ b/lib/ig_files/pages/logical.html
@@ -40,10 +40,10 @@
   </tbody>
 </table>
 
-<h2>
+<h2 id="supporting-models-header">
   Supporting logical models defined as part of this Implementation Guide
 </h2>
-<table class="codes">
+<table id="supporting-models-table" class="codes">
   <thead>
     <tr>
       <td>

--- a/lib/ig_files/pages/profiles.html
+++ b/lib/ig_files/pages/profiles.html
@@ -43,10 +43,10 @@
   </tbody>
 </table>
 
-<h2>
+<h2 id="supporting-profiles-header">
   Supporting profiles defined as part of this Implementation Guide
 </h2>
-<table class="codes">
+<table id="supporting-profiles-table" class="codes">
   <thead>
     <tr>
       <td>

--- a/lib/ig_files/pages/valuesets.html
+++ b/lib/ig_files/pages/valuesets.html
@@ -21,9 +21,7 @@
 
 <!-- ============CONTENT CONTENT=============== -->
 
-<h2>
-  Value Sets defined as part of this Implementation Guide
-</h2>
+<value-sets-header/>
 
 <table class="codes">
   <thead>

--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -31,6 +31,10 @@ class ElementDefinition {
     this._id = id;
     // After setting the id, we should re-set the path, which is based on the id
     this._path = this._id.split('.').map(s => /^[^:]*/.exec(s)[0]).join('.');
+    // If the base was explicitly set, we need to set the path there too
+    if (this._base != null) {
+      this._base.path = this._path;
+    }
   }
 
   /**
@@ -656,12 +660,12 @@ class ElementDefinition {
 
   /**
    * Finds and returns all child elements of this element.  For example, the children of `Foo.bar` might be the
-   * elements `Foo.bar.one` and `Foo.bar.two`.  This will not "expand" or "unroll" elements; it only returns those
-   * child elements that already exist in the structure definition.
+   * elements `Foo.bar.one`, `Foo.bar.two`, and `Foo.bar.two.a`.  This will not "expand" or "unroll" elements; it
+   * only returns those child elements that already exist in the structure definition.
    * @returns {ElementDefinition[]} the child elements of this element
    */
   children() {
-    // TODO: this has a bug in that children of choice ([x]) elements won't be properly identifier if the choice
+    // TODO: this has a bug in that children of choice ([x]) elements won't be properly identified if the choice
     // was expanded.  Don't fix for now, however, as we need to tag this code as-is since it is what produced the
     // balloted logical models for the BreastCancer IG.
     return this.structDef.elements.filter(e => {
@@ -721,18 +725,34 @@ class ElementDefinition {
           if (!rootEl) {
             return;
           }
-          const newElements = def.elements.slice(1).map(e => {
-            const eClone = e.clone();
-            eClone.id = eClone.id.replace(def.type, `${this.id}`);
-            eClone.structDef = this.structDef;
-            return eClone;
-          });
-          this.structDef.addElements(newElements);
+          this.unfold(resolve);
           return this.findChild(path, resolve);
         }
       }
-
     }
+  }
+
+  /**
+   * If the element has a single type, graft the type's elements into this StructureDefinition as child elements.
+   * @param {function({code: string, profile?: string, targetProfile?: string, aggregation?: string[], versioning?: string})} resolve - a function that can resolve a type to a StructureDefinition instance
+   * @returns {ElementDefinition[]} the unfolded elements or an empty array if the type is multi-value or type can't
+   *   be resolved.
+   */
+  unfold(resolve = (arg) => null) {
+    if (this.type.length === 1) {
+      const def = resolve(this.type[0]);
+      if (def) {
+        const newElements = def.elements.slice(1).map(e => {
+          const eClone = e.clone();
+          eClone.id = eClone.id.replace(def.type, `${this.id}`);
+          eClone.structDef = this.structDef;
+          return eClone;
+        });
+        this.structDef.addElements(newElements);
+        return newElements;
+      }
+    }
+    return [];
   }
 
   /**
@@ -872,7 +892,7 @@ class ElementDefinition {
   }
 
   /**
-   * Removes this element, and optionally its childre, from its StructureDefinition so it is no longer recognized as an
+   * Removes this element, and optionally its children, from its StructureDefinition so it is no longer recognized as an
    * element of the StructureDefinition.
    * @param {boolean} [detachChildren=true] - indicates if this element's children should also be detached from the
    *   StructureDefinition

--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -34,7 +34,7 @@ class ElementDefinition {
     // After setting the id, we should re-set the path, which is based on the id
     this._path = this._id.split('.').map(s => /^[^:]*/.exec(s)[0]).join('.');
     // If the base was explicitly set, we need to set the path there too
-    if (this._base != null) {
+    if (this._base != null && this._base.path.startsWith(`${this.structDef.type}.`)) {
       this._base.path = this._path;
     }
   }

--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -471,7 +471,7 @@ class ElementDefinition {
         coding.sliceIt('value', 'code');
         const slice = coding.newSlice(`Fixed_${code.code}`); // TODO: use symbolized version of display if it's there?
         if (code.display) {
-          slice.short = slice.definition = code.display;
+          slice.short = slice.definition = common.trim(code.display);
         } else {
           slice.short = slice.definition = `Code: ${code.code}${code.system ? ' from ' + code.system : ''}`;
         }
@@ -500,12 +500,12 @@ class ElementDefinition {
         codingCode.fixedCode = code.code;
       }
       if (code.display) {
-        this.short = this.definition = code.display;
+        this.short = this.definition = common.trim(code.display);
       }
     } else if (this.type.some(t => t.code === 'code')) {
       this.fixedCode = code.code;
       if (code.display) {
-        this.short = this.definition = code.display;
+        this.short = this.definition = common.trim(code.display);
       }
     } else {
       // Not something we can fix a code on
@@ -569,7 +569,7 @@ class ElementDefinition {
     slice.min = 1;
     slice.max = '1';
     if (code.display) {
-      slice.short = slice.definition = code.display;
+      slice.short = slice.definition = common.trim(code.display);
     } else {
       slice.short = slice.definition = `Code: ${code.code}${code.system ? ' from ' + code.system : ''}`;
     }

--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -3,6 +3,8 @@ const cloneDeep = require('lodash/cloneDeep');
 const escapeRegExp = require('lodash/escapeRegExp');
 const common = require('../common');
 
+/** @typedef {import('./StructureDefinition')} StructureDefinition */
+
 /**
  * A class representing a FHIR ElementDefinition.  For the most part, each allowable property in an ElementDefinition
  * is represented via a get/set in this class, and the value is expected to be the FHIR-compliant JSON that would go
@@ -270,11 +272,11 @@ class ElementDefinition {
   set condition(condition) { this._condition = condition; }
 
   /**
-   * @returns {{key: string, requirements?: string, severity: string, human: string, expression: string, xpath?: string, source?: string}} constraint
+   * @returns {{key: string, requirements?: string, severity: string, human: string, expression: string, xpath?: string, source?: string}[]} constraint
    */
   get constraint() { return this._constraint; }
   /**
-   * @param {{key: string, requirements?: string, severity: string, human: string, expression: string, xpath?: string, source?: string}} constraint
+   * @param {{key: string, requirements?: string, severity: string, human: string, expression: string, xpath?: string, source?: string}[]} constraint
    */
   set constraint(constraint) { this._constraint = constraint; }
 
@@ -324,11 +326,11 @@ class ElementDefinition {
   set mapping(mapping) { this._mapping = mapping; }
 
   /**
-   * @returns {Object} structDef
+   * @returns {StructureDefinition} structDef
    */
   get structDef() { return this._structDef; }
   /**
-   * @param {Object} structDef
+   * @param {StructureDefinition} structDef
    */
   set structDef(structDef) { this._structDef = structDef; }
 

--- a/lib/logical/StructureDefinition.js
+++ b/lib/logical/StructureDefinition.js
@@ -444,6 +444,7 @@ class StructureDefinition {
     if (json.snapshot && json.snapshot.element) {
       for (const el of json.snapshot.element) {
         const ed = ElementDefinition.fromJSON(el);
+        // @ts-ignore
         ed.structDef = this;
         sd.elements.push(ed);
       }

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -1,5 +1,6 @@
 const bunyan = require('bunyan');
 const mdls = require('shr-models');
+const escapeRegExp = require('lodash/escapeRegExp');
 const isEqual = require('lodash/isEqual');
 const uniqWith = require('lodash/uniqWith');
 const common = require('../common');
@@ -916,7 +917,7 @@ class ModelsExporter {
    * - they cannot be a choice type
    * - they cannot be a reference
    * - they cannot be sliced or a slice
-   * - their type must be single-value (no fields)
+   * - their type must be single-value (no fields) or they must be a backbone element with one direct value child
    * @param {ElementDefinition} element - the element to check if it is compactable
    * @param {Map<string, boolean>} singleValueMap - a map with keys representing the URLs of single-value models
    */
@@ -936,6 +937,13 @@ class ModelsExporter {
     // Don't compact sliced elements or their slices since it's important for slice types to remain compatible
     if (element.slicing != null || element.sliceName != null) {
       return false;
+    }
+    // If it's a BackboneElement, then its compactable if it has one direct child element and that
+    // child's name starts w/ value.
+    if (element.type[0].code === 'BackboneElement') {
+      const directChildren = element.children().filter(e => e.id.lastIndexOf('.') === element.id.length);
+      const re = new RegExp(`^${escapeRegExp(element.id)}\.value([A-Z][^.]*)?$`);
+      return directChildren.length === 1 && re.test(directChildren[0].id);
     }
     // It's compactable if it is a single-value element
     return singleValueMap.has(element.type[0].code);

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -5,6 +5,8 @@ const uniqWith = require('lodash/uniqWith');
 const common = require('../common');
 const StructureDefinition = require('./StructureDefinition');
 
+/** @typedef {import('./ElementDefinition')} ElementDefinition */
+
 // Constants used in various places throughout the code
 const CODEABLE_CONCEPT_ID = new mdls.Identifier('shr.core', 'CodeableConcept');
 const CODING_ID = new mdls.Identifier('shr.core', 'Coding');
@@ -53,6 +55,14 @@ class ModelsExporter {
       }
     }
 
+    // Compact the models if the config specifies
+    if (this._config.implementationGuide.compactModels) {
+      this.compactModels();
+    }
+
+    // Last step: clear out all of the aliases since they were only needed for processing
+    this.clearAliases();
+
     return this.models;
   }
 
@@ -98,18 +108,6 @@ class ModelsExporter {
       }
       for (const field of def.fields) {
         this.addElement(model, field, false);
-      }
-
-      // The publisher requires each structure to have at least one field, so add a dummy field if necessary
-      if (model.elements.length === 1) {
-        const dummy = model.newElement('intentionallyBlank');
-        dummy.short = 'Workaround for limitation in IG publisher: StructureDefinitions must have at least one field';
-        dummy.definition = dummy.short;
-        dummy.min = 0;
-        dummy.max = '0';
-        dummy.mustSupport = false;
-        dummy.isModifier = false;
-        dummy.isSummary = false;
       }
 
       this._modelsMap.set(model.id, model);
@@ -812,6 +810,143 @@ class ModelsExporter {
       return StructureDefinition.fromJSON(def);
     }
     return def;
+  }
+
+  /**
+   * Clears all of the aliases from the structure definitions, as they're not needed post-processing.
+   */
+  clearAliases() {
+    for (const model of this._modelsMap.values()) {
+      for (const element of model.elements) {
+        element.alias = undefined;
+      }
+    }
+  }
+
+  /**
+   * Compacts the models to simpler representations. In order to reduce complexity while allowing for both compact and
+   * non-compact representations (based on configuration), the model simplification is performed as a post-process,
+   * allowing all other code to remain as-is.
+   * @see #compactModel
+   */
+  compactModels() {
+    // First build up a map containing the URLs of all single-value models.  These are the model references that will
+    // be replaced by their values during the compaction process.
+    const singleValueMap = new Map();
+    for (const element of this._specs.dataElements.all) {
+      if (element.value != null && element.fields.length === 0) {
+        singleValueMap.set(common.fhirURL(element.identifier, this._config.fhirURL, 'model'), true);
+      }
+    }
+
+    // Now iterate through all the models, compacting one at a time
+    for (const model of this._modelsMap.values()) {
+      this.compactModel(model, singleValueMap);
+    }
+  }
+
+  /**
+   * Compacts the model to a simpler representations.  This removes indirection introduced by single-value models.
+   * For example, if a model has a field called `foo` that is a `FooModel`, but `FooModel` only has a single `value`
+   * field of type `string`, the the `foo` field will be simplified to take on the type of `string` rather than
+   * `FooModel`.
+   * @param {StructureDefinition} model - the model to compact
+   * @param {Map<string, boolean>} singleValueMap - a map with keys representing the URLs of single-value models
+   */
+  compactModel(model, singleValueMap) {
+    for (let i=0; i < model.elements.length; i++) {
+      const element = model.elements[i];
+      if (!this.elementIsCompactable(element, singleValueMap)) {
+        continue;
+      }
+      // It can be compacted.  Get the child element(s) and pop them up a level!
+      let children = element.children();
+      if (children.length === 0) {
+        children = element.unfold(this.resolve.bind(this));
+      }
+      // If there are no children then there's nothing to replace the element with.  This may happen with elements
+      // that are just marker base classes.
+      if (children.length === 0) {
+        continue;
+      }
+      const child = children[0];
+      // Update the child short and definition to reflect the element's short and definition
+      child.definition = element.definition;
+      child.short = element.short;
+      // Update the child min/max to reflect the aggregate min/max
+      child.min = element.min * child.min;
+      if (child.max !== '*') {
+        child.max = element.max === '*' ? '*' : `${parseInt(element.max) * parseInt(child.max)}`;
+      }
+      // Update the child base as appropriate
+      if (child.base.min !== child.min || child.base.max !== child.max) {
+        child.base = {
+          path: child.base.path,
+          min: child.min,
+          max: child.max
+        };
+      }
+      // Update the code as appropriate
+      if (element.code && element.code.length > 0) {
+        if (child.code == null) {
+          child.code = element.code;
+        } else {
+          for (const c of element.code) {
+            if (child.code.every(c2 => c.code != c2.code || c.system != c2.system)) {
+              child.code.push(c);
+            }
+          }
+        }
+      }
+      // Update child flags as appropriate
+      if (element.mustSupport) {
+        child.mustSupport = true;
+      }
+      if (element.isModifier) {
+        child.isModifier = true;
+      }
+      if (element.isSummary) {
+        child.isSummary = true;
+      }
+      // Update all the children w/ the new id root
+      const originalId = child.id;
+      children.forEach(el => el.id = el.id.replace(originalId, element.id));
+      // Detach the old element
+      element.detach(false);
+      // Since it was compacted, it's possible it could be compacted more! Rewind i so we repeat this element again.
+      i = i-1;
+    }
+  }
+
+  /**
+   * Checks if the given element is compactable -- meaning it can be replaced by its value.  Elements must meet the
+   * following conditions to be compactable:
+   * - they cannot be a choice type
+   * - they cannot be a reference
+   * - they cannot be sliced or a slice
+   * - their type must be single-value (no fields)
+   * @param {ElementDefinition} element - the element to check if it is compactable
+   * @param {Map<string, boolean>} singleValueMap - a map with keys representing the URLs of single-value models
+   */
+  elementIsCompactable(element, singleValueMap) {
+    // Don't compact choice elements. This is partly to keep this simple to implement, but also to avoid the following
+    // potential issues:
+    // - Compacting a type in a choice may lose its context (i.e., there is nowhere to put the original definition)
+    // - Compacting multiple types in a choice may introduce duplicate types w/ conflicting constraints
+    if (element.type == null || element.type.length > 1) {
+      return false;
+    }
+    // Don't compact references, as that would require references to standalone instances that would now be devoid of
+    // the context that their wrapping type provided.
+    if (element.type[0].code === 'Reference') {
+      return false;
+    }
+    // Don't compact sliced elements or their slices since it's important for slice types to remain compatible
+    if (element.slicing != null || element.sliceName != null) {
+      return false;
+    }
+    // It's compactable if it is a single-value element
+    return singleValueMap.has(element.type[0].code);
   }
 }
 

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -869,10 +869,11 @@ class ModelsExporter {
       if (child.max !== '*') {
         child.max = element.max === '*' ? '*' : `${parseInt(element.max) * parseInt(child.max)}`;
       }
-      // Update the child base as appropriate
-      if (child.base.min !== child.min || child.base.max !== child.max) {
+      // Update the child base as appropriate.  Don't update base if it came from another resource/datatype.
+      const basePathRoot = child.base.path.split('.', 2)[0];
+      if (basePathRoot.endsWith('-model') && (basePathRoot !== model.type || child.base.min !== child.min || child.base.max !== child.max)) {
         child.base = {
-          path: child.base.path,
+          path: child.path,
           min: child.min,
           max: child.max
         };

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -213,7 +213,7 @@ class ModelsExporter {
    * StructureDefinition element (or its children, as appropriate).
    * @param {StructureDefinition} model - the StructureDefinition to which to apply the constraints
    * @param {Object} value - the SHR Value object potentiall containing constraints to be applied
-   * @param {Object} el - the ElementDefinition associated with the SHR Value object
+   * @param {ElementDefinition} el - the ElementDefinition associated with the SHR Value object
    */
   applyConstraints(model, value, el) {
     // First apply the type constraints and includes type constraints because they build
@@ -319,9 +319,8 @@ class ModelsExporter {
    * a sub-path.
    * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
    * @param {Object} value - the SHR Value object that defined this constraint
-   * @param {Object} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
    * @param {Object} constraint - the constraint to apply
-   * @returns {Object} the ElementDefinition to which this constraint was applied
    */
   applyValueSetConstraint(model, value, el, constraint) {
     // TODO: Some of this code is copied from profile exporter.  We should consolidate when appropriate.
@@ -353,9 +352,8 @@ class ModelsExporter {
    * a sub-path.
    * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
    * @param {Object} value - the SHR Value object that defined this constraint
-   * @param {Object} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
    * @param {Object} constraint - the constraint to apply
-   * @returns {Object} the ElementDefinition to which this constraint was applied
    */
   applyCodeConstraint(model, value, el, constraint) {
     el.fixCode(constraint.code, this.shrPathToFhirPath(value, constraint.path), this.resolve.bind(this));
@@ -366,9 +364,8 @@ class ModelsExporter {
    * a sub-path.
    * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
    * @param {Object} value - the SHR Value object that defined this constraint
-   * @param {Object} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
    * @param {Object} constraint - the constraint to apply
-   * @returns {Object} the ElementDefinition to which this constraint was applied
    */
   applyBooleanConstraint(model, value, el, constraint) {
     el.fixBoolean(constraint.value, this.shrPathToFhirPath(value, constraint.path), this.resolve.bind(this));
@@ -379,9 +376,8 @@ class ModelsExporter {
    * a sub-path.
    * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
    * @param {Object} value - the SHR Value object that defined this constraint
-   * @param {Object} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
    * @param {Object} constraint - the constraint to apply
-   * @returns {Object} the ElementDefinition to which this constraint was applied
    */
   applyCardConstraint(model, value, el, constraint) {
     el.modifyCard(constraint.card.min, constraint.card.max, this.shrPathToFhirPath(value, constraint.path), this.resolve.bind(this));
@@ -394,9 +390,8 @@ class ModelsExporter {
    * because these logical models don't support true inheritance.
    * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
    * @param {Object} value - the SHR Value object that defined this constraint
-   * @param {Object} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
    * @param {Object} constraint - the constraint to apply
-   * @returns {Object} the ElementDefinition to which this constraint was applied
    */
   applyTypeConstraint(model, value, el, constraint) {
     if (!constraint.onValue && (constraint.path == null || constraint.path.length == 0)) {
@@ -462,7 +457,7 @@ class ModelsExporter {
         if (currentEl.alias == null) {
           currentEl.alias = [];
         }
-        if (!currentEl.alias.includes(shortName)) {
+        if (currentEl.alias.indexOf(shortName) === -1) {
           currentEl.alias.push(shortName);
         }
       }
@@ -494,9 +489,8 @@ class ModelsExporter {
    * don't support true inheritance.
    * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
    * @param {Object} value - the SHR Value object that defined this constraint
-   * @param {Object} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
    * @param {Object} constraint - the constraint to apply
-   * @returns {Object} the ElementDefinition to which this constraint was applied
    */
   applyIncludesTypeConstraint(model, value, el, constraint) {
     // For IncludesType constraints, we must make the value a "section header" (no type) instead.  This is
@@ -629,9 +623,8 @@ class ModelsExporter {
    * paths in logical models.
    * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
    * @param {Object} value - the SHR Value object that defined this constraint
-   * @param {Object} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
    * @param {Object} constraint - the constraint to apply
-   * @returns {Object} the ElementDefinition to which this constraint was applied
    */
   applyIncludesCodeConstraint(model, value, el, constraint) {
     // Unfortunately, we can't use the normal approach here since logical models don't allow paths to be repeated.

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -55,10 +55,8 @@ class ModelsExporter {
       }
     }
 
-    // Compact the models if the config specifies
-    if (this._config.implementationGuide.compactModels) {
-      this.compactModels();
-    }
+    // Compact the models
+    this.compactModels();
 
     // Last step: clear out all of the aliases since they were only needed for processing
     this.clearAliases();

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -132,7 +132,7 @@ class ModelsExporter {
     } else if (isValue) {
       const name = value instanceof mdls.ChoiceValue ? 'value[x]' : 'value';
       el = model.newElement(name);
-      const parentDescription = model.description ? common.lowerFirst(model.description) : 'the logical model instance';
+      const parentDescription = model.description ? common.lowerFirst(common.trim(model.description)) : 'the logical model instance';
       el.short = `${common.capitalize(common.valueName(value))} representing ${this.shortDescription(parentDescription)}`;
       el.definition = `${common.capitalize(common.valueName(value))} representing ${parentDescription}`;
       el.alias = this.aliases(value, false);
@@ -722,11 +722,11 @@ class ModelsExporter {
   getDescription(identifier, defaultText) {
     const def = this._specs.dataElements.findByIdentifier(identifier);
     let description;
-    if (def && def.description) {
-      description = def.description.trim();
+    if (def) {
+      description = common.trim(def.description);
     }
-    if (defaultText && (typeof description === 'undefined' || description == null || description == '')) {
-      description = defaultText.trim();
+    if (description == null || description == '') {
+      description = common.trim(defaultText);
     }
     return description;
   }
@@ -739,7 +739,7 @@ class ModelsExporter {
   getConcepts(identifier) {
     const def = this._specs.dataElements.findByIdentifier(identifier);
     if (def && def.concepts) {
-      return def.concepts.map(c => ({ system: c.system, code: c.code, display: c.display }));
+      return def.concepts.map(c => ({ system: c.system, code: c.code, display: common.trim(c.display) }));
     }
     return [];
   }

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -1,5 +1,7 @@
 const bunyan = require('bunyan');
 const mdls = require('shr-models');
+const isEqual = require('lodash/isEqual');
+const uniqWith = require('lodash/uniqWith');
 const common = require('../common');
 const StructureDefinition = require('./StructureDefinition');
 
@@ -783,7 +785,8 @@ class ModelsExporter {
       return [];
     } else if (value instanceof mdls.ChoiceValue) {
       const nonTBDs = value.aggregateOptions.filter(o => !(o instanceof mdls.TBD));
-      return nonTBDs.map(o => this.toSingleType(o));
+      // If the choice had CodeableConcept and Coding then it now has two Codings. This is bad, so uniq it.
+      return uniqWith(nonTBDs.map(o => this.toSingleType(o)), isEqual);
     }
     return [this.toSingleType(value)];
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.6.1",
+  "version": "5.7.0-beta.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.4",
+  "version": "5.7.0-beta.5",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-models": "^5.5.0",
-    "shr-test-helpers": "^5.2.0"
+    "shr-models": "^5.5.3",
+    "shr-test-helpers": "^5.2.2"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.5.0"
+    "shr-models": "^5.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.1",
+  "version": "5.7.0-beta.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.6",
+  "version": "5.7.0-beta.7",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.7",
+  "version": "5.7.0-beta.8",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.2",
+  "version": "5.7.0-beta.3",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.5",
+  "version": "5.7.0-beta.6",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.8",
+  "version": "5.7.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0-beta.3",
+  "version": "5.7.0-beta.4",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/test/fixtures/AbstractAndPlainGroup.json
+++ b/test/fixtures/AbstractAndPlainGroup.json
@@ -79,7 +79,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -107,7 +107,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Plain-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -154,7 +154,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -182,7 +182,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Plain-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -256,9 +256,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -299,9 +296,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -385,9 +379,6 @@
           "path": "shr-test-Plain-model.value",
           "short": "String representing it is not an entry element",
           "definition": "String representing it is not an entry element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -428,9 +419,6 @@
           "path": "shr-test-Plain-model.value",
           "short": "String representing it is not an entry element",
           "definition": "String representing it is not an entry element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/BooleanAndCodeConstraints.json
+++ b/test/fixtures/BooleanAndCodeConstraints.json
@@ -56,9 +56,6 @@
           "path": "shr-test-Bool-model.value",
           "short": "Boolean representing a boolean element.",
           "definition": "Boolean representing a boolean element.",
-          "alias": [
-            "boolean"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -99,9 +96,6 @@
           "path": "shr-test-Bool-model.value",
           "short": "Boolean representing a boolean element.",
           "definition": "Boolean representing a boolean element.",
-          "alias": [
-            "boolean"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -178,9 +172,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -227,9 +218,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -312,9 +300,6 @@
           "path": "shr-test-BooleanAndCodeConstraints-model.value",
           "short": "Boolean representing it has boolean and code constraints.",
           "definition": "Boolean representing it has boolean and code constraints.",
-          "alias": [
-            "boolean"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -346,30 +331,6 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-BooleanAndCodeConstraints-model.coded.value",
-          "path": "shr-test-BooleanAndCodeConstraints-model.coded.value",
-          "short": "Foobar",
-          "definition": "Foobar",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
               "code": "code"
             }
           ],
@@ -383,19 +344,18 @@
           "path": "shr-test-BooleanAndCodeConstraints-model.bool",
           "short": "A boolean element.",
           "definition": "A boolean element.",
-          "min": 1,
+          "min": 0,
           "max": "1",
           "base": {
             "path": "shr-test-BooleanAndCodeConstraints-model.bool",
-            "min": 1,
+            "min": 0,
             "max": "1"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Bool-model"
+              "code": "boolean"
             }
           ],
-          "fixedBoolean": false,
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
@@ -424,9 +384,6 @@
           "path": "shr-test-BooleanAndCodeConstraints-model.value",
           "short": "Boolean representing it has boolean and code constraints.",
           "definition": "Boolean representing it has boolean and code constraints.",
-          "alias": [
-            "boolean"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -458,30 +415,6 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-BooleanAndCodeConstraints-model.coded.value",
-          "path": "shr-test-BooleanAndCodeConstraints-model.coded.value",
-          "short": "Foobar",
-          "definition": "Foobar",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
               "code": "code"
             }
           ],
@@ -495,19 +428,18 @@
           "path": "shr-test-BooleanAndCodeConstraints-model.bool",
           "short": "A boolean element.",
           "definition": "A boolean element.",
-          "min": 1,
+          "min": 0,
           "max": "1",
           "base": {
             "path": "shr-test-BooleanAndCodeConstraints-model.bool",
-            "min": 1,
+            "min": 0,
             "max": "1"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Bool-model"
+              "code": "boolean"
             }
           ],
-          "fixedBoolean": false,
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
@@ -600,7 +532,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -621,16 +553,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -642,7 +587,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -689,7 +634,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -710,16 +655,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -731,7 +689,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -805,9 +763,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -848,9 +803,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -934,9 +886,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -946,7 +895,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -984,9 +933,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -996,7 +942,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -1070,9 +1016,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1082,7 +1025,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -1120,9 +1063,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1132,7 +1072,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -1206,9 +1146,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1249,9 +1186,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/Choice.json
+++ b/test/fixtures/Choice.json
@@ -66,11 +66,6 @@
           },
           "short": "Choice of types representing it is an element with a choice",
           "definition": "Choice of types representing it is an element with a choice",
-          "alias": [
-            "string",
-            "code",
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -155,11 +150,6 @@
           },
           "short": "Choice of types representing it is an element with a choice",
           "definition": "Choice of types representing it is an element with a choice",
-          "alias": [
-            "string",
-            "code",
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -270,9 +260,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -319,9 +306,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/ChoiceOfChoice.json
+++ b/test/fixtures/ChoiceOfChoice.json
@@ -66,12 +66,6 @@
           },
           "short": "Choice of types representing it is an element with a choice containing a choice",
           "definition": "Choice of types representing it is an element with a choice containing a choice",
-          "alias": [
-            "string",
-            "integer",
-            "decimal",
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -159,12 +153,6 @@
           },
           "short": "Choice of types representing it is an element with a choice containing a choice",
           "definition": "Choice of types representing it is an element with a choice containing a choice",
-          "alias": [
-            "string",
-            "integer",
-            "decimal",
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/ChoiceValueSetConstraint.json
+++ b/test/fixtures/ChoiceValueSetConstraint.json
@@ -56,10 +56,6 @@
           "path": "shr-test-CodedChoice-model.value[x]",
           "short": "Coded or code representing an element with a choice of code fields.",
           "definition": "Coded or code representing an element with a choice of code fields.",
-          "alias": [
-            "coded",
-            "code"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -103,10 +99,6 @@
           "path": "shr-test-CodedChoice-model.value[x]",
           "short": "Coded or code representing an element with a choice of code fields.",
           "definition": "Coded or code representing an element with a choice of code fields.",
-          "alias": [
-            "coded",
-            "code"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -184,27 +176,6 @@
         {
           "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
           "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
-          "short": "An element with a choice of code fields.",
-          "definition": "An element with a choice of code fields.",
-          "min": 0,
-          "max": "1",
-          "base": {
-            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
-            "min": 0,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-CodedChoice-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice.value[x]",
-          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.value[x]",
           "slicing": {
             "discriminator": [
               {
@@ -215,16 +186,12 @@
             "ordered": false,
             "rules": "open"
           },
-          "short": "Coded or code representing an element with a choice of code fields.",
-          "definition": "Coded or code representing an element with a choice of code fields.",
-          "alias": [
-            "coded",
-            "code"
-          ],
+          "short": "An element with a choice of code fields.",
+          "definition": "An element with a choice of code fields.",
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-CodedChoice-model.value[x]",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
             "min": 0,
             "max": "1"
           },
@@ -249,7 +216,7 @@
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-CodedChoice-model.value[x]",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode",
             "min": 0,
             "max": "1"
           },
@@ -290,27 +257,6 @@
         {
           "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
           "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
-          "short": "An element with a choice of code fields.",
-          "definition": "An element with a choice of code fields.",
-          "min": 0,
-          "max": "1",
-          "base": {
-            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
-            "min": 0,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-CodedChoice-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice.value[x]",
-          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.value[x]",
           "slicing": {
             "discriminator": [
               {
@@ -321,16 +267,12 @@
             "ordered": false,
             "rules": "open"
           },
-          "short": "Coded or code representing an element with a choice of code fields.",
-          "definition": "Coded or code representing an element with a choice of code fields.",
-          "alias": [
-            "coded",
-            "code"
-          ],
+          "short": "An element with a choice of code fields.",
+          "definition": "An element with a choice of code fields.",
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-CodedChoice-model.value[x]",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
             "min": 0,
             "max": "1"
           },
@@ -355,7 +297,7 @@
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-CodedChoice-model.value[x]",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode",
             "min": 0,
             "max": "1"
           },
@@ -434,9 +376,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -483,9 +422,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/Coded.json
+++ b/test/fixtures/Coded.json
@@ -56,9 +56,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -105,9 +102,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/ElementValue.json
+++ b/test/fixtures/ElementValue.json
@@ -63,9 +63,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -75,7 +72,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -113,9 +110,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -125,7 +119,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -199,9 +193,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -242,9 +233,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/FixedCodeExtravaganza.json
+++ b/test/fixtures/FixedCodeExtravaganza.json
@@ -56,9 +56,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -105,9 +102,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -200,10 +194,6 @@
           },
           "short": "Code or code representing an element with all sorts of fixed codes.",
           "definition": "Code or code representing an element with all sorts of fixed codes.",
-          "alias": [
-            "code",
-            "coding"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -288,10 +278,6 @@
           "short": "Additional Content defined by implementations",
           "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
           "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-          "alias": [
-            "extensions",
-            "user content"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -578,10 +564,6 @@
           "short": "Additional Content defined by implementations",
           "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
           "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-          "alias": [
-            "extensions",
-            "user content"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -790,30 +772,6 @@
           "max": "1",
           "base": {
             "path": "shr-test-FixedCodeExtravaganza-model.coded",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-FixedCodeExtravaganza-model.coded.value",
-          "path": "shr-test-FixedCodeExtravaganza-model.coded.value",
-          "short": "Foobar4",
-          "definition": "Foobar4",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
             "min": 1,
             "max": "1"
           },
@@ -861,10 +819,6 @@
           },
           "short": "Code or code representing an element with all sorts of fixed codes.",
           "definition": "Code or code representing an element with all sorts of fixed codes.",
-          "alias": [
-            "code",
-            "coding"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -949,10 +903,6 @@
           "short": "Additional Content defined by implementations",
           "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
           "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-          "alias": [
-            "extensions",
-            "user content"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -1239,10 +1189,6 @@
           "short": "Additional Content defined by implementations",
           "definition": "May be used to represent additional information that is not part of the basic definition of the element. In order to make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
           "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-          "alias": [
-            "extensions",
-            "user content"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -1451,30 +1397,6 @@
           "max": "1",
           "base": {
             "path": "shr-test-FixedCodeExtravaganza-model.coded",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-FixedCodeExtravaganza-model.coded.value",
-          "path": "shr-test-FixedCodeExtravaganza-model.coded.value",
-          "short": "Foobar4",
-          "definition": "Foobar4",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
             "min": 1,
             "max": "1"
           },
@@ -1548,9 +1470,6 @@
           "path": "shr-core-CodeSystem-model.value",
           "short": "Uri representing the logical model instance",
           "definition": "Uri representing the logical model instance",
-          "alias": [
-            "uri"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1592,9 +1511,6 @@
           "path": "shr-core-CodeSystem-model.value",
           "short": "Uri representing the logical model instance",
           "definition": "Uri representing the logical model instance",
-          "alias": [
-            "uri"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1671,9 +1587,6 @@
           "path": "shr-core-CodeSystemVersion-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1715,9 +1628,6 @@
           "path": "shr-core-CodeSystemVersion-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1794,9 +1704,6 @@
           "path": "shr-core-DisplayText-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1838,9 +1745,6 @@
           "path": "shr-core-DisplayText-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/ForeignElementValue.json
+++ b/test/fixtures/ForeignElementValue.json
@@ -63,9 +63,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -75,7 +72,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -113,9 +110,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -125,7 +119,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -199,9 +193,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -242,9 +233,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/ForeignSimple.json
+++ b/test/fixtures/ForeignSimple.json
@@ -63,9 +63,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -106,9 +103,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/Group.json
+++ b/test/fixtures/Group.json
@@ -84,7 +84,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -105,16 +105,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -126,7 +139,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -173,7 +186,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -194,16 +207,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -215,7 +241,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -289,9 +315,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -332,9 +355,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -411,9 +431,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -460,9 +477,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -552,9 +566,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -564,7 +575,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -602,9 +613,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -614,7 +622,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -688,9 +696,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -700,7 +705,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -738,9 +743,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -750,7 +752,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -824,9 +826,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -867,9 +866,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/GroupWithChoiceOfChoice.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.json
@@ -56,11 +56,6 @@
           "path": "shr-test-GroupWithChoiceOfChoice-model.value[x]",
           "short": "Choice of types representing it is a group of elements with a choice containing a choice",
           "definition": "Choice of types representing it is a group of elements with a choice containing a choice",
-          "alias": [
-            "simple",
-            "foreignElementValue",
-            "elementValue"
-          ],
           "min": 0,
           "max": "2",
           "base": {
@@ -104,7 +99,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -125,12 +120,18 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         }
       ]
     },
@@ -156,11 +157,6 @@
           "path": "shr-test-GroupWithChoiceOfChoice-model.value[x]",
           "short": "Choice of types representing it is a group of elements with a choice containing a choice",
           "definition": "Choice of types representing it is a group of elements with a choice containing a choice",
-          "alias": [
-            "simple",
-            "foreignElementValue",
-            "elementValue"
-          ],
           "min": 0,
           "max": "2",
           "base": {
@@ -204,7 +200,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -225,12 +221,18 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         }
       ]
     }
@@ -299,9 +301,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -342,9 +341,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -421,9 +417,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -470,9 +463,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -562,9 +552,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -574,7 +561,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -612,9 +599,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -624,7 +608,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -698,9 +682,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -710,7 +691,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -748,9 +729,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -760,7 +738,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -834,9 +812,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -877,9 +852,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/IncludesCodeConstraints.json
+++ b/test/fixtures/IncludesCodeConstraints.json
@@ -56,9 +56,6 @@
           "path": "shr-test-IncludesCodesList-model.value",
           "short": "Code representing an entry with a includes codes constraint.",
           "definition": "Code representing an entry with a includes codes constraint.",
-          "alias": [
-            "codeableConcept"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -113,9 +110,6 @@
           "path": "shr-test-IncludesCodesList-model.value",
           "short": "Code representing an entry with a includes codes constraint.",
           "definition": "Code representing an entry with a includes codes constraint.",
-          "alias": [
-            "codeableConcept"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -206,9 +200,6 @@
           "path": "shr-core-CodeSystem-model.value",
           "short": "Uri representing the logical model instance",
           "definition": "Uri representing the logical model instance",
-          "alias": [
-            "uri"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -250,9 +241,6 @@
           "path": "shr-core-CodeSystem-model.value",
           "short": "Uri representing the logical model instance",
           "definition": "Uri representing the logical model instance",
-          "alias": [
-            "uri"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -329,9 +317,6 @@
           "path": "shr-core-CodeSystemVersion-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -373,9 +358,6 @@
           "path": "shr-core-CodeSystemVersion-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -452,9 +434,6 @@
           "path": "shr-core-DisplayText-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -496,9 +475,6 @@
           "path": "shr-core-DisplayText-model.value",
           "short": "String representing the logical model instance",
           "definition": "String representing the logical model instance",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/IncludesTypeConstraints.json
+++ b/test/fixtures/IncludesTypeConstraints.json
@@ -56,9 +56,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -99,9 +96,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -185,9 +179,6 @@
           ],
           "short": "Simple representing an entry with a includes types constraints.",
           "definition": "Simple representing an entry with a includes types constraints.",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -213,7 +204,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -234,7 +225,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -272,9 +263,6 @@
           ],
           "short": "Simple representing an entry with a includes types constraints.",
           "definition": "Simple representing an entry with a includes types constraints.",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -300,7 +288,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -321,7 +309,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -395,9 +383,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -438,9 +423,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -517,9 +499,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -560,9 +539,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/IncludesTypeConstraintsZeroedOut.json
+++ b/test/fixtures/IncludesTypeConstraintsZeroedOut.json
@@ -56,9 +56,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -99,9 +96,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -185,9 +179,6 @@
           ],
           "short": "Simple representing an entry with a includes types constraints.",
           "definition": "Simple representing an entry with a includes types constraints.",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -213,7 +204,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -251,9 +242,6 @@
           ],
           "short": "Simple representing an entry with a includes types constraints.",
           "definition": "Simple representing an entry with a includes types constraints.",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -279,7 +267,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -353,9 +341,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -396,9 +381,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -475,9 +457,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -518,9 +497,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/NestedCardConstraint.json
+++ b/test/fixtures/NestedCardConstraint.json
@@ -56,9 +56,6 @@
           "path": "shr-test-OptionalValue-model.value",
           "short": "String representing an element with an optional value.",
           "definition": "String representing an element with an optional value.",
-          "alias": [
-            "string"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -99,9 +96,6 @@
           "path": "shr-test-OptionalValue-model.value",
           "short": "String representing an element with an optional value.",
           "definition": "String representing an element with an optional value.",
-          "alias": [
-            "string"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -187,7 +181,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -227,7 +221,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -315,16 +309,16 @@
           "path": "shr-test-NestedCardConstraint-model.optionalField.optionalValue",
           "short": "An element with an optional value.",
           "definition": "An element with an optional value.",
-          "min": 1,
+          "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-OptionalField-model.optionalValue",
+            "path": "shr-test-NestedCardConstraint-model.optionalField.optionalValue",
             "min": 0,
             "max": "1"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -376,16 +370,16 @@
           "path": "shr-test-NestedCardConstraint-model.optionalField.optionalValue",
           "short": "An element with an optional value.",
           "definition": "An element with an optional value.",
-          "min": 1,
+          "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-OptionalField-model.optionalValue",
+            "path": "shr-test-NestedCardConstraint-model.optionalField.optionalValue",
             "min": 0,
             "max": "1"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,

--- a/test/fixtures/NestedIncludesCodeConstraints.json
+++ b/test/fixtures/NestedIncludesCodeConstraints.json
@@ -56,9 +56,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -105,9 +102,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -190,53 +184,12 @@
           "path": "shr-test-NestedIncludesCodes-model.value",
           "short": "Coded representing an entry with a nested includes codes constraint.",
           "definition": "Coded representing an entry with a nested includes codes constraint.",
-          "alias": [
-            "coded"
-          ],
           "min": 0,
           "max": "*",
           "base": {
             "path": "shr-test-NestedIncludesCodes-model.value",
             "min": 0,
             "max": "*"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "constraint": [
-            {
-              "key": "value-1",
-              "severity": "error",
-              "human": "There must exist a value of 'bar' (Foobar) at value.",
-              "expression": "value.where($this = 'bar').exists()"
-            },
-            {
-              "key": "value-2",
-              "severity": "error",
-              "human": "There must exist a value of 'far' (Boofar) at value.",
-              "expression": "value.where($this = 'far').exists()"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-NestedIncludesCodes-model.value.value",
-          "path": "shr-test-NestedIncludesCodes-model.value.value",
-          "short": "Code representing it is a coded element",
-          "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
-            "min": 1,
-            "max": "1"
           },
           "type": [
             {
@@ -277,53 +230,12 @@
           "path": "shr-test-NestedIncludesCodes-model.value",
           "short": "Coded representing an entry with a nested includes codes constraint.",
           "definition": "Coded representing an entry with a nested includes codes constraint.",
-          "alias": [
-            "coded"
-          ],
           "min": 0,
           "max": "*",
           "base": {
             "path": "shr-test-NestedIncludesCodes-model.value",
             "min": 0,
             "max": "*"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "constraint": [
-            {
-              "key": "value-1",
-              "severity": "error",
-              "human": "There must exist a value of 'bar' (Foobar) at value.",
-              "expression": "value.where($this = 'bar').exists()"
-            },
-            {
-              "key": "value-2",
-              "severity": "error",
-              "human": "There must exist a value of 'far' (Boofar) at value.",
-              "expression": "value.where($this = 'far').exists()"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-NestedIncludesCodes-model.value.value",
-          "path": "shr-test-NestedIncludesCodes-model.value.value",
-          "short": "Code representing it is a coded element",
-          "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
-            "min": 1,
-            "max": "1"
           },
           "type": [
             {

--- a/test/fixtures/NestedIncludesTypeConstraints.json
+++ b/test/fixtures/NestedIncludesTypeConstraints.json
@@ -72,7 +72,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -119,7 +119,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -302,9 +302,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -345,9 +342,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -498,7 +492,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -519,7 +513,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -624,7 +618,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -645,7 +639,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -719,9 +713,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -762,9 +753,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -841,9 +829,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -884,9 +869,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/NestedListCardConstraints.json
+++ b/test/fixtures/NestedListCardConstraints.json
@@ -56,9 +56,6 @@
           "path": "shr-test-OptionalList-model.value",
           "short": "String representing an element with an optional list.",
           "definition": "String representing an element with an optional list.",
-          "alias": [
-            "string"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -99,9 +96,6 @@
           "path": "shr-test-OptionalList-model.value",
           "short": "String representing an element with an optional list.",
           "definition": "String representing an element with an optional list.",
-          "alias": [
-            "string"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -178,16 +172,16 @@
           "path": "shr-test-ListField-model.optionalList",
           "short": "An element with an optional list.",
           "definition": "An element with an optional list.",
-          "min": 1,
-          "max": "1",
+          "min": 0,
+          "max": "*",
           "base": {
             "path": "shr-test-ListField-model.optionalList",
-            "min": 1,
-            "max": "1"
+            "min": 0,
+            "max": "*"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalList-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -218,16 +212,16 @@
           "path": "shr-test-ListField-model.optionalList",
           "short": "An element with an optional list.",
           "definition": "An element with an optional list.",
-          "min": 1,
-          "max": "1",
+          "min": 0,
+          "max": "*",
           "base": {
             "path": "shr-test-ListField-model.optionalList",
-            "min": 1,
-            "max": "1"
+            "min": 0,
+            "max": "*"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalList-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -315,36 +309,12 @@
           "path": "shr-test-NestedListCardConstraints-model.listField.optionalList",
           "short": "An element with an optional list.",
           "definition": "An element with an optional list.",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-ListField-model.optionalList",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalList-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-NestedListCardConstraints-model.listField.optionalList.value",
-          "path": "shr-test-NestedListCardConstraints-model.listField.optionalList.value",
-          "short": "String representing an element with an optional list.",
-          "definition": "String representing an element with an optional list.",
-          "alias": [
-            "string"
-          ],
           "min": 2,
           "max": "10",
           "base": {
-            "path": "shr-test-OptionalList-model.value",
-            "min": 0,
-            "max": "*"
+            "path": "shr-test-NestedListCardConstraints-model.listField.optionalList",
+            "min": 2,
+            "max": "10"
           },
           "type": [
             {
@@ -400,36 +370,12 @@
           "path": "shr-test-NestedListCardConstraints-model.listField.optionalList",
           "short": "An element with an optional list.",
           "definition": "An element with an optional list.",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-ListField-model.optionalList",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalList-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-NestedListCardConstraints-model.listField.optionalList.value",
-          "path": "shr-test-NestedListCardConstraints-model.listField.optionalList.value",
-          "short": "String representing an element with an optional list.",
-          "definition": "String representing an element with an optional list.",
-          "alias": [
-            "string"
-          ],
           "min": 2,
           "max": "10",
           "base": {
-            "path": "shr-test-OptionalList-model.value",
-            "min": 0,
-            "max": "*"
+            "path": "shr-test-NestedListCardConstraints-model.listField.optionalList",
+            "min": 2,
+            "max": "10"
           },
           "type": [
             {

--- a/test/fixtures/NestedValueSetConstraints.json
+++ b/test/fixtures/NestedValueSetConstraints.json
@@ -56,9 +56,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -105,9 +102,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -199,30 +193,6 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-NestedValueSetConstraints-model.coded.value",
-          "path": "shr-test-NestedValueSetConstraints-model.coded.value",
-          "short": "Code representing it is a coded element",
-          "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
               "code": "code"
             }
           ],
@@ -265,30 +235,6 @@
           "base": {
             "path": "shr-test-NestedValueSetConstraints-model.coded",
             "min": 0,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-NestedValueSetConstraints-model.coded.value",
-          "path": "shr-test-NestedValueSetConstraints-model.coded.value",
-          "short": "Code representing it is a coded element",
-          "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-Coded-model.value",
-            "min": 1,
             "max": "1"
           },
           "type": [
@@ -394,7 +340,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -415,16 +361,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -436,7 +395,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -483,7 +442,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -504,16 +463,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -525,7 +497,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -599,9 +571,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -642,9 +611,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -728,9 +694,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -740,7 +703,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -778,9 +741,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -790,7 +750,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -864,9 +824,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -876,7 +833,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -914,9 +871,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -926,7 +880,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -1000,9 +954,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1043,9 +994,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/NotDone.json
+++ b/test/fixtures/NotDone.json
@@ -57,22 +57,6 @@
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
-        },
-        {
-          "id": "shr-test-NotDone-model.intentionallyBlank",
-          "path": "shr-test-NotDone-model.intentionallyBlank",
-          "short": "Workaround for limitation in IG publisher: StructureDefinitions must have at least one field",
-          "definition": "Workaround for limitation in IG publisher: StructureDefinitions must have at least one field",
-          "min": 0,
-          "max": "0",
-          "base": {
-            "path": "shr-test-NotDone-model.intentionallyBlank",
-            "min": 0,
-            "max": "0"
-          },
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
         }
       ]
     },
@@ -88,22 +72,6 @@
             "path": "shr-test-NotDone-model",
             "min": 0,
             "max": "*"
-          },
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-NotDone-model.intentionallyBlank",
-          "path": "shr-test-NotDone-model.intentionallyBlank",
-          "short": "Workaround for limitation in IG publisher: StructureDefinitions must have at least one field",
-          "definition": "Workaround for limitation in IG publisher: StructureDefinitions must have at least one field",
-          "min": 0,
-          "max": "0",
-          "base": {
-            "path": "shr-test-NotDone-model.intentionallyBlank",
-            "min": 0,
-            "max": "0"
           },
           "mustSupport": false,
           "isModifier": false,

--- a/test/fixtures/OnValueIncludesTypeConstraints.json
+++ b/test/fixtures/OnValueIncludesTypeConstraints.json
@@ -300,6 +300,13 @@
         {
           "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList",
           "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with a value that is a list of elements",
           "definition": "It is an element with a value that is a list of elements",
           "min": 0,
@@ -309,47 +316,19 @@
             "min": 0,
             "max": "1"
           },
-          "type": [
-            {
-              "code": "BackboneElement"
-            }
-          ],
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
         },
         {
-          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value",
-          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value",
-          "code": [
-            {
-              "system": "http://foo.org",
-              "code": "bar",
-              "display": "Foobar"
-            }
-          ],
-          "short": "Simple representing it is an element with a value that is a list of elements",
-          "definition": "Simple representing it is an element with a value that is a list of elements",
-          "min": 0,
-          "max": "1",
-          "base": {
-            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value",
-            "min": 0,
-            "max": "1"
-          },
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild",
-          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild",
+          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild",
+          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild",
+            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild",
             "min": 0,
             "max": "1"
           },
@@ -363,14 +342,14 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild2",
-          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild2",
+          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild2",
+          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild2",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
           "min": 0,
           "max": "2",
           "base": {
-            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild2",
+            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild2",
             "min": 0,
             "max": "2"
           },
@@ -405,6 +384,13 @@
         {
           "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList",
           "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with a value that is a list of elements",
           "definition": "It is an element with a value that is a list of elements",
           "min": 0,
@@ -414,47 +400,19 @@
             "min": 0,
             "max": "1"
           },
-          "type": [
-            {
-              "code": "BackboneElement"
-            }
-          ],
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
         },
         {
-          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value",
-          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value",
-          "code": [
-            {
-              "system": "http://foo.org",
-              "code": "bar",
-              "display": "Foobar"
-            }
-          ],
-          "short": "Simple representing it is an element with a value that is a list of elements",
-          "definition": "Simple representing it is an element with a value that is a list of elements",
-          "min": 0,
-          "max": "1",
-          "base": {
-            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value",
-            "min": 0,
-            "max": "1"
-          },
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild",
-          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild",
+          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild",
+          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild",
+            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild",
             "min": 0,
             "max": "1"
           },
@@ -468,14 +426,14 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild2",
-          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild2",
+          "id": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild2",
+          "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild2",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
           "min": 0,
           "max": "2",
           "base": {
-            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.value.simpleChild2",
+            "path": "shr-test-OnValueIncludesTypeConstraints-model.elementValueList.simpleChild2",
             "min": 0,
             "max": "2"
           },

--- a/test/fixtures/OnValueIncludesTypeConstraints.json
+++ b/test/fixtures/OnValueIncludesTypeConstraints.json
@@ -63,9 +63,6 @@
           ],
           "short": "Simple representing it is an element with a value that is a list of elements",
           "definition": "Simple representing it is an element with a value that is a list of elements",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -75,7 +72,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -113,9 +110,6 @@
           ],
           "short": "Simple representing it is an element with a value that is a list of elements",
           "definition": "Simple representing it is an element with a value that is a list of elements",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "*",
           "base": {
@@ -125,7 +119,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -192,9 +186,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -235,9 +226,6 @@
           "path": "shr-test-SimpleChild2-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -342,9 +330,6 @@
           ],
           "short": "Simple representing it is an element with a value that is a list of elements",
           "definition": "Simple representing it is an element with a value that is a list of elements",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -370,7 +355,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -391,7 +376,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -450,9 +435,6 @@
           ],
           "short": "Simple representing it is an element with a value that is a list of elements",
           "definition": "Simple representing it is an element with a value that is a list of elements",
-          "alias": [
-            "simple"
-          ],
           "min": 0,
           "max": "1",
           "base": {
@@ -478,7 +460,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -499,7 +481,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -573,9 +555,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -616,9 +595,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -695,9 +671,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -738,9 +711,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/ReferenceChoice.json
+++ b/test/fixtures/ReferenceChoice.json
@@ -56,10 +56,6 @@
           "path": "shr-test-ReferenceChoice-model.value[x]",
           "short": "Simple or Coded representing it is a reference to one of a few types",
           "definition": "Simple or Coded representing it is a reference to one of a few types",
-          "alias": [
-            "simple",
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -105,10 +101,6 @@
           "path": "shr-test-ReferenceChoice-model.value[x]",
           "short": "Simple or Coded representing it is a reference to one of a few types",
           "definition": "Simple or Coded representing it is a reference to one of a few types",
-          "alias": [
-            "simple",
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/Simple.json
+++ b/test/fixtures/Simple.json
@@ -63,9 +63,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -106,9 +103,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/SimpleReference.json
+++ b/test/fixtures/SimpleReference.json
@@ -56,9 +56,6 @@
           "path": "shr-test-SimpleReference-model.value",
           "short": "Simple representing it is a reference to a simple element",
           "definition": "Simple representing it is a reference to a simple element",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -100,9 +97,6 @@
           "path": "shr-test-SimpleReference-model.value",
           "short": "Simple representing it is a reference to a simple element",
           "definition": "Simple representing it is a reference to a simple element",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/TwoDeepElementValue.json
+++ b/test/fixtures/TwoDeepElementValue.json
@@ -54,11 +54,15 @@
         {
           "id": "shr-test-TwoDeepElementValue-model.value",
           "path": "shr-test-TwoDeepElementValue-model.value",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "ElementValue representing it is an element with a two-deep element value",
           "definition": "ElementValue representing it is an element with a two-deep element value",
-          "alias": [
-            "elementValue"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -68,7 +72,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -97,11 +101,15 @@
         {
           "id": "shr-test-TwoDeepElementValue-model.value",
           "path": "shr-test-TwoDeepElementValue-model.value",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "ElementValue representing it is an element with a two-deep element value",
           "definition": "ElementValue representing it is an element with a two-deep element value",
-          "alias": [
-            "elementValue"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -111,7 +119,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -185,9 +193,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -197,7 +202,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -235,9 +240,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -247,7 +249,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -321,9 +323,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -364,9 +363,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/TypeConstrainedChoices.json
+++ b/test/fixtures/TypeConstrainedChoices.json
@@ -269,27 +269,6 @@
           },
           "type": [
             {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-TypeConstrainedChoice-model.choice.valueString",
-          "path": "shr-test-TypeConstrainedChoice-model.choice.valueString",
-          "short": "string",
-          "definition": "string",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-TypeConstrainedChoice-model.choice.valueString",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
               "code": "string"
             }
           ],
@@ -325,27 +304,6 @@
           "max": "1",
           "base": {
             "path": "shr-test-TypeConstrainedChoice-model.choice",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-TypeConstrainedChoice-model.choice.valueString",
-          "path": "shr-test-TypeConstrainedChoice-model.choice.valueString",
-          "short": "string",
-          "definition": "string",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-TypeConstrainedChoice-model.choice.valueString",
             "min": 1,
             "max": "1"
           },
@@ -768,48 +726,6 @@
           },
           "type": [
             {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
-          "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
-          "short": "Choice representing it is an element with a choice value.",
-          "definition": "Choice representing it is an element with a choice value.",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
-          "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
-          "short": "It is a coded element",
-          "definition": "It is a coded element",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
               "code": "code"
             }
           ],
@@ -873,48 +789,6 @@
           "base": {
             "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue",
             "min": 0,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
-          "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
-          "short": "Choice representing it is an element with a choice value.",
-          "definition": "Choice representing it is an element with a choice value.",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
-          "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
-          "short": "It is a coded element",
-          "definition": "It is a coded element",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
-            "min": 1,
             "max": "1"
           },
           "type": [

--- a/test/fixtures/TypeConstrainedChoices.json
+++ b/test/fixtures/TypeConstrainedChoices.json
@@ -66,11 +66,6 @@
           },
           "short": "Choice of types representing it is an element with a choice",
           "definition": "Choice of types representing it is an element with a choice",
-          "alias": [
-            "string",
-            "code",
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -155,11 +150,6 @@
           },
           "short": "Choice of types representing it is an element with a choice",
           "definition": "Choice of types representing it is an element with a choice",
-          "alias": [
-            "string",
-            "code",
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -291,9 +281,6 @@
           "path": "shr-test-TypeConstrainedChoice-model.choice.valueString",
           "short": "string",
           "definition": "string",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -355,9 +342,6 @@
           "path": "shr-test-TypeConstrainedChoice-model.choice.valueString",
           "short": "string",
           "definition": "string",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -434,9 +418,6 @@
           "path": "shr-test-ChoiceValue-model.value",
           "short": "Choice representing it is an element with a choice value.",
           "definition": "Choice representing it is an element with a choice value.",
-          "alias": [
-            "choice"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -477,9 +458,6 @@
           "path": "shr-test-ChoiceValue-model.value",
           "short": "Choice representing it is an element with a choice value.",
           "definition": "Choice representing it is an element with a choice value.",
-          "alias": [
-            "choice"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -554,6 +532,16 @@
         {
           "id": "shr-test-TwoDeepChoiceField-model.choiceValue",
           "path": "shr-test-TwoDeepChoiceField-model.choiceValue",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "type",
+                "path": "$this"
+              }
+            ],
+            "ordered": false,
+            "rules": "open"
+          },
           "short": "It is an element with a choice value.",
           "definition": "It is an element with a choice value.",
           "min": 0,
@@ -565,12 +553,46 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ChoiceValue-model"
+              "code": "string"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
+        },
+        {
+          "id": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode:code",
+          "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
+          "sliceName": "code",
+          "short": "code",
+          "definition": "code",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "mustSupport": false,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/CodeChoice"
+            }
+          }
         }
       ]
     },
@@ -594,6 +616,16 @@
         {
           "id": "shr-test-TwoDeepChoiceField-model.choiceValue",
           "path": "shr-test-TwoDeepChoiceField-model.choiceValue",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "type",
+                "path": "$this"
+              }
+            ],
+            "ordered": false,
+            "rules": "open"
+          },
           "short": "It is an element with a choice value.",
           "definition": "It is an element with a choice value.",
           "min": 0,
@@ -605,12 +637,46 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ChoiceValue-model"
+              "code": "string"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
+        },
+        {
+          "id": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode:code",
+          "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
+          "sliceName": "code",
+          "short": "code",
+          "definition": "code",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "mustSupport": false,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/CodeChoice"
+            }
+          }
         }
       ]
     }
@@ -714,9 +780,6 @@
           "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
           "short": "Choice representing it is an element with a choice value.",
           "definition": "Choice representing it is an element with a choice value.",
-          "alias": [
-            "choice"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -738,9 +801,6 @@
           "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
           "short": "It is a coded element",
           "definition": "It is a coded element",
-          "alias": [
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -750,12 +810,18 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         }
       ]
     },
@@ -823,9 +889,6 @@
           "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value",
           "short": "Choice representing it is an element with a choice value.",
           "definition": "Choice representing it is an element with a choice value.",
-          "alias": [
-            "choice"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -847,9 +910,6 @@
           "path": "shr-test-TypeConstrainedChoiceWithPath-model.twoDeepChoiceField.choiceValue.value.valueCoded",
           "short": "It is a coded element",
           "definition": "It is a coded element",
-          "alias": [
-            "coded"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -859,12 +919,18 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         }
       ]
     }
@@ -926,9 +992,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -975,9 +1038,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/TypeConstrainedReference.json
+++ b/test/fixtures/TypeConstrainedReference.json
@@ -56,10 +56,6 @@
           "path": "shr-test-TypeConstrainedReference-model.value",
           "short": "Simple representing it is an element a constraint on a reference.",
           "definition": "Simple representing it is an element a constraint on a reference.",
-          "alias": [
-            "simple",
-            "simpleChild"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -101,10 +97,6 @@
           "path": "shr-test-TypeConstrainedReference-model.value",
           "short": "Simple representing it is an element a constraint on a reference.",
           "definition": "Simple representing it is an element a constraint on a reference.",
-          "alias": [
-            "simple",
-            "simpleChild"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -189,9 +181,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -232,9 +221,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -311,9 +297,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -354,9 +337,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -440,9 +420,6 @@
           ],
           "short": "Simple representing it is a reference to a simple element",
           "definition": "Simple representing it is a reference to a simple element",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -491,9 +468,6 @@
           ],
           "short": "Simple representing it is a reference to a simple element",
           "definition": "Simple representing it is a reference to a simple element",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/TypeConstraints.json
+++ b/test/fixtures/TypeConstraints.json
@@ -332,27 +332,6 @@
           },
           "type": [
             {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-GroupDerivative-model.elementValue.value",
-          "path": "shr-test-GroupDerivative-model.elementValue.value",
-          "short": "A derivative of the simple type.",
-          "definition": "A derivative of the simple type.",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-GroupDerivative-model.elementValue.value",
-            "min": 1,
-            "max": "1"
-          },
-          "type": [
-            {
               "code": "string"
             }
           ],
@@ -411,27 +390,6 @@
             "path": "shr-test-GroupDerivative-model.elementValue",
             "min": 0,
             "max": "*"
-          },
-          "type": [
-            {
-              "code": "BackboneElement"
-            }
-          ],
-          "mustSupport": false,
-          "isModifier": false,
-          "isSummary": false
-        },
-        {
-          "id": "shr-test-GroupDerivative-model.elementValue.value",
-          "path": "shr-test-GroupDerivative-model.elementValue.value",
-          "short": "A derivative of the simple type.",
-          "definition": "A derivative of the simple type.",
-          "min": 1,
-          "max": "1",
-          "base": {
-            "path": "shr-test-GroupDerivative-model.elementValue.value",
-            "min": 1,
-            "max": "1"
           },
           "type": [
             {

--- a/test/fixtures/TypeConstraints.json
+++ b/test/fixtures/TypeConstraints.json
@@ -56,9 +56,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -99,9 +96,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -185,9 +179,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -235,9 +226,6 @@
           ],
           "short": "Simple representing it is an element with an element value",
           "definition": "Simple representing it is an element with an element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -314,9 +302,6 @@
           "path": "shr-test-GroupDerivative-model.simpleChild",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -326,7 +311,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -359,10 +344,6 @@
           "path": "shr-test-GroupDerivative-model.elementValue.value",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
-          "alias": [
-            "simple",
-            "simpleChild"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -372,7 +353,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -403,9 +384,6 @@
           "path": "shr-test-GroupDerivative-model.simpleChild",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -415,7 +393,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -448,10 +426,6 @@
           "path": "shr-test-GroupDerivative-model.elementValue.value",
           "short": "A derivative of the simple type.",
           "definition": "A derivative of the simple type.",
-          "alias": [
-            "simple",
-            "simpleChild"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -461,7 +435,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -556,7 +530,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -577,16 +551,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -598,7 +585,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -645,7 +632,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -666,16 +653,29 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
+              "code": "code"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
-          "isSummary": false
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/Coded"
+            }
+          }
         },
         {
           "id": "shr-test-Group-model.elementValue",
           "path": "shr-test-Group-model.elementValue",
+          "code": [
+            {
+              "system": "http://foo.org",
+              "code": "bar",
+              "display": "Foobar"
+            }
+          ],
           "short": "It is an element with an element value",
           "definition": "It is an element with an element value",
           "min": 0,
@@ -687,7 +687,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -761,9 +761,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -804,9 +801,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -883,9 +877,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -932,9 +923,6 @@
           "path": "shr-test-Coded-model.value",
           "short": "Code representing it is a coded element",
           "definition": "Code representing it is a coded element",
-          "alias": [
-            "code"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1024,9 +1012,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1036,7 +1021,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -1074,9 +1059,6 @@
           ],
           "short": "Simple representing it is an element with a foreign element value",
           "definition": "Simple representing it is an element with a foreign element value",
-          "alias": [
-            "simple"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1086,7 +1068,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -1160,9 +1142,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -1203,9 +1182,6 @@
           "path": "shr-other-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/test/fixtures/TypeConstraintsWithPath.json
+++ b/test/fixtures/TypeConstraintsWithPath.json
@@ -72,7 +72,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -119,7 +119,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -469,7 +469,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -551,7 +551,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -669,7 +669,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -751,7 +751,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -825,9 +825,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -868,9 +865,6 @@
           "path": "shr-test-Simple-model.value",
           "short": "String representing it is a simple element",
           "definition": "String representing it is a simple element",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -947,9 +941,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {
@@ -990,9 +981,6 @@
           "path": "shr-test-SimpleChild-model.value",
           "short": "String representing a derivative of the simple type.",
           "definition": "String representing a derivative of the simple type.",
-          "alias": [
-            "string"
-          ],
           "min": 1,
           "max": "1",
           "base": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -912,13 +912,13 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-models@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.0.tgz#41c163bfb22aa39678c2bafebccccb50a8574a3a"
+shr-models@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.3.tgz#bc972ba2355bd7dd35d1169c7f17332967165c65"
 
-shr-test-helpers@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.2.0.tgz#8bb0982c53b1ce7d4e792bdf1cf73d94bde650f8"
+shr-test-helpers@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.2.2.tgz#31c18d3db71a0181cd18e74105b42881756f5834"
   dependencies:
     fs-extra "^5.0.0"
 


### PR DESCRIPTION
_CM/KM will review together on Aug 30_

This PR contains some new fixes and some fixes from Dylan already reviewed by Chris before they were merged into `sep_ballot_fixes`.

Already reviewed changes from Dylan:
- Filtering and "hiding" of profiles, models, extensions, value sets, code systems
- Support for multiple pages of documentation

New fixes:
- IG config related:
    - Allow fixed-business-version to be controlled by config.implementationGuide.version
    - Allow npm-name to be controlled by config.implementationGuide.npmName
    - Allow history link to be controlled by config.implementationGuide.historyLink
    - Add support for "hiding" supporting profiles/models via config.implementationGuide.primarySelectionStrategy.hideSupporting
    - Fix incorrect casing on license
    - Add version for uscore dependency
- IG rendering related:
    - Update to latest IG Publisher jar
    - Improve display of listing pages when there is nothing to list
    - Fix empty descriptions from being rendered as 'undefined'
    - Remove the download link for the full IG
    - Move copyright symbol in footer (per Grahame)
    - Remove pub tools version number from footer (per Grahame)
- Profile related:
    - Improve handling of slices inside of slices
    - Support type constraints on elements inside extensions
    - Support direct IncludesType constraints on extensions
    - Create a code system to define the codes used by profiles on `Basic` (HL7/us-breastcancer#6)
    - Fix type constraints on choices to properly narrow choices in FHIR profile element
    - Fix specialized types to use base type when constraining choices (HL7/us-breastcancer#11)
    - Fix incorrect constraint merging logic (standardhealth/shr_spec#73)
    - Fix incorrect slicing base on extensions
    - Fix bug which could potentially cause infinite loops
    - Fix to better identify no-diff profiles (and not create unnecessary differentials) (standardhealth/shr-cli#116)
    - Don't inherit examples from FHIR resources when creating profiles (HL7/us-breastcancer#3)
    - Always trim description and short fields to remove trailing spaces
- Logical Model Related
    - Create "compact" models that eliminate unecessary levels of indirection
    - Fix duplicate `Codings` (HL7/us-breastcancer#5)

Needed before merging:
- bump shr-* dependencies
- bump version number to non-beta