### PR TITLE
Fix logical resolve

### DIFF
--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -905,7 +905,23 @@ class ModelsExporter {
       }
       // Update all the children w/ the new id root
       const originalId = child.id;
-      children.forEach(el => el.id = el.id.replace(originalId, element.id));
+      children.forEach(el => {
+        if (el.id.startsWith(originalId)) {
+          // If the compacted element is now a choice, we need to add [x] at the end of its name
+          const newId = originalId.endsWith('[x]') && !element.id.endsWith('[x]') ? `${element.id}[x]` : element.id;
+          el.id = el.id.replace(originalId, newId);
+        } else if (originalId.endsWith('[x]') && el.id.startsWith(originalId.slice(0, -3))) {
+          // This element is based on a specific choice (e.g., value[x] -> valueCode) so we need special handling
+          const re = new RegExp(`^${originalId.slice(0,-3)}[A-Z][^\.:]*$`);
+          const pointBaseToOriginal = re.test(el.base.path);
+          const newIdBase = element.id.endsWith('[x]') ? element.id.slice(0, -3) : element.id;
+          el.id = el.id.replace(originalId.slice(0, -3), newIdBase);
+          // Fix the base *after* assigning the id, since assigning the id may overwrite the existing base
+          if (pointBaseToOriginal) {
+            el.base = common.cloneJSON(child.base);
+          }
+        }
+      });
       // Detach the old element
       element.detach(false);
       // Since it was compacted, it's possible it could be compacted more! Rewind i so we repeat this element again.

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -789,12 +789,14 @@ class ModelsExporter {
   resolve(type) {
     const stringType = common.typeToString(type);
 
-    const re = new RegExp(`${this._config.fhirURL}/StructureDefinition/([a-z].*)-([A-Z].*)-model`);
+    const re = new RegExp(`${this._config.fhirURL}/StructureDefinition/(([a-z].*)-([A-Z].*)-model)`);
     const localMatches = re.exec(stringType);
     if (localMatches) {
-      const [ns, name] = [localMatches[1].replace(/-/g, '.'), localMatches[2]];
+      if (this._modelsMap.has(localMatches[1])) {
+        return this._modelsMap.get(localMatches[1]);
+      }
+      const [ns, name] = [localMatches[2].replace(/-/g, '.'), localMatches[3]];
       // NOTE: possible recursion here!
-      // TODO: Caching
       return this.exportModel(this._specs.dataElements.find(ns, name));
     }
     const def = this._fhir.find(stringType);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/test/fixtures/ChoiceValueSetConstraint.json
+++ b/test/fixtures/ChoiceValueSetConstraint.json
@@ -174,8 +174,8 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
-          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
+          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice[x]",
+          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice[x]",
           "slicing": {
             "discriminator": [
               {
@@ -191,7 +191,7 @@
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice[x]",
             "min": 0,
             "max": "1"
           },
@@ -208,15 +208,15 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode:code",
-          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode",
+          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoiceCode:code",
+          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoiceCode",
           "sliceName": "code",
           "short": "Coded or code representing an element with a choice of code fields.",
           "definition": "Coded or code representing an element with a choice of code fields.",
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoiceCode",
             "min": 0,
             "max": "1"
           },
@@ -255,8 +255,8 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
-          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
+          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice[x]",
+          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice[x]",
           "slicing": {
             "discriminator": [
               {
@@ -272,7 +272,7 @@
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice[x]",
             "min": 0,
             "max": "1"
           },
@@ -289,15 +289,15 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode:code",
-          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode",
+          "id": "shr-test-ChoiceValueSetConstraint-model.codedChoiceCode:code",
+          "path": "shr-test-ChoiceValueSetConstraint-model.codedChoiceCode",
           "sliceName": "code",
           "short": "Coded or code representing an element with a choice of code fields.",
           "definition": "Coded or code representing an element with a choice of code fields.",
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoice.valueCode",
+            "path": "shr-test-ChoiceValueSetConstraint-model.codedChoiceCode",
             "min": 0,
             "max": "1"
           },

--- a/test/fixtures/TypeConstrainedChoices.json
+++ b/test/fixtures/TypeConstrainedChoices.json
@@ -372,25 +372,69 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-ChoiceValue-model.value",
-          "path": "shr-test-ChoiceValue-model.value",
+          "id": "shr-test-ChoiceValue-model.value[x]",
+          "path": "shr-test-ChoiceValue-model.value[x]",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "type",
+                "path": "$this"
+              }
+            ],
+            "ordered": false,
+            "rules": "open"
+          },
           "short": "Choice representing it is an element with a choice value.",
           "definition": "Choice representing it is an element with a choice value.",
           "min": 1,
           "max": "1",
           "base": {
-            "path": "shr-test-ChoiceValue-model.value",
+            "path": "shr-test-ChoiceValue-model.value[x]",
             "min": 1,
             "max": "1"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Choice-model"
+              "code": "string"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
+        },
+        {
+          "id": "shr-test-ChoiceValue-model.valueCode:code",
+          "path": "shr-test-ChoiceValue-model.valueCode",
+          "sliceName": "code",
+          "short": "code",
+          "definition": "code",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "shr-test-ChoiceValue-model.value[x]",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "mustSupport": false,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/CodeChoice"
+            }
+          }
         }
       ]
     },
@@ -412,25 +456,69 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-ChoiceValue-model.value",
-          "path": "shr-test-ChoiceValue-model.value",
+          "id": "shr-test-ChoiceValue-model.value[x]",
+          "path": "shr-test-ChoiceValue-model.value[x]",
+          "slicing": {
+            "discriminator": [
+              {
+                "type": "type",
+                "path": "$this"
+              }
+            ],
+            "ordered": false,
+            "rules": "open"
+          },
           "short": "Choice representing it is an element with a choice value.",
           "definition": "Choice representing it is an element with a choice value.",
           "min": 1,
           "max": "1",
           "base": {
-            "path": "shr-test-ChoiceValue-model.value",
+            "path": "shr-test-ChoiceValue-model.value[x]",
             "min": 1,
             "max": "1"
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Choice-model"
+              "code": "string"
+            },
+            {
+              "code": "code"
+            },
+            {
+              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model"
             }
           ],
           "mustSupport": false,
           "isModifier": false,
           "isSummary": false
+        },
+        {
+          "id": "shr-test-ChoiceValue-model.valueCode:code",
+          "path": "shr-test-ChoiceValue-model.valueCode",
+          "sliceName": "code",
+          "short": "code",
+          "definition": "code",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "shr-test-ChoiceValue-model.value[x]",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ],
+          "mustSupport": false,
+          "isModifier": false,
+          "isSummary": false,
+          "binding": {
+            "strength": "required",
+            "valueSetReference": {
+              "reference": "http://standardhealthrecord.org/test/vs/CodeChoice"
+            }
+          }
         }
       ]
     }
@@ -488,8 +576,8 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-TwoDeepChoiceField-model.choiceValue",
-          "path": "shr-test-TwoDeepChoiceField-model.choiceValue",
+          "id": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
+          "path": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
           "slicing": {
             "discriminator": [
               {
@@ -505,7 +593,7 @@
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-TwoDeepChoiceField-model.choiceValue",
+            "path": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
             "min": 0,
             "max": "1"
           },
@@ -525,16 +613,16 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode:code",
-          "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
+          "id": "shr-test-TwoDeepChoiceField-model.choiceValueCode:code",
+          "path": "shr-test-TwoDeepChoiceField-model.choiceValueCode",
           "sliceName": "code",
           "short": "code",
           "definition": "code",
           "min": 1,
           "max": "1",
           "base": {
-            "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
-            "min": 1,
+            "path": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
+            "min": 0,
             "max": "1"
           },
           "type": [
@@ -572,8 +660,8 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-TwoDeepChoiceField-model.choiceValue",
-          "path": "shr-test-TwoDeepChoiceField-model.choiceValue",
+          "id": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
+          "path": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
           "slicing": {
             "discriminator": [
               {
@@ -589,7 +677,7 @@
           "min": 0,
           "max": "1",
           "base": {
-            "path": "shr-test-TwoDeepChoiceField-model.choiceValue",
+            "path": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
             "min": 0,
             "max": "1"
           },
@@ -609,16 +697,16 @@
           "isSummary": false
         },
         {
-          "id": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode:code",
-          "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
+          "id": "shr-test-TwoDeepChoiceField-model.choiceValueCode:code",
+          "path": "shr-test-TwoDeepChoiceField-model.choiceValueCode",
           "sliceName": "code",
           "short": "code",
           "definition": "code",
           "min": 1,
           "max": "1",
           "base": {
-            "path": "shr-test-TwoDeepChoiceField-model.choiceValue.valueCode",
-            "min": 1,
+            "path": "shr-test-TwoDeepChoiceField-model.choiceValue[x]",
+            "min": 0,
             "max": "1"
           },
           "type": [

--- a/test/fixtures/TypeConstraints.json
+++ b/test/fixtures/TypeConstraints.json
@@ -188,7 +188,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,
@@ -235,7 +235,7 @@
           },
           "type": [
             {
-              "code": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model"
+              "code": "string"
             }
           ],
           "mustSupport": false,


### PR DESCRIPTION
The `resolve` function used to re-export the model every time it was called, even if the model had been previously exported. This could cause a bug when compacting models that would overwrite a compacted model with an un-compacted one (when `resolve` re-exports it). In the _shimi_ branch, this was seem with `Quantity`'s `comparator` field.