### PR TITLE
Add hybrid primary selection strategy

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -114,6 +114,17 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
       // TODO: Get a logger!
       console.error('Namespace strategy requires config.implementationGuide.primarySelectionStrategy.primary to be an array');
     }
+  // If strategy is "hybrid", set every entry within selected namespaces and every selected entry as primary
+  } else if (config.implementationGuide.primarySelectionStrategy && config.implementationGuide.primarySelectionStrategy.strategy === 'hybrid') {
+    const primary = config.implementationGuide.primarySelectionStrategy.primary;
+    if (Array.isArray(primary)) {
+      isPrimaryFn = (id) => {
+        return (idToElementMap.get(id).isEntry) && ((primary.indexOf(idToElementMap.get(id).identifier.name) != -1) || (primary.indexOf(idToElementMap.get(id).identifier.namespace) != -1) || (primary.indexOf(idToElementMap.get(id).identifier.fqn) != -1));
+      };
+    } else {
+      // TODO: Get a logger!
+      console.error('Hybrid strategy requires config.implementationGuide.primarySelectionStrategy.primary to be an array');
+    }
   }
   if (isPrimaryFn == null) {
     // If strategy is "entry" or default, set every entry as primary


### PR DESCRIPTION
This adds hybrid selection to the primary selection strategy as well.

This was requested by @mlterryMitre as an additional feature to add, because it is needed to support the hybrid filter strategy.

@cmoesel, if it doesn't look like there's a problem to you, could we get this change added onto the DSTU2 beta release that you made? If we need to merge this into a different branch than `master` or need to rebase, or anything like that, let me know.