### PR TITLE
 Fix bad reference to SD type in DSTU2 

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1115,7 +1115,7 @@ class FHIRExporter {
     let matchedType;
     // First try to find the most direct matched type
     for (const t of snapshotEl.type) {
-      if (t.code === sdToAdd.type) {
+      if (t.code === MVH.sdType(sdToAdd)) {
         matchedType = t;
         this.markSelectedOptionsInChoice(snapshotEl.type, [t]);
         break;
@@ -1137,7 +1137,7 @@ class FHIRExporter {
     }
     // If we didn't find the matched type, it is an error.
     if (matchedType == null) {
-      logger.error('Cannot make choice element explicit at %s. Could not find compatible type match for: %s. ERROR_CODE:?????', snapshotEl.id, sdToAdd.type);
+      logger.error('Cannot make choice element explicit at %s. Could not find compatible type match for: %s. ERROR_CODE:?????', snapshotEl.id, MVH.sdType(sdToAdd));
       return [];
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
DSTU2 StructureDefinition doesn't have a type property, but the code was trying to reference one.  Replaced with the MultiVersionHelper function to get the type.