### PR TITLE
Avoid duplicate SHR maps from element.mapping

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -193,7 +193,7 @@ class FHIRExporter {
           ssEl.mapping.forEach(fixURI);
         }
       }
-      
+
       // (2) Fix incorrect display text for US jurisdiction
       if (profile.jurisdiction) {
         profile.jurisdiction.forEach(j => {
@@ -214,8 +214,7 @@ class FHIRExporter {
         // If the snapshot element was found, add the mapping in as an 'shr' identity
         // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
         if (elem && !r.sourcePath[0].isPrimitive) {
-          elem.mapping = elem.mapping || [];
-          elem.mapping.push({ 'identity': 'shr', 'map': `<${r.sourcePath[0].fqn}>` });
+          pushShrMapToElementMappings(`<${r.sourcePath[0].fqn}>`, elem);
         }
       }
 
@@ -971,28 +970,20 @@ class FHIRExporter {
       };
     }
 
-    // Make sure the mapping arrays in the FHIR object and the differential exist; create if not
-    ss.mapping = ss.mapping || [];
-    df.mapping = df.mapping || [];
-
     // Check if the field being mapped is the definition's 'Value' element
     // TODO: If def.value is a ChoiceValue, test that at least one ID equals the sourceValue (using .some())
     const isValue = def.value !== undefined && sourceValue.effectiveIdentifier == def.value.identifier;
-    const shrMapping = { 'identity': 'shr' };
     if (isValue) {
       // If it is the 'Value' element, just map it through to the SHR 'Value'
-      shrMapping['map'] = '<Value>';
-      ss.mapping.push(shrMapping);
-      df.mapping.push(shrMapping);
+      pushShrMapToElementMappings('<Value>', ss, df);
     } else {
       // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
       if (!sourceValue.identifier.isPrimitive && !sourceValue._derivedFromIncludesTypeConstraint) {
         // Build the mapping based on the sourcePath for the rule, to handle nested elements
-        shrMapping['map'] = rule.sourcePath.map((pathElem) => {
+        const shrMap = rule.sourcePath.map((pathElem) => {
           return `<${pathElem.fqn}>`;
         }).join('.');
-        ss.mapping.push(shrMapping);
-        df.mapping.push(shrMapping);
+        pushShrMapToElementMappings(shrMap, ss, df);
       }
     }
 
@@ -3968,6 +3959,23 @@ function typesHaveSameCodesProfilesAndTargetProfiles(t1, t2) {
     }
   }
   return true;
+}
+
+/**
+ * Pushes an SHR mapping value (used for toFHIR/fromFHIR serialization) to the mapping property of one or more elements
+ * @param {string} shrMap - the string to store in the `map` value of the mapping object
+ * @param  {...Object} elements - the elements containing mappings to push the SHR maps onto
+ */
+function pushShrMapToElementMappings(shrMap, ...elements) {
+  for (const element of elements) {
+    if (element.mapping == null) {
+      element.mapping = [{ identity: 'shr', map: shrMap }];
+    }
+    // Else if mapping array exists, only add SHR map if it doesn't already exist (no duplicates allowed)
+    else if (element.mapping.every(em => em.identity !== 'shr' || em.map !== shrMap)) {
+      element.mapping.push({ identity: 'shr', map: shrMap });
+    }
+  }
 }
 
 // NOTE: This class only used if REPORT_PROFILE_INDICATORS is set to true

--- a/lib/export.js
+++ b/lib/export.js
@@ -203,21 +203,6 @@ class FHIRExporter {
         });
       }
 
-      // Insert mapping rules into the FHIR mapping element
-      for (let r of map.rules) {
-        if (r.sourcePath == undefined) {
-          break;
-        }
-        const rulePath = `${map.targetItem}.${r.target}`;
-        // Find the profile snapshot element that corresponds to the mapping rule
-        const elem = profile.snapshot.element.find(e => e.id == rulePath);
-        // If the snapshot element was found, add the mapping in as an 'shr' identity
-        // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
-        if (elem && !r.sourcePath[0].isPrimitive) {
-          pushShrMapToElementMappings(`<${r.sourcePath[0].fqn}>`, elem);
-        }
-      }
-
       // There are some bugs in Argonauth resources that cause errors in the IG publisher.
       // Fix invalid ids in mappings (e.g., "us-core-(stu3)")
       if (this._target === 'FHIR_DSTU_2' && map.targetItem.startsWith('http://fhir.org/guides/argonaut/')) {


### PR DESCRIPTION
Prior implementation sometimes pushed the same SHR map onto an element multiple times.  This only adds an SHR map if it doesn't already exist.