### PR TITLE
Apply card constraints first in logical models

### DIFF
--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -215,7 +215,12 @@ class ModelsExporter {
    * @param {ElementDefinition} el - the ElementDefinition associated with the SHR Value object
    */
   applyConstraints(model, value, el) {
-    // First apply the type constraints and includes type constraints because they build
+    // First handle the card constraints because other constraints (IncludesType) may further
+    // modify them as necessary.
+    for (const c of value.constraintsFilter.card.constraints) {
+      this.applyCardConstraint(model, value, el, c);
+    }
+    // Then apply the type constraints and includes type constraints because they build
     // out some structure and affect the types, then do the rest
     for (const c of value.constraintsFilter.type.constraints) {
       this.applyTypeConstraint(model, value, el, c);
@@ -235,9 +240,6 @@ class ModelsExporter {
     }
     for (const c of value.constraintsFilter.boolean.constraints) {
       this.applyBooleanConstraint(model, value, el, c);
-    }
-    for (const c of value.constraintsFilter.card.constraints) {
-      this.applyCardConstraint(model, value, el, c);
     }
 
     // If the value is a choice, then there may be constraints on the individual options


### PR DESCRIPTION
The includes type constraint purposely sets an element's cardinality to `0..1` or `1..1` in the logical models. When card constraints are processed *after* that, however, they may overwrite the `0..1` or `1..1` card.  To avoid this, process card constraints first.

This is tough to reproduce.  I was only able to trigger the bug on the shr_spec _mini_ branch with the _ig-wound-config.json_ -- and furthermore, it only happened if you exported CIMCORE and then re-ran the CLI importing the CIMCORE (instead of the CIMPL).

I wouldn't try to reproduce.  I'd just do a regression test to make sure nothing broke.