### PR TITLE
Support for SHR field mappings as needed for fromFHIR

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1097,6 +1097,10 @@ class FHIRExporter {
       const ss = common.cloneJSON(sdToUnroll.snapshot.element[i]);
       ss.id = `${baseId}${ss.id.slice(baseEl.id.length)}`;
       ss.path = `${basePath}${ss.path.slice(baseEl.path.length)}`;
+      // Remove the SHR mappings since they are relative to the unrolled object (not to the path they're unrolled to)
+      if (ss.mapping) {
+        ss.mapping = ss.mapping.filter(m => m.identity !== 'shr');
+      }
       // Only unroll this element if it's not unrolled already -- this check may not actually be necessary
       if (!profile.snapshot.element.some(e => e.id == ss.id)) {
         unrolled.push(ss);

--- a/lib/export.js
+++ b/lib/export.js
@@ -193,7 +193,7 @@ class FHIRExporter {
           ssEl.mapping.forEach(fixURI);
         }
       }
-      
+
       // (2) Fix incorrect display text for US jurisdiction
       if (profile.jurisdiction) {
         profile.jurisdiction.forEach(j => {
@@ -214,8 +214,7 @@ class FHIRExporter {
         // If the snapshot element was found, add the mapping in as an 'shr' identity
         // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
         if (elem && !r.sourcePath[0].isPrimitive) {
-          elem.mapping = elem.mapping || [];
-          elem.mapping.push({ 'identity': 'shr', 'map': `<${r.sourcePath[0].fqn}>` });
+          pushShrMapToElementMappings(`<${r.sourcePath[0].fqn}>`, elem);
         }
       }
 
@@ -971,28 +970,20 @@ class FHIRExporter {
       };
     }
 
-    // Make sure the mapping arrays in the FHIR object and the differential exist; create if not
-    ss.mapping = ss.mapping || [];
-    df.mapping = df.mapping || [];
-
     // Check if the field being mapped is the definition's 'Value' element
     // TODO: If def.value is a ChoiceValue, test that at least one ID equals the sourceValue (using .some())
     const isValue = def.value !== undefined && sourceValue.effectiveIdentifier == def.value.identifier;
-    const shrMapping = { 'identity': 'shr' };
     if (isValue) {
       // If it is the 'Value' element, just map it through to the SHR 'Value'
-      shrMapping['map'] = '<Value>';
-      ss.mapping.push(shrMapping);
-      df.mapping.push(shrMapping);
+      pushShrMapToElementMappings('<Value>', ss, df);
     } else {
       // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
       if (!sourceValue.identifier.isPrimitive && !sourceValue._derivedFromIncludesTypeConstraint) {
         // Build the mapping based on the sourcePath for the rule, to handle nested elements
-        shrMapping['map'] = rule.sourcePath.map((pathElem) => {
+        const shrMap = rule.sourcePath.map((pathElem) => {
           return `<${pathElem.fqn}>`;
         }).join('.');
-        ss.mapping.push(shrMapping);
-        df.mapping.push(shrMapping);
+        pushShrMapToElementMappings(shrMap, ss, df);
       }
     }
 
@@ -3968,6 +3959,23 @@ function typesHaveSameCodesProfilesAndTargetProfiles(t1, t2) {
     }
   }
   return true;
+}
+
+/**
+ * Pushes an SHR mapping value (used for toFHIR/fromFHIR serialization) to the mapping property of one or more elements
+ * @param {string} shrMap - the string to store in the `map` value of the mapping object
+ * @param  {...Object} elements - the elements containing mappings to push the SHR maps onto
+ */
+function pushShrMapToElementMappings(shrMap, ...elements) {
+  for (const element of elements) {
+    if (element.mapping == null) {
+      element.mapping = [{ identity: 'shr', map: shrMap }];
+    }
+    // Else if mapping array exists, only add SHR map if it doesn't already exist (no duplicates allowed)
+    else if (element.mapping.every(em => em.identity !== 'shr' || em.map !== shrMap)) {
+      element.mapping.push({ identity: 'shr', map: shrMap });
+    }
+  }
 }
 
 // NOTE: This class only used if REPORT_PROFILE_INDICATORS is set to true

--- a/lib/export.js
+++ b/lib/export.js
@@ -2955,6 +2955,11 @@ class FHIRExporter {
       }
     }
 
+    const shrMap = sourcePath.map((pathElem) => {
+      return `<${pathElem.fqn}>`;
+    }).join('.');
+    pushShrMapToElementMappings(shrMap, ssEl, dfEl);
+
     this.applyConstraints(sourceValue, profile, ssEl, dfEl, true, sourcePath);
 
     return;

--- a/lib/export.js
+++ b/lib/export.js
@@ -155,6 +155,7 @@ class FHIRExporter {
       valueSets: this._valueSetExporter.valueSets,
       codeSystems: this._codeSystemExporter.codeSystems,
       models: this._modelsExporter.models,
+      base: this._fhir,
     };
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -962,8 +962,9 @@ class FHIRExporter {
       // If it is the 'Value' element, just map it through to the SHR 'Value'
       pushShrMapToElementMappings('<Value>', ss, df);
     } else {
-      // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
-      if (!sourceValue.identifier.isPrimitive && !sourceValue._derivedFromIncludesTypeConstraint) {
+      // If it isn't; and it's not derived from includes type constraints, map it to the fqn of the field being mapped
+      // TODO: Determine why we're excluding derivedFromIncludesTypeConstraints
+      if (!sourceValue._derivedFromIncludesTypeConstraint) {
         // Build the mapping based on the sourcePath for the rule, to handle nested elements
         const shrMap = rule.sourcePath.map((pathElem) => {
           return `<${pathElem.fqn}>`;

--- a/lib/export.js
+++ b/lib/export.js
@@ -127,9 +127,13 @@ class FHIRExporter {
 
     // Delete intermediate variables
     const profiles = Array.from(this._profilesMap.values()).filter(p => common.isCustomProfile(p));
+    // For use in shr-es6-export, create a noDiffProfiles array as well, so profiles that only
+    // Contain mapping differences can be exported
+    const noDiffProfiles = Array.from(this._profilesMap.values()).filter(p => !common.isCustomProfile(p));
     for (const p of profiles) {
       delete(p._shr);
     }
+<<<<<<< HEAD
 
     const extensions = this._extensionExporter.extensions;
 
@@ -142,7 +146,13 @@ class FHIRExporter {
       });
     }
 
+=======
+    for (const p of noDiffProfiles) {
+      delete (p._shr);
+    }
+>>>>>>> Modify the definition of 'no-diff' profiles, such that profiles that differ only by mapping rules are considered 'no-diff', and export the 'no-diff' profiles as a separate object
     return {
+      noDiffProfiles,
       profiles,
       extensions,
       valueSets: this._valueSetExporter.valueSets,
@@ -457,20 +467,19 @@ class FHIRExporter {
       }
       profile.differential.element = fixedDifferentials;
 
-      // Check if this is a "no-diff" profile.
+      // Check if this is a "no-diff" profile. A profile is considered "no-diff"
+      // If the "mapping" is different, as the mappings are only used internally by other SHR profiles
       const isNoDiffProfile = profile.differential.element.length <= 1 || profile.differential.element.every(e => {
         const keys = Object.keys(e);
         return keys.every(k => {
-          return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition';
+          return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition' || k === 'mapping';
         });
       });
       if (isNoDiffProfile) {
-        // Substitute it with the original resource!
-        // First, remember the original id
-        const originalId = profile.id;
-        // Now re-set the profile to the original resource
-        profile = common.cloneJSON(def);
-        this._profilesMap.set(originalId, profile);
+        // Now flag the profile as "not an SHR profile", so it doesn't get included in the
+        // Profiles list displayed to the user
+        profile._shr = false;
+        this._profilesMap.set(profile.id, profile);
       } else {
         // Perform additional QA
         this.additionalQA(profile);

--- a/lib/export.js
+++ b/lib/export.js
@@ -133,7 +133,9 @@ class FHIRExporter {
     for (const p of profiles) {
       delete(p._shr);
     }
-<<<<<<< HEAD
+    for (const p of noDiffProfiles) {
+      delete (p._shr);
+    }
 
     const extensions = this._extensionExporter.extensions;
 
@@ -146,11 +148,6 @@ class FHIRExporter {
       });
     }
 
-=======
-    for (const p of noDiffProfiles) {
-      delete (p._shr);
-    }
->>>>>>> Modify the definition of 'no-diff' profiles, such that profiles that differ only by mapping rules are considered 'no-diff', and export the 'no-diff' profiles as a separate object
     return {
       noDiffProfiles,
       profiles,

--- a/lib/export.js
+++ b/lib/export.js
@@ -962,7 +962,7 @@ class FHIRExporter {
     if (isValue) {
       ss.mapping.push({ 'identity': 'shr', 'map': '<Value>' });
     } else {
-      if (!sourceValue.identifier.isPrimitive) {
+      if (!sourceValue.identifier.isPrimitive && def.identifier.fqn != 'shr.core.Quantity') {
         ss.mapping.push({ 'identity': 'shr', 'map': `<${sourceValue.identifier.fqn}>` });
       }
     }

--- a/lib/export.js
+++ b/lib/export.js
@@ -3838,6 +3838,16 @@ function setCardinalityOnFHIRElements(card, snapshotEl, differentialEl, skipIfEq
         delete(differentialEl.max);
       }
     }
+    if (!snapshotEl.base) {
+      snapshotEl.base = {
+        path: snapshotEl.path,
+        min: originalProperties.min,
+        max: originalProperties.max
+      };
+      if (differentialEl != null) {
+        differentialEl.base = snapshotEl.base;
+      }
+    }
   }
 }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -186,6 +186,22 @@ class FHIRExporter {
           ssEl.mapping.forEach(fixURI);
         }
       }
+
+      // Insert mapping rules into the FHIR mapping element
+      for (let r of map.rules) {
+        if (r.sourcePath == undefined) {
+          break;
+        }
+        const rulePath = `${map.targetItem}.${r.target}`;
+        // Find the profile snapshot element that corresponds to the mapping rule
+        const elem = profile.snapshot.element.find(e => e.id == rulePath);
+        // If the snapshot element was found, add the mapping in as an 'shr' identity
+        // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
+        if (elem && map.identifier.name == 'PatientSingleConstraintEntry') {
+          elem.mapping.push({ 'identity': 'shr', 'map': `<${r.sourcePath[0].fqn}>` });
+        }
+      }
+      
       // (2) Fix incorrect display text for US jurisdiction
       if (profile.jurisdiction) {
         profile.jurisdiction.forEach(j => {

--- a/lib/export.js
+++ b/lib/export.js
@@ -956,17 +956,6 @@ class FHIRExporter {
       return;
     }
 
-    // Insert mapping rules into the FHIR mapping element
-    ss.mapping = ss.mapping || [];
-    const isValue = sourceValue.effectiveIdentifier == def.value.identifier;
-    if (isValue) {
-      ss.mapping.push({ 'identity': 'shr', 'map': '<Value>' });
-    } else {
-      if (!sourceValue.identifier.isPrimitive && def.identifier.fqn != 'shr.core.Quantity') {
-        ss.mapping.push({ 'identity': 'shr', 'map': `<${sourceValue.identifier.fqn}>` });
-      }
-    }
-
     let df = common.getDifferentialElementById(profile, ss.id);
     const dfIsNew = (typeof df === 'undefined');
     if (dfIsNew) {
@@ -974,6 +963,29 @@ class FHIRExporter {
         id: ss.id,
         path: ss.path
       };
+    }
+
+    // Make sure the mapping arrays in the FHIR object and the differential exist; create if not
+    ss.mapping = ss.mapping || [];
+    df.mapping = df.mapping || [];
+
+    // Check if the field being mapped is the definition's 'Value' element
+    // TODO: If def.value is a ChoiceValue, test that at least one ID equals the sourceValue (using .some())
+    const isValue = def.value !== undefined && sourceValue.effectiveIdentifier == def.value.identifier;
+    const shrMapping = { 'identity': 'shr' };
+    if (isValue) {
+      // If it is the 'Value' element, just map it through to the SHR 'Value'
+      shrMapping['map'] = '<Value>';
+      ss.mapping.push(shrMapping);
+      df.mapping.push(shrMapping);
+    } else {
+      // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
+      // The shr.core.Quantity restriction is temporary, until support for that element is added
+      if (!sourceValue.identifier.isPrimitive && def.identifier.fqn != 'shr.core.Quantity') {
+        shrMapping['map'] = `<${sourceValue.identifier.fqn}>`;
+        ss.mapping.push(shrMapping);
+        df.mapping.push(shrMapping);
+      }
     }
 
     if (typeof ss.type === 'undefined' && typeof MVH.edContentReference(profile, ss) !== 'undefined') {

--- a/lib/export.js
+++ b/lib/export.js
@@ -149,9 +149,9 @@ class FHIRExporter {
     }
 
     return {
-      noDiffProfiles,
       profiles,
       extensions,
+      _noDiffProfiles: noDiffProfiles,
       valueSets: this._valueSetExporter.valueSets,
       codeSystems: this._codeSystemExporter.codeSystems,
       models: this._modelsExporter.models,

--- a/lib/export.js
+++ b/lib/export.js
@@ -2900,7 +2900,6 @@ class FHIRExporter {
       if (isModifier) {
         ssEl.mustSupport = ssEl.isModifier = true;
       }
-      delete(ssEl.base);
       delete(ssEl.short);
       MVH.deleteEdComment(profile, ssEl);
       delete(ssEl.alias);
@@ -2953,6 +2952,15 @@ class FHIRExporter {
       if (dfIsNew) {
         this.insertExtensionElementInList(dfEl, profile.differential.element);
       }
+    }
+
+    // If there isn't already a base, add it.  It's always defined in the base resource and has 0..* cardinality.
+    if (!ssEl.base) {
+      ssEl.base = dfEl.base = {
+        path: `${MVH.sdType(profile)}.${extType}`,
+        min: 0,
+        max: '*'
+      };
     }
 
     const shrMap = sourcePath.map((pathElem) => {

--- a/lib/export.js
+++ b/lib/export.js
@@ -980,9 +980,11 @@ class FHIRExporter {
       df.mapping.push(shrMapping);
     } else {
       // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
-      // The shr.core.Quantity restriction is temporary, until support for that element is added
-      if (!sourceValue.identifier.isPrimitive && def.identifier.fqn != 'shr.core.Quantity') {
-        shrMapping['map'] = `<${sourceValue.identifier.fqn}>`;
+      if (!sourceValue.identifier.isPrimitive) {
+        // Build the mapping based on the sourcePath for the rule, to handle nested elements
+        shrMapping['map'] = rule.sourcePath.map((pathElem) => {
+          return `<${pathElem.fqn}>`;
+        }).join('.');
         ss.mapping.push(shrMapping);
         df.mapping.push(shrMapping);
       }

--- a/lib/export.js
+++ b/lib/export.js
@@ -986,7 +986,7 @@ class FHIRExporter {
       df.mapping.push(shrMapping);
     } else {
       // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
-      if (!sourceValue.identifier.isPrimitive) {
+      if (!sourceValue.identifier.isPrimitive && !sourceValue._derivedFromIncludesTypeConstraint) {
         // Build the mapping based on the sourcePath for the rule, to handle nested elements
         shrMapping['map'] = rule.sourcePath.map((pathElem) => {
           return `<${pathElem.fqn}>`;

--- a/lib/export.js
+++ b/lib/export.js
@@ -197,7 +197,7 @@ class FHIRExporter {
         const elem = profile.snapshot.element.find(e => e.id == rulePath);
         // If the snapshot element was found, add the mapping in as an 'shr' identity
         // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
-        if (elem && map.identifier.name == 'PatientSingleConstraintEntry') {
+        if (elem && !r.sourcePath[0].isPrimitive) {
           elem.mapping.push({ 'identity': 'shr', 'map': `<${r.sourcePath[0].fqn}>` });
         }
       }

--- a/lib/export.js
+++ b/lib/export.js
@@ -956,6 +956,17 @@ class FHIRExporter {
       return;
     }
 
+    // Insert mapping rules into the FHIR mapping element
+    ss.mapping = ss.mapping || [];
+    const isValue = sourceValue.effectiveIdentifier == def.value.identifier;
+    if (isValue) {
+      ss.mapping.push({ 'identity': 'shr', 'map': '<Value>' });
+    } else {
+      if (!sourceValue.identifier.isPrimitive) {
+        ss.mapping.push({ 'identity': 'shr', 'map': `<${sourceValue.identifier.fqn}>` });
+      }
+    }
+
     let df = common.getDifferentialElementById(profile, ss.id);
     const dfIsNew = (typeof df === 'undefined');
     if (dfIsNew) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -203,21 +203,6 @@ class FHIRExporter {
         });
       }
 
-      // Insert mapping rules into the FHIR mapping element
-      for (let r of map.rules) {
-        if (r.sourcePath == undefined) {
-          break;
-        }
-        const rulePath = `${map.targetItem}.${r.target}`;
-        // Find the profile snapshot element that corresponds to the mapping rule
-        const elem = profile.snapshot.element.find(e => e.id == rulePath);
-        // If the snapshot element was found, add the mapping in as an 'shr' identity
-        // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
-        if (elem && !r.sourcePath[0].isPrimitive) {
-          pushShrMapToElementMappings(`<${r.sourcePath[0].fqn}>`, elem);
-        }
-      }
-
       // There are some bugs in Argonauth resources that cause errors in the IG publisher.
       // Fix invalid ids in mappings (e.g., "us-core-(stu3)")
       if (this._target === 'FHIR_DSTU_2' && map.targetItem.startsWith('http://fhir.org/guides/argonaut/')) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -3213,6 +3213,15 @@ class FHIRExporter {
       MVH.setEdSliceName(profile, ssSliceSection[0], sliceName);
       MVH.setEdSliceName(profile, dfSliceSection[0], sliceName);
 
+      // Set the base
+      if (!ssSliceSection[0].base) {
+        ssSliceSection[0].base = dfSliceSection[0].base = {
+          path: baseElement.path,
+          min: baseElement.min,
+          max: baseElement.max
+        };
+      }
+
       // The base slice section element has slicing (from the copy), but we don't need to repeat that
       delete(ssSliceSection[0].slicing);
       delete(dfSliceSection[0].slicing);

--- a/lib/export.js
+++ b/lib/export.js
@@ -186,6 +186,15 @@ class FHIRExporter {
           ssEl.mapping.forEach(fixURI);
         }
       }
+      
+      // (2) Fix incorrect display text for US jurisdiction
+      if (profile.jurisdiction) {
+        profile.jurisdiction.forEach(j => {
+          if (j.coding) {
+            j.coding.forEach(c => { if (c.code === 'US') c.display = 'United States of America'; });
+          }
+        });
+      }
 
       // Insert mapping rules into the FHIR mapping element
       for (let r of map.rules) {
@@ -198,17 +207,9 @@ class FHIRExporter {
         // If the snapshot element was found, add the mapping in as an 'shr' identity
         // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
         if (elem && !r.sourcePath[0].isPrimitive) {
+          elem.mapping = elem.mapping || [];
           elem.mapping.push({ 'identity': 'shr', 'map': `<${r.sourcePath[0].fqn}>` });
         }
-      }
-      
-      // (2) Fix incorrect display text for US jurisdiction
-      if (profile.jurisdiction) {
-        profile.jurisdiction.forEach(j => {
-          if (j.coding) {
-            j.coding.forEach(c => { if (c.code === 'US') c.display = 'United States of America'; });
-          }
-        });
       }
 
       // There are some bugs in Argonauth resources that cause errors in the IG publisher.


### PR DESCRIPTION
Finalizes the SHR field mappings in ElementDefinitions, to be used by from- and toFHIR function definition in the shr-es6-exporter. 