### PR TITLE
Mcode fixes

### DIFF
--- a/lib/codeSystems.js
+++ b/lib/codeSystems.js
@@ -29,12 +29,12 @@ class CodeSystemExporter {
   exportCodeSystem(codeSystem) {
     const fhirCS = this._fhir.codeSystemTemplate;
     fhirCS.id = common.fhirID(codeSystem.identifier);
-    fhirCS.text.div = getTextDiv(codeSystem, this._config.projectShorthand);
+    fhirCS.text.div = getTextDiv(codeSystem);
     fhirCS.url = codeSystem.url;
     fhirCS.identifier.system = this._config.projectURL;
     fhirCS.identifier.value = codeSystem.identifier.fqn;
     fhirCS.name = codeSystem.identifier.name;
-    fhirCS.title = `${this._config.projectShorthand} ${codeSystem.identifier.name} CodeSystem`;
+    fhirCS.title = codeSystem.identifier.name;
     fhirCS.date = this._config.publishDate || common.todayString();
     fhirCS.publisher = this._config.publisher;
     fhirCS.contact = this._config.contact;
@@ -88,9 +88,9 @@ class CodeSystemExporter {
   }
 }
 
-function getTextDiv(codeSystem, projectShorthand) {
+function getTextDiv(codeSystem) {
   return `<div xmlns="http://www.w3.org/1999/xhtml">
-<p><b>${common.escapeHTML(projectShorthand + ' ' + codeSystem.identifier.name)} CodeSystem</b></p>
+<p><b>${common.escapeHTML(codeSystem.identifier.name)} CodeSystem</b></p>
 <p>${common.escapeHTML(codeSystem.description)}</p>
 </div>`;
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -243,6 +243,75 @@ class ProcessTracker {
   }
 }
 
+class TargetItem {
+  constructor(target, commands=[], comments) {
+    this._target = target;
+    this._commands = commands;
+    this._comments = comments;
+  }
+
+  static parse(itemTarget) {
+    const matches = /([^\s\(]+)(\s+\((.+)\))?(\s+\/\/\s*(.*))?/.exec(itemTarget);
+    if (matches == null || typeof matches[1] === 'undefined') {
+      return;
+    }
+    const target = matches[1];
+    let commands, comments;
+    if (typeof matches[3] !== 'undefined') {
+      commands = MappingCommand.parseMany(matches[3]);
+    }
+    if (typeof matches[5] !== 'undefined') {
+      comments = matches[5];
+    }
+    return new TargetItem(target, commands, comments);
+  }
+
+  get target() { return this._target; }
+  get commands() { return this._commands; }
+  get comments() { return this._comments; }
+
+  // The "noProfile" command indicates that no profile should be generated for the target item, despite any
+  // differences.  This is used when you want to use a resource (like Patient) as-is.
+  hasNoProfileCommand() {
+    return this._commands.some(c => c.key == 'no profile');
+  }
+  findNoProfileCommand() {
+    return this._commands.find(c => c.key == 'no profile');
+  }
+  addNoProfileCommand(at) {
+    this._commands.push(new MappingCommand('no profile', at));
+  }
+
+  toItemTarget() {
+    const commandStr = this._commands.length == 0 ? '' : ` (${this._commands.map(c => c.toString()).join('; ')})`;
+    const commentsStr = typeof this._comments === 'undefined' ? '' : ` // ${this._comments}`;
+    return `${this._target}${commandStr}${commentsStr}`;
+  }
+}
+
+class MappingCommand {
+  constructor(key, value) {
+    this._key = key;
+    this._value = value;
+  }
+
+  static parseSingle(command) {
+    const [k, v] = command.split('=', 2).map(s => s.trim());
+    return new MappingCommand(k, v);
+  }
+
+  static parseMany(commands) {
+    return commands.split(';').map(c => MappingCommand.parseSingle(c));
+  }
+
+  get key() { return this._key; }
+  get value() { return this._value; }
+
+  toString() {
+    return `${this._key} = ${this._value}`;
+  }
+}
+
 class FHIRExportError extends Error {
   constructor(message = 'FHIR export error') {
     super(message);
@@ -251,4 +320,4 @@ class FHIRExportError extends Error {
   }
 }
 
-module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, valueName, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, lowerFirst, todayString, isCustomProfile, typeToString, trim, getTarget, ProcessTracker};
+module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, valueName, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, lowerFirst, todayString, isCustomProfile, typeToString, trim, getTarget, ProcessTracker, TargetItem, MappingCommand};

--- a/lib/export.js
+++ b/lib/export.js
@@ -155,7 +155,8 @@ class FHIRExporter {
   mappingToProfile(map) {
     // Setup a child logger to associate logs with the current map
     const lastLogger = logger;
-    logger = rootLogger.child({ shrId: map.identifier.fqn, target: map.targetItem });
+    const targetItem = common.TargetItem.parse(map.targetItem);
+    logger = rootLogger.child({ shrId: map.identifier.fqn, target: targetItem.target });
     logger.debug('Start mapping element');
     this._processTracker.start(map.identifier.fqn, common.fhirID(map.identifier));
     try {
@@ -166,12 +167,12 @@ class FHIRExporter {
       const profileID = common.fhirID(map.identifier);
       const profileURL = common.fhirURL(map.identifier, this._config.fhirURL);
       if (REPORT_PROFILE_INDICATORS) {
-        this._profileIndicators.set(profileID, new ProfileIndicators(profileURL, map.targetItem));
+        this._profileIndicators.set(profileID, new ProfileIndicators(profileURL, targetItem.target));
       }
 
-      const def = this._fhir.find(map.targetItem);
+      const def = this._fhir.find(targetItem.target);
       if (typeof def === 'undefined') {
-        logger.error('Invalid FHIR target: %s. ERROR_CODE:13001', map.targetItem);
+        logger.error('Invalid FHIR target: %s. ERROR_CODE:13001', targetItem.target);
         return;
       }
       let profile = common.cloneJSON(def);
@@ -198,7 +199,7 @@ class FHIRExporter {
 
       // There are some bugs in Argonauth resources that cause errors in the IG publisher.
       // Fix invalid ids in mappings (e.g., "us-core-(stu3)")
-      if (this._target === 'FHIR_DSTU_2' && map.targetItem.startsWith('http://fhir.org/guides/argonaut/')) {
+      if (this._target === 'FHIR_DSTU_2' && targetItem.target.startsWith('http://fhir.org/guides/argonaut/')) {
         // Fix the mapping on the profile as well as each of its elements
         [profile, ...profile.snapshot.element].forEach(e => {
           if (e.mapping) {
@@ -269,7 +270,7 @@ class FHIRExporter {
 
       this.processMappingRules(map, profile);
       this.addExtensions(map, profile);
-      if (map.targetItem == 'Basic') {
+      if (targetItem.target == 'Basic') {
         this.setCodeOnBasic(map, profile);
       }
 
@@ -448,7 +449,7 @@ class FHIRExporter {
           return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition';
         });
       });
-      if (isNoDiffProfile) {
+      if (isNoDiffProfile || targetItem.hasNoProfileCommand()) {
         // Substitute it with the original resource!
         // First, remember the original id
         const originalId = profile.id;
@@ -620,6 +621,7 @@ class FHIRExporter {
   enhanceMap(map) {
     // We're going to mess with things, so let's just clone the mapping now!
     map = map.clone();
+    const targetItem = common.TargetItem.parse(map.target);
 
     // Some mapping rules indicate to slice using an "includes" strategy.  This means to slice on the
     // IncludesTypeConstraints.  To implement this, we expand the one mapping rule to many (one per IncludesType).
@@ -742,7 +744,7 @@ class FHIRExporter {
       }
 
       if (t.hasSliceNumberCommand()) {
-        const fhirDef = this._fhir.find(map.targetItem);
+        const fhirDef = this._fhir.find(targetItem.target);
         const ss = common.getSnapshotElement(fhirDef, t.target, parseInt(t.findSliceNumberCommand().value, 10));
         if (typeof ss === 'undefined') {
           logger.error(`Mapping to ${map.target}'s ${rule.target}: slice could not be found. ERROR_CODE:13046`);
@@ -929,7 +931,7 @@ class FHIRExporter {
         // To do this, we need to know what the source maps to (to determine the type to replace the [x])
         const map = this._specs.maps.findByTargetAndIdentifier(this._target, sourceValue.effectiveIdentifier);
         if (typeof map !== 'undefined') {
-          const newTarget = fieldTarget.target.replace(/\[x\]$/, common.capitalize(map.targetItem));
+          const newTarget = fieldTarget.target.replace(/\[x\]$/, common.capitalize(common.TargetItem.parse(map.targetItem).target));
           const newFieldTarget = new FieldTarget(newTarget, fieldTarget.commands, fieldTarget.comments);
           ss = this.getSnapshotElementForFieldTarget(profile, newFieldTarget, sourceValue, sliceCard);
         }
@@ -1540,7 +1542,7 @@ class FHIRExporter {
 
       const sMapsTo = this._specs.maps.findByTargetAndIdentifier(this._target, sourceValue.effectiveIdentifier);
       if (sMapsTo) {
-        sourceString += ` (mapped to ${sMapsTo.targetItem})`;
+        sourceString += ` (mapped to ${common.TargetItem.parse(sMapsTo.targetItem).target})`;
       }
       logger.error('Mismatched types. Cannot map %s to %s. ERROR_CODE:13022', sourceString, typesToString(snapshotEl.type));
       return;
@@ -1796,7 +1798,7 @@ class FHIRExporter {
 
     let matchedType;
     const sourceProfile = this.lookupProfile(sourceIdentifier, true, true);
-    const allowableTargetTypes = this.getTypeHierarchy(sourceMap.targetItem);
+    const allowableTargetTypes = this.getTypeHierarchy(common.TargetItem.parse(sourceMap.targetItem).target);
     const allowableTargetProfiles = allowableTargetTypes.map(t => this._fhir.find(t).url);
     const basedOnTargetProfiles = this.getRecursiveBasedOns(sourceIdentifier).map(b => common.fhirURL(b, this._config.fhirURL));
     for (let i=0; i < targetTypes.length; i++) {
@@ -3594,6 +3596,7 @@ class FHIRExporter {
   }
 }
 
+// NOTE: Similar "TargetItem" class is in common.js
 class FieldTarget {
   constructor(target, commands=[], comments) {
     this._target = target;
@@ -3609,7 +3612,7 @@ class FieldTarget {
     const target = matches[1];
     let commands, comments;
     if (typeof matches[3] !== 'undefined') {
-      commands = MappingCommand.parseMany(matches[3]);
+      commands = common.MappingCommand.parseMany(matches[3]);
     }
     if (typeof matches[5] !== 'undefined') {
       comments = matches[5];
@@ -3630,7 +3633,7 @@ class FieldTarget {
     return this._commands.find(c => c.key == 'slice at');
   }
   addSliceAtCommand(at) {
-    this._commands.push(new MappingCommand('slice at', at));
+    this._commands.push(new common.MappingCommand('slice at', at));
   }
 
   // The "slice on" command indicates what FHIR calls the "discriminator path".
@@ -3641,7 +3644,7 @@ class FieldTarget {
     return this._commands.find(c => c.key == 'slice on');
   }
   addSliceOnCommand(on) {
-    this._commands.push(new MappingCommand('slice on', on));
+    this._commands.push(new common.MappingCommand('slice on', on));
   }
 
   // The "slice on type" command indicates what FHIR calls the "discriminator type".
@@ -3653,7 +3656,7 @@ class FieldTarget {
     return this._commands.find(c => c.key == 'slice on type');
   }
   addSliceOnTypeCommand(on) {
-    this._commands.push(new MappingCommand('slice on type', on));
+    this._commands.push(new common.MappingCommand('slice on type', on));
   }
 
   // The "in slice" command is for elements to indicate what slice they belong to (by slice name).
@@ -3665,7 +3668,7 @@ class FieldTarget {
     return this._commands.find(c => c.key == 'in slice');
   }
   addInSliceCommand(sliceName) {
-    this._commands.push(new MappingCommand('in slice', sliceName));
+    this._commands.push(new common.MappingCommand('in slice', sliceName));
   }
 
   // The "slice #" command is used to map elements to an existing slice (when mapping to a profile).
@@ -3677,7 +3680,7 @@ class FieldTarget {
     return this._commands.find(c => c.key == 'slice #');
   }
   addSliceNumberCommand(sliceNumber) {
-    this._commands.push(new MappingCommand('slice #', sliceNumber));
+    this._commands.push(new common.MappingCommand('slice #', sliceNumber));
   }
 
   // The "slice strategy" command currently only supports one strategy: "includes".  If not set, then it slices
@@ -3689,36 +3692,13 @@ class FieldTarget {
     return this._commands.find(c => c.key == 'slice strategy');
   }
   addSliceStrategyCommand(strategy) {
-    this._commands.push(new MappingCommand('slice strategy', strategy));
+    this._commands.push(new common.MappingCommand('slice strategy', strategy));
   }
 
   toRuleTarget() {
     const commandStr = this._commands.length == 0 ? '' : ` (${this._commands.map(c => c.toString()).join('; ')})`;
     const commentsStr = typeof this._comments === 'undefined' ? '' : ` // ${this._comments}`;
     return `${this._target}${commandStr}${commentsStr}`;
-  }
-}
-
-class MappingCommand {
-  constructor(key, value) {
-    this._key = key;
-    this._value = value;
-  }
-
-  static parseSingle(command) {
-    const [k, v] = command.split('=', 2).map(s => s.trim());
-    return new MappingCommand(k, v);
-  }
-
-  static parseMany(commands) {
-    return commands.split(';').map(c => MappingCommand.parseSingle(c));
-  }
-
-  get key() { return this._key; }
-  get value() { return this._value; }
-
-  toString() {
-    return `${this._key} = ${this._value}`;
   }
 }
 
@@ -3813,7 +3793,7 @@ function aggregateCardinality(...card) {
 }
 
 function mappingAsText(map, simple=false) {
-  let text = `${map.identifier.fqn} maps to ${map.targetItem}:\n`;
+  let text = `${map.identifier.fqn} maps to ${common.TargetItem.parse(map.targetItem).target}:\n`;
   for (const rule of map.rules) {
     text += `  ${rule.toString()}\n`;
   }

--- a/lib/export.js
+++ b/lib/export.js
@@ -217,8 +217,8 @@ class FHIRExporter {
       profile.text = this.getText(originalMap);
       profile.url = profileURL;
       profile.identifier = [{ system: this._config.projectURL, value: map.identifier.fqn }];
-      profile.name = `${map.identifier.name}Profile`;
-      MVH.setSdTitle(profile, `${this._config.projectShorthand} ${map.identifier.name} Profile`);
+      profile.name = map.identifier.name;
+      MVH.setSdTitle(profile, map.identifier.name);
       profile.description = this.getDescription(map.identifier);
       profile.publisher = this._config.publisher;
       profile.contact = MVH.convertContactDetails(profile, this._config.contact);
@@ -558,9 +558,9 @@ class FHIRExporter {
       status: 'generated',
       div:
 `<div xmlns="http://www.w3.org/1999/xhtml">
-  <p><b>${common.escapeHTML(this._config.projectShorthand + ' ' + map.identifier.name)} Profile</b></p>
+  <p><b>${common.escapeHTML(map.identifier.name)} Profile</b></p>
   <p>${common.escapeHTML(this.getDescription(map.identifier))}</p>
-  <p><b>${common.escapeHTML(this._config.projectShorthand)} Mapping Summary</b></p>
+  <p><b>Mapping Summary</b></p>
   <p><pre>${common.escapeHTML(mappingAsText(map, true))}</pre></p>
 </div>`
     };
@@ -2868,7 +2868,7 @@ class FHIRExporter {
       ssEl.id = `${ssEl.id}:${common.shortID(identifier)}`;
       ssEl.path;
       MVH.setEdSliceName(profile, ssEl, common.shortID(identifier));
-      ssEl.definition = this.getDescription(identifier, `${this._config.projectShorthand} ${identifier.name} Extension`);
+      ssEl.definition = this.getDescription(identifier, identifier.name);
       ssEl.min = sourceValue.effectiveCard.min;
       ssEl.max = typeof sourceValue.effectiveCard.max === 'undefined' ? '*' : sourceValue.effectiveCard.max.toString();
       ssEl.type = [MVH.convertType(profile, { code : 'Extension', profile : extURL })];
@@ -2904,7 +2904,7 @@ class FHIRExporter {
       }
       // If it already has a definition, just keep it as is since we shouldn't be chaning semantic meaning
       if (typeof ssEl.definition === 'undefined') {
-        dfEl.definition = ssEl.definition = this.getDescription(identifier, `SHR ${identifier.name} Extension`);
+        dfEl.definition = ssEl.definition = this.getDescription(identifier, identifier.name);
       }
       const targetCard = getFHIRElementCardinality(ssEl);
       if (sourceValue.effectiveCard.fitsWithinCardinalityOf(targetCard)) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -218,7 +218,7 @@ class FHIRExporter {
       profile.url = profileURL;
       profile.identifier = [{ system: this._config.projectURL, value: map.identifier.fqn }];
       profile.name = map.identifier.name;
-      MVH.setSdTitle(profile, map.identifier.name);
+      MVH.setSdTitle(profile, common.fhirID(map.identifier));
       profile.description = this.getDescription(map.identifier);
       profile.publisher = this._config.publisher;
       profile.contact = MVH.convertContactDetails(profile, this._config.contact);

--- a/lib/export.js
+++ b/lib/export.js
@@ -2834,11 +2834,7 @@ class FHIRExporter {
 
   addExtension(def, profile, sourcePath, extURL) {
     const sourceValue = this.findValueByPath(sourcePath, def);
-    if (sourceValue.effectiveCard.max == 0) {
-      // Since we're based on FHIR Resources (and don't base on other Profiles), it doesn't make sense to profile *out*
-      // an extension -- since the extension isn't in the base resource to begin with.  So, instead, just skip it.
-      return;
-    }
+    const aggSourceCard = this.getAggregateEffectiveCardinality(def.identifier, sourcePath);
 
     const identifier = sourceValue.effectiveIdentifier;
 
@@ -2863,14 +2859,18 @@ class FHIRExporter {
 
     let dfEl; // To be assigned later
     if (typeof ssEl === 'undefined') {
+      // Don't add a new extension if the card is 0..0, because that doesn't add value.  It only confuses.
+      if (aggSourceCard.max == 0) {
+        return;
+      }
       // Find the base extension element from which this extension will be derived
       ssEl = common.cloneJSON(baseExtEl);
       ssEl.id = `${ssEl.id}:${common.shortID(identifier)}`;
       ssEl.path;
       MVH.setEdSliceName(profile, ssEl, common.shortID(identifier));
       ssEl.definition = this.getDescription(identifier, identifier.name);
-      ssEl.min = sourceValue.effectiveCard.min;
-      ssEl.max = typeof sourceValue.effectiveCard.max === 'undefined' ? '*' : sourceValue.effectiveCard.max.toString();
+      ssEl.min = aggSourceCard.min;
+      ssEl.max = typeof aggSourceCard.max === 'undefined' ? '*' : aggSourceCard.max.toString();
       ssEl.type = [MVH.convertType(profile, { code : 'Extension', profile : extURL })];
       // TODO: Do we need to add the condition and constraints here?
       if (isModifier) {
@@ -2907,10 +2907,10 @@ class FHIRExporter {
         dfEl.definition = ssEl.definition = this.getDescription(identifier, identifier.name);
       }
       const targetCard = getFHIRElementCardinality(ssEl);
-      if (sourceValue.effectiveCard.fitsWithinCardinalityOf(targetCard)) {
-        setCardinalityOnFHIRElements(sourceValue.effectiveCard, ssEl, dfEl);
+      if (aggSourceCard.fitsWithinCardinalityOf(targetCard)) {
+        setCardinalityOnFHIRElements(aggSourceCard, ssEl, dfEl);
       } else {
-        logger.error('Cannot constrain cardinality from %s to %s. ERROR_CODE:13014', targetCard.toString(), sourceValue.effectiveCard.toString());
+        logger.error('Cannot constrain cardinality from %s to %s. ERROR_CODE:13014', targetCard.toString(), aggSourceCard.toString());
       }
       if (isModifier && (typeof ssEl.mustSupport === 'undefined' || !ssEl.mustSupport)) {
         dfEl.mustSupport = ssEl.mustSupport = true;

--- a/lib/export.js
+++ b/lib/export.js
@@ -28,7 +28,8 @@ function setLogger(bunyanLogger) {
 const allowedConversions = {
   'boolean': ['code'],
   'dateTime': ['date', 'instant'],
-  'shr.core.CodeableConcept': ['Coding', 'code']
+  'shr.core.CodeableConcept': ['Coding', 'code'],
+  'shr.core.Coding': ['CodeableConcept', 'code']
 };
 
 function exportToFHIR(specifications, configuration) {
@@ -1053,6 +1054,19 @@ class FHIRExporter {
         if (typeof sdToUnroll === 'undefined') {
           logger.error('Cannot unroll %s at %s: invalid SHR element. ERROR_CODE:13010', identifier.fqn, snapshotEl.id);
           return;
+        }
+        // If the element types don't allow the looked up profile type, this may be a case of an allowable conversion
+        // (e.g., CIMPL element is Coding and FHIR type is CodeableConcept).  In this case, unroll the target FHIR type.
+        if (!snapshotEl.type.some(t => t.code === MVH.sdType(sdToUnroll))) {
+          // If there is an allowed conversion type, use that instead
+          const allowed = this.findAllowedConversionTargetTypes(identifier, snapshotEl.type);
+          if (allowed.length > 0) {
+            // Multiple values are possible but not likely. There's no way to choose, so just take the first one.
+            sdToUnroll = this.lookupStructureDefinition(allowed[0].code);
+          } else {
+            // Nothing matched.  This will fall through to an error.
+            sdToUnroll = null;
+          }
         }
       }
     } else {
@@ -2528,16 +2542,11 @@ class FHIRExporter {
       return;
     }
 
-    let codeType;
-    if (identifier instanceof mdls.Identifier) {
-      codeType = identifier.fqn;
-    } else {
-      codeType = identifier;
-    }
-
     if (snapshotEl.path.endsWith('[x]')) {
       [snapshotEl, differentialEl] = this.addExplicitChoiceElement(identifier, profile, snapshotEl, differentialEl);
     }
+
+    const codeType = ['Quantity', 'CodeableConcept', 'Coding', 'code'].find(c => snapshotEl.type.some(t => t.code === c));
 
     // Different behavior based on code type
     switch (codeType) {
@@ -2551,9 +2560,7 @@ class FHIRExporter {
         }
       }
       return; // we're done here!
-    case 'shr.core.Coding':
     case 'Coding':
-    case 'shr.core.Quantity':
     case 'Quantity': {
       // First check if there's an existing fixed[x] or pattern[x] applied
       let fixedPropName;
@@ -2603,7 +2610,6 @@ class FHIRExporter {
       }
       // TODO: Differentials?
     } return;
-    case 'shr.core.CodeableConcept':
     case 'CodeableConcept': {
       // First check if there's an existing fixedCodeableConcept or patternCodeableConcept applied
       let fixedPropName;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -493,14 +493,13 @@ class ExtensionExporter {
           return;
         }
         const code = VALUE_SUPPORTED_TYPES.indexOf(map.targetItem) >= 0 ? map.targetItem : 'Reference';
-        const typeObj = { code };
         const profile = this._profileExporter.lookupProfile(map.identifier, true, true);
         if (code == 'Reference') {
           return { code: code, targetProfile: profile.url };
         } else if (common.isCustomProfile(profile)) {
           return { code: code, profile: profile.url };
         }
-        return typeObj;
+        return { code };
       }
     }
   }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -98,7 +98,7 @@ class ExtensionExporter {
     let type, value;
     const map = this._specs.maps.findByTargetAndIdentifier(this._target, def.identifier);
     if (typeof map !== 'undefined') {
-      type = VALUE_SUPPORTED_TYPES.indexOf(map.targetItem) >= 0 ? map.targetItem : 'Reference';
+      type = VALUE_SUPPORTED_TYPES.indexOf(common.TargetItem.parse(map.targetItem).target) >= 0 ? common.TargetItem.parse(map.targetItem).target : 'Reference';
       value = new mdls.IdentifiableValue(map.identifier).withMinMax(1,1);
     } else if (typeof def.value !== 'undefined' && def.value.effectiveCard.max <= 1 && def.fields.length == 0) {
       if (def.value instanceof mdls.ChoiceValue && this.choiceSupportsValueX(def.value)) {
@@ -111,7 +111,7 @@ class ExtensionExporter {
         } else {
           const valMap = this._specs.maps.findByTargetAndIdentifier(this._target, def.value.identifier);
           if (typeof valMap !== 'undefined') {
-            type = VALUE_SUPPORTED_TYPES.indexOf(valMap.targetItem) >= 0 ? valMap.targetItem : 'Reference';
+            type = VALUE_SUPPORTED_TYPES.indexOf(common.TargetItem.parse(valMap.targetItem).target) >= 0 ? common.TargetItem.parse(valMap.targetItem).target : 'Reference';
             value = def.value;
           }
         }
@@ -492,7 +492,7 @@ class ExtensionExporter {
         if (typeof map === 'undefined') {
           return;
         }
-        const code = VALUE_SUPPORTED_TYPES.indexOf(map.targetItem) >= 0 ? map.targetItem : 'Reference';
+        const code = VALUE_SUPPORTED_TYPES.indexOf(common.TargetItem.parse(map.targetItem).target) >= 0 ? common.TargetItem.parse(map.targetItem).target : 'Reference';
         const profile = this._profileExporter.lookupProfile(map.identifier, true, true);
         if (code == 'Reference') {
           return { code: code, targetProfile: profile.url };

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -60,7 +60,7 @@ class ExtensionExporter {
     ext.url = common.fhirURL(def.identifier, this._config.fhirURL, 'extension');
 
     ext.name = def.identifier.name;
-    MVH.setSdTitle(ext, def.identifier.name);
+    MVH.setSdTitle(ext, common.fhirID(def.identifier));
     ext.publisher = this._config.publisher;
     ext.contact = MVH.convertContactDetails(ext, this._config.contact);
     ext.identifier[0].value = def.identifier.fqn;

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -50,7 +50,7 @@ class ExtensionExporter {
     if (typeof def === 'undefined' && identifier.isPrimitive) {
       // We can cheat by creating a definition to represent the primitive value
       def = new mdls.DataElement(identifier, false)
-        .withDescription(`The ${identifier.name} that represents the value of the ${this._config.projectShorthand} element to which it is applied.`)
+        .withDescription(`The ${identifier.name} that represents the value of the element to which it is applied.`)
         .withValue(new mdls.IdentifiableValue(identifier).withMinMax(1,1));
     }
 
@@ -59,8 +59,8 @@ class ExtensionExporter {
     ext.text.div = this.getTextDiv(identifier);
     ext.url = common.fhirURL(def.identifier, this._config.fhirURL, 'extension');
 
-    ext.name = `${def.identifier.name}Extension`;
-    MVH.setSdTitle(ext, `${this._config.projectShorthand} ${def.identifier.name} Extension`);
+    ext.name = def.identifier.name;
+    MVH.setSdTitle(ext, def.identifier.name);
     ext.publisher = this._config.publisher;
     ext.contact = MVH.convertContactDetails(ext, this._config.contact);
     ext.identifier[0].value = def.identifier.fqn;
@@ -191,7 +191,7 @@ class ExtensionExporter {
     const ssExt = {
       id: `${baseId}`,
       path: `${this.getExtensionPathFromExtensionID(baseId)}`,
-      short: def.identifier.isPrimitive ? def.identifier.name : `${this._config.projectShorthand} ${def.identifier.name} Extension`,
+      short: def.identifier.name,
       definition: def.description ? def.description.trim() : undefined,
       min: card.min,
       max: typeof card.max === 'undefined' ? '*' : card.max.toString(),
@@ -512,7 +512,7 @@ class ExtensionExporter {
       description = def.description.trim();
     }
     return `<div xmlns="http://www.w3.org/1999/xhtml">
-  <p><b>${common.escapeHTML(this._config.projectShorthand + ' ' + identifier.name)} Extension</b></p>
+  <p><b>${common.escapeHTML(identifier.name)} Extension</b></p>
   <p>${common.escapeHTML(description)}</p>
 </div>`;
   }

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -171,7 +171,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     };
     pushXmlResource(`StructureDefinition/${profile.id}`, MVH.sdTitle(profile), 'profile');
 
-    const name = MVH.sdTitle(profile).replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ Profile$/, '');
+    const name = MVH.sdTitle(profile);
     const sdType = MVH.sdType(profile);
     let fhirHREF;
     const fhirJSON = fhir.find(sdType);
@@ -240,8 +240,8 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
       fs.writeFileSync(mapPath,
 `
 <p> </p>
-<p><b>${config.projectShorthand} Mapping Source</b></p>
-<p>This structure represents the following ${config.projectShorthand} mapping definition:</p>
+<p><b>Mapping Source</b></p>
+<p>This structure represents the following mapping definition:</p>
 <pre>
 ${match[1]}
 </pre>`
@@ -309,7 +309,7 @@ ${match[1]}
       'template-base': 'sd-extension.html',
     };
     pushXmlResource(`StructureDefinition/${extension.id}`, MVH.sdTitle(extension), 'extension');
-    const name = MVH.sdTitle(extension).replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ Extension$/, '');
+    const name = MVH.sdTitle(extension);
     if (!hideSupporting || primaryExtensionUrls.has(extension.url)) {
       htmlExtensions.push(
         `<tr>
@@ -357,7 +357,7 @@ ${match[1]}
     }
     pushXmlResource(`ValueSet/${valueSet.id}`, MVH.vsTitle(valueSet), 'terminology');
 
-    const name = MVH.vsTitle(valueSet).replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ ValueSet$/, '');
+    const name = MVH.vsTitle(valueSet);
     if (!hideSupporting || primaryLocalValueSetUrls.has(valueSet.url)) {
       htmlLocalValueSets.push(
         `<tr>
@@ -410,7 +410,7 @@ ${match[1]}
       }
       pushXmlResource(`CodeSystem/${codeSystem.id}`, codeSystem.title, 'terminology');
 
-      const name = codeSystem.title.replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ CodeSystem$/, '');
+      const name = codeSystem.title;
       if (!hideSupporting || primaryCodeSystemUrls.has(codeSystem.url)) {
         htmlCodeSystems.push(
         `<tr>
@@ -436,7 +436,7 @@ ${match[1]}
       };
       pushXmlResource(`StructureDefinition/${model.id}`, model.name, 'logical');
 
-      const name = MVH.sdTitle(model).replace(new RegExp('^' + config.projectShorthand + ' '), '').replace(/ Logical Model$/, '');
+      const name = MVH.sdTitle(model);
       const htmlSnippet =
       `<tr>
         <td><a href="StructureDefinition-${model.id}.html">${name}</a></td>
@@ -521,8 +521,7 @@ ${match[1]}
   const profilesHtmlPath = path.join(outDir, 'pages', 'profiles.html');
   const profilesHtml = fs.readFileSync(profilesHtmlPath, 'utf8');
   let updatedProfilesHtml = profilesHtml.replace('<primary-profiles-go-here/>', htmlPrimaryProfiles.join(''))
-    .replace('<support-profiles-go-here/>', htmlSupportProfiles.join(''))
-    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+    .replace('<support-profiles-go-here/>', htmlSupportProfiles.join(''));
   if (hideSupporting) {
     updatedProfilesHtml = updatedProfilesHtml
       .replace('<h2 id="supporting-profiles-header">', '<h2 id="supporting-profiles-header" style="display: none">')
@@ -534,8 +533,7 @@ ${match[1]}
   // Rewrite the updated Extensions HTML file
   const extensionsHtmlPath = path.join(outDir, 'pages', 'extensions.html');
   const extensionsHtml = fs.readFileSync(extensionsHtmlPath, 'utf8');
-  let updatedExtensionsHtml = extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''))
-    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+  let updatedExtensionsHtml = extensionsHtml.replace('<extensions-go-here/>', htmlExtensions.join(''));
   if (htmlExtensions.length === 0) {
     updatedExtensionsHtml = updatedExtensionsHtml
       .replace('<table class="codes">', 'None\n<table class="codes" style="display: none">');
@@ -554,8 +552,7 @@ ${match[1]}
   const valueSetsHtmlPath = path.join(outDir, 'pages', 'valuesets.html');
   const valueSetsHtml = fs.readFileSync(valueSetsHtmlPath, 'utf8');
   let updatedValueSetsHtml = valueSetsHtml.replace('<local-value-sets-go-here/>', htmlLocalValueSets.join(''))
-    .replace('<external-value-sets-go-here/>', htmlExternalValueSets.join(''))
-    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+    .replace('<external-value-sets-go-here/>', htmlExternalValueSets.join(''));
   if (hideSupporting) {
     updatedValueSetsHtml = updatedValueSetsHtml
       .replace('<local-value-sets-header/>', '<h2>Primary local value sets used in this Implementation Guide</h2>')
@@ -586,8 +583,7 @@ ${match[1]}
   </ol>
   <p>This list is not inclusive of code systems associated with external value sets used in the IG.</p>`;
   let updatedCodeSystemsHtml = codeSystemsHtml.replace('<code-systems-go-here/>', htmlCodeSystems.join(''))
-    .replace('<code-systems-disclaimer/>', codeSystemsDisclaimer)
-    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+    .replace('<code-systems-disclaimer/>', codeSystemsDisclaimer);
   if (hideSupporting) {
     updatedCodeSystemsHtml = updatedCodeSystemsHtml
       .replace('<code-systems-header/>', '<h2>Primary code systems used in this Implementation Guide</h2>');
@@ -606,8 +602,7 @@ ${match[1]}
   const modelsHtmlPath = path.join(outDir, 'pages', 'logical.html');
   const modelsHtml = fs.readFileSync(modelsHtmlPath, 'utf8');
   let updatedModelsHtml = modelsHtml.replace('<primary-models-go-here/>', htmlPrimaryModels.join(''))
-    .replace('<support-models-go-here/>', htmlSupportModels.join(''))
-    .replace('<project-shorthand-go-here/>', config.projectShorthand);
+    .replace('<support-models-go-here/>', htmlSupportModels.join(''));
   if (hideSupporting) {
     updatedModelsHtml = updatedModelsHtml
       .replace('<h2 id="supporting-models-header">', '<h2 id="supporting-models-header" style="display: none">')

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -171,7 +171,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     };
     pushXmlResource(`StructureDefinition/${profile.id}`, MVH.sdTitle(profile), 'profile');
 
-    const name = MVH.sdTitle(profile);
+    const name = profile.name;
     const sdType = MVH.sdType(profile);
     let fhirHREF;
     const fhirJSON = fhir.find(sdType);
@@ -309,7 +309,7 @@ ${match[1]}
       'template-base': 'sd-extension.html',
     };
     pushXmlResource(`StructureDefinition/${extension.id}`, MVH.sdTitle(extension), 'extension');
-    const name = MVH.sdTitle(extension);
+    const name = extension.name;
     if (!hideSupporting || primaryExtensionUrls.has(extension.url)) {
       htmlExtensions.push(
         `<tr>
@@ -436,7 +436,7 @@ ${match[1]}
       };
       pushXmlResource(`StructureDefinition/${model.id}`, model.name, 'logical');
 
-      const name = MVH.sdTitle(model);
+      const name = model.name;
       const htmlSnippet =
       `<tr>
         <td><a href="StructureDefinition-${model.id}.html">${name}</a></td>

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -83,8 +83,8 @@ class ModelsExporter {
       model.text = this.getText(def);
       model.url = common.fhirURL(def.identifier, this._config.fhirURL, 'model');
       model.identifier = [{ system: this._config.projectURL, value: def.identifier.fqn }],
-      model.name = `${def.identifier.name}Model`;
-      model.title = def.identifier.name;
+      model.name = def.identifier.name;
+      model.title = common.fhirID(def.identifier);
       model.status = 'draft';
       model.date = this._config.publishDate || common.todayString();
       model.publisher = this._config.publisher;

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -84,7 +84,7 @@ class ModelsExporter {
       model.url = common.fhirURL(def.identifier, this._config.fhirURL, 'model');
       model.identifier = [{ system: this._config.projectURL, value: def.identifier.fqn }],
       model.name = `${def.identifier.name}Model`;
-      model.title = `${this._config.projectShorthand} ${def.identifier.name} Logical Model`;
+      model.title = def.identifier.name;
       model.status = 'draft';
       model.date = this._config.publishDate || common.todayString();
       model.publisher = this._config.publisher;
@@ -712,7 +712,7 @@ class ModelsExporter {
       status: 'generated',
       div:
 `<div xmlns="http://www.w3.org/1999/xhtml">
-  <p><b>${common.escapeHTML(this._config.projectShorthand + ' ' + def.identifier.name)} Logical Model</b></p>
+  <p><b>${common.escapeHTML(def.identifier.name)} Logical Model</b></p>
   <p>${common.escapeHTML(this.getDescription(def.identifier))}</p>
 </div>`
     };

--- a/lib/multiVersionHelper.js
+++ b/lib/multiVersionHelper.js
@@ -366,6 +366,7 @@ function convertType(structDef, type) {
   } else if (type.targetProfile != null) {
     newType.profile = [type.targetProfile];
   }
+  delete(newType.targetProfile);
   return newType;
 }
 

--- a/lib/valueSets.js
+++ b/lib/valueSets.js
@@ -30,11 +30,11 @@ class ValueSetExporter {
   exportValueSet(valueSet) {
     const fhirVS = this._fhir.valueSetTemplate;
     fhirVS.id = common.fhirID(valueSet.identifier/*, 'valueset'*/);
-    fhirVS.text.div = getTextDiv(valueSet, this._config.projectShorthand);
+    fhirVS.text.div = getTextDiv(valueSet);
     fhirVS.url = valueSet.url;
     MVH.setVsIdentifier(fhirVS, [{ system: this._config.projectURL, value: valueSet.identifier.fqn}]);
     fhirVS.name = `${valueSet.identifier.name}`;
-    MVH.setVsTitle(fhirVS, `${this._config.projectShorthand} ${valueSet.identifier.name} ValueSet`);
+    MVH.setVsTitle(fhirVS, valueSet.identifier.name);
     fhirVS.date = this._config.publishDate || common.todayString();
     fhirVS.publisher = this._config.publisher;
     // Since fhirVS doesn't have a fhirVersion attribute, create a dummy one needed for the MVH call
@@ -183,9 +183,9 @@ class ValueSetExporter {
   }
 }
 
-function getTextDiv(valueSet, projectShorthand) {
+function getTextDiv(valueSet) {
   return `<div xmlns="http://www.w3.org/1999/xhtml">
-<p><b>${common.escapeHTML(projectShorthand + ' ' + valueSet.identifier.name)} ValueSet</b></p>
+<p><b>${common.escapeHTML(valueSet.identifier.name)} ValueSet</b></p>
 <p>${common.escapeHTML(valueSet.description)}</p>
 </div>`;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.9.0-beta.1",
+  "version": "5.9.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.8.1",
+  "version": "5.9.0-beta.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/test/fixtures/AbstractAndPlainGroup.json
+++ b/test/fixtures/AbstractAndPlainGroup.json
@@ -4,7 +4,7 @@
     "id": "shr-test-AbstractAndPlainGroup-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR AbstractAndPlainGroup Logical Model</b></p>\n  <p>It is an abstract group of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>AbstractAndPlainGroup Logical Model</b></p>\n  <p>It is an abstract group of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-AbstractAndPlainGroup-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.AbstractAndPlainGroup"
       }
     ],
-    "name": "AbstractAndPlainGroupModel",
-    "title": "FOOBAR AbstractAndPlainGroup Logical Model",
+    "name": "AbstractAndPlainGroup",
+    "title": "shr-test-AbstractAndPlainGroup",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -197,7 +197,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -206,8 +206,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -320,7 +320,7 @@
     "id": "shr-test-Plain-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Plain Logical Model</b></p>\n  <p>It is not an entry element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Plain Logical Model</b></p>\n  <p>It is not an entry element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Plain-model",
     "identifier": [
@@ -329,8 +329,8 @@
         "value": "shr.test.Plain"
       }
     ],
-    "name": "PlainModel",
-    "title": "FOOBAR Plain Logical Model",
+    "name": "Plain",
+    "title": "shr-test-Plain",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/BooleanAndCodeConstraints.json
+++ b/test/fixtures/BooleanAndCodeConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Bool-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Bool Logical Model</b></p>\n  <p>A boolean element.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Bool Logical Model</b></p>\n  <p>A boolean element.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Bool-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Bool"
       }
     ],
-    "name": "BoolModel",
-    "title": "FOOBAR Bool Logical Model",
+    "name": "Bool",
+    "title": "shr-test-Bool",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -120,7 +120,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -129,8 +129,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -248,7 +248,7 @@
     "id": "shr-test-BooleanAndCodeConstraints-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR BooleanAndCodeConstraints Logical Model</b></p>\n  <p>It has boolean and code constraints.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>BooleanAndCodeConstraints Logical Model</b></p>\n  <p>It has boolean and code constraints.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-BooleanAndCodeConstraints-model",
     "identifier": [
@@ -257,8 +257,8 @@
         "value": "shr.test.BooleanAndCodeConstraints"
       }
     ],
-    "name": "BooleanAndCodeConstraintsModel",
-    "title": "FOOBAR BooleanAndCodeConstraints Logical Model",
+    "name": "BooleanAndCodeConstraints",
+    "title": "shr-test-BooleanAndCodeConstraints",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -452,7 +452,7 @@
     "id": "shr-test-Group-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Group-model",
     "identifier": [
@@ -461,8 +461,8 @@
         "value": "shr.test.Group"
       }
     ],
-    "name": "GroupModel",
-    "title": "FOOBAR Group Logical Model",
+    "name": "Group",
+    "title": "shr-test-Group",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -704,7 +704,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -713,8 +713,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -827,7 +827,7 @@
     "id": "shr-test-ForeignElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ForeignElementValue-model",
     "identifier": [
@@ -836,8 +836,8 @@
         "value": "shr.test.ForeignElementValue"
       }
     ],
-    "name": "ForeignElementValueModel",
-    "title": "FOOBAR ForeignElementValue Logical Model",
+    "name": "ForeignElementValue",
+    "title": "shr-test-ForeignElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -957,7 +957,7 @@
     "id": "shr-test-ElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model",
     "identifier": [
@@ -966,8 +966,8 @@
         "value": "shr.test.ElementValue"
       }
     ],
-    "name": "ElementValueModel",
-    "title": "FOOBAR ElementValue Logical Model",
+    "name": "ElementValue",
+    "title": "shr-test-ElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -1087,7 +1087,7 @@
     "id": "shr-other-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model",
     "identifier": [
@@ -1096,8 +1096,8 @@
         "value": "shr.other.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-other-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/Choice.json
+++ b/test/fixtures/Choice.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Choice-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Choice Logical Model</b></p>\n  <p>It is an element with a choice</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Choice Logical Model</b></p>\n  <p>It is an element with a choice</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Choice-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Choice"
       }
     ],
-    "name": "ChoiceModel",
-    "title": "FOOBAR Choice Logical Model",
+    "name": "Choice",
+    "title": "shr-test-Choice",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -208,7 +208,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -217,8 +217,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/ChoiceOfChoice.json
+++ b/test/fixtures/ChoiceOfChoice.json
@@ -4,7 +4,7 @@
     "id": "shr-test-ChoiceOfChoice-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ChoiceOfChoice Logical Model</b></p>\n  <p>It is an element with a choice containing a choice</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ChoiceOfChoice Logical Model</b></p>\n  <p>It is an element with a choice containing a choice</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ChoiceOfChoice-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.ChoiceOfChoice"
       }
     ],
-    "name": "ChoiceOfChoiceModel",
-    "title": "FOOBAR ChoiceOfChoice Logical Model",
+    "name": "ChoiceOfChoice",
+    "title": "shr-test-ChoiceOfChoice",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/ChoiceValueSetConstraint.json
+++ b/test/fixtures/ChoiceValueSetConstraint.json
@@ -4,7 +4,7 @@
     "id": "shr-test-CodedChoice-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR CodedChoice Logical Model</b></p>\n  <p>An element with a choice of code fields.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>CodedChoice Logical Model</b></p>\n  <p>An element with a choice of code fields.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-CodedChoice-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.CodedChoice"
       }
     ],
-    "name": "CodedChoiceModel",
-    "title": "FOOBAR CodedChoice Logical Model",
+    "name": "CodedChoice",
+    "title": "shr-test-CodedChoice",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -126,7 +126,7 @@
     "id": "shr-test-ChoiceValueSetConstraint-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ChoiceValueSetConstraint Logical Model</b></p>\n  <p>It has valueset constraints on a choice field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ChoiceValueSetConstraint Logical Model</b></p>\n  <p>It has valueset constraints on a choice field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ChoiceValueSetConstraint-model",
     "identifier": [
@@ -135,8 +135,8 @@
         "value": "shr.test.ChoiceValueSetConstraint"
       }
     ],
-    "name": "ChoiceValueSetConstraintModel",
-    "title": "FOOBAR ChoiceValueSetConstraint Logical Model",
+    "name": "ChoiceValueSetConstraint",
+    "title": "shr-test-ChoiceValueSetConstraint",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -324,7 +324,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -333,8 +333,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/Coded.json
+++ b/test/fixtures/Coded.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/ElementValue.json
+++ b/test/fixtures/ElementValue.json
@@ -4,7 +4,7 @@
     "id": "shr-test-ElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.ElementValue"
       }
     ],
-    "name": "ElementValueModel",
-    "title": "FOOBAR ElementValue Logical Model",
+    "name": "ElementValue",
+    "title": "shr-test-ElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -134,7 +134,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -143,8 +143,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/FixedCodeExtravaganza.json
+++ b/test/fixtures/FixedCodeExtravaganza.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -132,7 +132,7 @@
     "id": "shr-test-FixedCodeExtravaganza-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR FixedCodeExtravaganza Logical Model</b></p>\n  <p>An element with all sorts of fixed codes.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FixedCodeExtravaganza Logical Model</b></p>\n  <p>An element with all sorts of fixed codes.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-FixedCodeExtravaganza-model",
     "identifier": [
@@ -141,8 +141,8 @@
         "value": "shr.test.FixedCodeExtravaganza"
       }
     ],
-    "name": "FixedCodeExtravaganzaModel",
-    "title": "FOOBAR FixedCodeExtravaganza Logical Model",
+    "name": "FixedCodeExtravaganza",
+    "title": "shr-test-FixedCodeExtravaganza",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -1418,7 +1418,7 @@
     "id": "shr-core-CodeSystem-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR CodeSystem Logical Model</b></p>\n  <p></p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>CodeSystem Logical Model</b></p>\n  <p></p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-core-CodeSystem-model",
     "identifier": [
@@ -1427,8 +1427,8 @@
         "value": "shr.core.CodeSystem"
       }
     ],
-    "name": "CodeSystemModel",
-    "title": "FOOBAR CodeSystem Logical Model",
+    "name": "CodeSystem",
+    "title": "shr-core-CodeSystem",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -1535,7 +1535,7 @@
     "id": "shr-core-CodeSystemVersion-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR CodeSystemVersion Logical Model</b></p>\n  <p></p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>CodeSystemVersion Logical Model</b></p>\n  <p></p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-core-CodeSystemVersion-model",
     "identifier": [
@@ -1544,8 +1544,8 @@
         "value": "shr.core.CodeSystemVersion"
       }
     ],
-    "name": "CodeSystemVersionModel",
-    "title": "FOOBAR CodeSystemVersion Logical Model",
+    "name": "CodeSystemVersion",
+    "title": "shr-core-CodeSystemVersion",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -1652,7 +1652,7 @@
     "id": "shr-core-DisplayText-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR DisplayText Logical Model</b></p>\n  <p></p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>DisplayText Logical Model</b></p>\n  <p></p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-core-DisplayText-model",
     "identifier": [
@@ -1661,8 +1661,8 @@
         "value": "shr.core.DisplayText"
       }
     ],
-    "name": "DisplayTextModel",
-    "title": "FOOBAR DisplayText Logical Model",
+    "name": "DisplayText",
+    "title": "shr-core-DisplayText",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/ForeignElementValue.json
+++ b/test/fixtures/ForeignElementValue.json
@@ -4,7 +4,7 @@
     "id": "shr-test-ForeignElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ForeignElementValue-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.ForeignElementValue"
       }
     ],
-    "name": "ForeignElementValueModel",
-    "title": "FOOBAR ForeignElementValue Logical Model",
+    "name": "ForeignElementValue",
+    "title": "shr-test-ForeignElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -134,7 +134,7 @@
     "id": "shr-other-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model",
     "identifier": [
@@ -143,8 +143,8 @@
         "value": "shr.other.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-other-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/ForeignSimple.json
+++ b/test/fixtures/ForeignSimple.json
@@ -4,7 +4,7 @@
     "id": "shr-other-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.other.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-other-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/Group.json
+++ b/test/fixtures/Group.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Group-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Group-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Group"
       }
     ],
-    "name": "GroupModel",
-    "title": "FOOBAR Group Logical Model",
+    "name": "Group",
+    "title": "shr-test-Group",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -256,7 +256,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -265,8 +265,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -379,7 +379,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -388,8 +388,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -507,7 +507,7 @@
     "id": "shr-test-ForeignElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ForeignElementValue-model",
     "identifier": [
@@ -516,8 +516,8 @@
         "value": "shr.test.ForeignElementValue"
       }
     ],
-    "name": "ForeignElementValueModel",
-    "title": "FOOBAR ForeignElementValue Logical Model",
+    "name": "ForeignElementValue",
+    "title": "shr-test-ForeignElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -637,7 +637,7 @@
     "id": "shr-test-ElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model",
     "identifier": [
@@ -646,8 +646,8 @@
         "value": "shr.test.ElementValue"
       }
     ],
-    "name": "ElementValueModel",
-    "title": "FOOBAR ElementValue Logical Model",
+    "name": "ElementValue",
+    "title": "shr-test-ElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -767,7 +767,7 @@
     "id": "shr-other-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model",
     "identifier": [
@@ -776,8 +776,8 @@
         "value": "shr.other.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-other-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/GroupWithChoiceOfChoice.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.json
@@ -4,7 +4,7 @@
     "id": "shr-test-GroupWithChoiceOfChoice-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR GroupWithChoiceOfChoice Logical Model</b></p>\n  <p>It is a group of elements with a choice containing a choice</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>GroupWithChoiceOfChoice Logical Model</b></p>\n  <p>It is a group of elements with a choice containing a choice</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-GroupWithChoiceOfChoice-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.GroupWithChoiceOfChoice"
       }
     ],
-    "name": "GroupWithChoiceOfChoiceModel",
-    "title": "FOOBAR GroupWithChoiceOfChoice Logical Model",
+    "name": "GroupWithChoiceOfChoice",
+    "title": "shr-test-GroupWithChoiceOfChoice",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -242,7 +242,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -251,8 +251,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -365,7 +365,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -374,8 +374,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -493,7 +493,7 @@
     "id": "shr-test-ForeignElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ForeignElementValue-model",
     "identifier": [
@@ -502,8 +502,8 @@
         "value": "shr.test.ForeignElementValue"
       }
     ],
-    "name": "ForeignElementValueModel",
-    "title": "FOOBAR ForeignElementValue Logical Model",
+    "name": "ForeignElementValue",
+    "title": "shr-test-ForeignElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -623,7 +623,7 @@
     "id": "shr-test-ElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model",
     "identifier": [
@@ -632,8 +632,8 @@
         "value": "shr.test.ElementValue"
       }
     ],
-    "name": "ElementValueModel",
-    "title": "FOOBAR ElementValue Logical Model",
+    "name": "ElementValue",
+    "title": "shr-test-ElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -753,7 +753,7 @@
     "id": "shr-other-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model",
     "identifier": [
@@ -762,8 +762,8 @@
         "value": "shr.other.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-other-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/IncludesCodeConstraints.json
+++ b/test/fixtures/IncludesCodeConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-IncludesCodesList-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR IncludesCodesList Logical Model</b></p>\n  <p>An entry with a includes codes constraint.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>IncludesCodesList Logical Model</b></p>\n  <p>An entry with a includes codes constraint.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-IncludesCodesList-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.IncludesCodesList"
       }
     ],
-    "name": "IncludesCodesListModel",
-    "title": "FOOBAR IncludesCodesList Logical Model",
+    "name": "IncludesCodesList",
+    "title": "shr-test-IncludesCodesList",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -148,7 +148,7 @@
     "id": "shr-core-CodeSystem-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR CodeSystem Logical Model</b></p>\n  <p></p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>CodeSystem Logical Model</b></p>\n  <p></p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-core-CodeSystem-model",
     "identifier": [
@@ -157,8 +157,8 @@
         "value": "shr.core.CodeSystem"
       }
     ],
-    "name": "CodeSystemModel",
-    "title": "FOOBAR CodeSystem Logical Model",
+    "name": "CodeSystem",
+    "title": "shr-core-CodeSystem",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -265,7 +265,7 @@
     "id": "shr-core-CodeSystemVersion-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR CodeSystemVersion Logical Model</b></p>\n  <p></p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>CodeSystemVersion Logical Model</b></p>\n  <p></p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-core-CodeSystemVersion-model",
     "identifier": [
@@ -274,8 +274,8 @@
         "value": "shr.core.CodeSystemVersion"
       }
     ],
-    "name": "CodeSystemVersionModel",
-    "title": "FOOBAR CodeSystemVersion Logical Model",
+    "name": "CodeSystemVersion",
+    "title": "shr-core-CodeSystemVersion",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -382,7 +382,7 @@
     "id": "shr-core-DisplayText-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR DisplayText Logical Model</b></p>\n  <p></p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>DisplayText Logical Model</b></p>\n  <p></p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-core-DisplayText-model",
     "identifier": [
@@ -391,8 +391,8 @@
         "value": "shr.core.DisplayText"
       }
     ],
-    "name": "DisplayTextModel",
-    "title": "FOOBAR DisplayText Logical Model",
+    "name": "DisplayText",
+    "title": "shr-core-DisplayText",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/IncludesTypeConstraints.json
+++ b/test/fixtures/IncludesTypeConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-SimpleChild2-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.SimpleChild2"
       }
     ],
-    "name": "SimpleChild2Model",
-    "title": "FOOBAR SimpleChild2 Logical Model",
+    "name": "SimpleChild2",
+    "title": "shr-test-SimpleChild2",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -120,7 +120,7 @@
     "id": "shr-test-IncludesTypesList-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR IncludesTypesList Logical Model</b></p>\n  <p>An entry with a includes types constraints.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>IncludesTypesList Logical Model</b></p>\n  <p>An entry with a includes types constraints.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-IncludesTypesList-model",
     "identifier": [
@@ -129,8 +129,8 @@
         "value": "shr.test.IncludesTypesList"
       }
     ],
-    "name": "IncludesTypesListModel",
-    "title": "FOOBAR IncludesTypesList Logical Model",
+    "name": "IncludesTypesList",
+    "title": "shr-test-IncludesTypesList",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -324,7 +324,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -333,8 +333,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -447,7 +447,7 @@
     "id": "shr-test-SimpleChild-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model",
     "identifier": [
@@ -456,8 +456,8 @@
         "value": "shr.test.SimpleChild"
       }
     ],
-    "name": "SimpleChildModel",
-    "title": "FOOBAR SimpleChild Logical Model",
+    "name": "SimpleChild",
+    "title": "shr-test-SimpleChild",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/IncludesTypeConstraintsZeroedOut.json
+++ b/test/fixtures/IncludesTypeConstraintsZeroedOut.json
@@ -4,7 +4,7 @@
     "id": "shr-test-SimpleChild2-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.SimpleChild2"
       }
     ],
-    "name": "SimpleChild2Model",
-    "title": "FOOBAR SimpleChild2 Logical Model",
+    "name": "SimpleChild2",
+    "title": "shr-test-SimpleChild2",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -120,7 +120,7 @@
     "id": "shr-test-IncludesTypesListWithZeroedOutType-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR IncludesTypesListWithZeroedOutType Logical Model</b></p>\n  <p>An entry with a includes types constraints.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>IncludesTypesListWithZeroedOutType Logical Model</b></p>\n  <p>An entry with a includes types constraints.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-IncludesTypesListWithZeroedOutType-model",
     "identifier": [
@@ -129,8 +129,8 @@
         "value": "shr.test.IncludesTypesListWithZeroedOutType"
       }
     ],
-    "name": "IncludesTypesListWithZeroedOutTypeModel",
-    "title": "FOOBAR IncludesTypesListWithZeroedOutType Logical Model",
+    "name": "IncludesTypesListWithZeroedOutType",
+    "title": "shr-test-IncludesTypesListWithZeroedOutType",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -282,7 +282,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -291,8 +291,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -405,7 +405,7 @@
     "id": "shr-test-SimpleChild-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model",
     "identifier": [
@@ -414,8 +414,8 @@
         "value": "shr.test.SimpleChild"
       }
     ],
-    "name": "SimpleChildModel",
-    "title": "FOOBAR SimpleChild Logical Model",
+    "name": "SimpleChild",
+    "title": "shr-test-SimpleChild",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/NestedCardConstraint.json
+++ b/test/fixtures/NestedCardConstraint.json
@@ -4,7 +4,7 @@
     "id": "shr-test-OptionalValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR OptionalValue Logical Model</b></p>\n  <p>An element with an optional value.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>OptionalValue Logical Model</b></p>\n  <p>An element with an optional value.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalValue-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.OptionalValue"
       }
     ],
-    "name": "OptionalValueModel",
-    "title": "FOOBAR OptionalValue Logical Model",
+    "name": "OptionalValue",
+    "title": "shr-test-OptionalValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -120,7 +120,7 @@
     "id": "shr-test-OptionalField-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR OptionalField Logical Model</b></p>\n  <p>An element with an optional field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>OptionalField Logical Model</b></p>\n  <p>An element with an optional field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalField-model",
     "identifier": [
@@ -129,8 +129,8 @@
         "value": "shr.test.OptionalField"
       }
     ],
-    "name": "OptionalFieldModel",
-    "title": "FOOBAR OptionalField Logical Model",
+    "name": "OptionalField",
+    "title": "shr-test-OptionalField",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -236,7 +236,7 @@
     "id": "shr-test-NestedCardConstraint-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR NestedCardConstraint Logical Model</b></p>\n  <p>It has a field with a nested card constraint.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>NestedCardConstraint Logical Model</b></p>\n  <p>It has a field with a nested card constraint.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-NestedCardConstraint-model",
     "identifier": [
@@ -245,8 +245,8 @@
         "value": "shr.test.NestedCardConstraint"
       }
     ],
-    "name": "NestedCardConstraintModel",
-    "title": "FOOBAR NestedCardConstraint Logical Model",
+    "name": "NestedCardConstraint",
+    "title": "shr-test-NestedCardConstraint",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/NestedIncludesCodeConstraints.json
+++ b/test/fixtures/NestedIncludesCodeConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -132,7 +132,7 @@
     "id": "shr-test-NestedIncludesCodes-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR NestedIncludesCodes Logical Model</b></p>\n  <p>An entry with a nested includes codes constraint.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>NestedIncludesCodes Logical Model</b></p>\n  <p>An entry with a nested includes codes constraint.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-NestedIncludesCodes-model",
     "identifier": [
@@ -141,8 +141,8 @@
         "value": "shr.test.NestedIncludesCodes"
       }
     ],
-    "name": "NestedIncludesCodesModel",
-    "title": "FOOBAR NestedIncludesCodes Logical Model",
+    "name": "NestedIncludesCodes",
+    "title": "shr-test-NestedIncludesCodes",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/NestedIncludesTypeConstraints.json
+++ b/test/fixtures/NestedIncludesTypeConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-ElementFieldList-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementFieldList Logical Model</b></p>\n  <p>It is an element with a field that is a list of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementFieldList Logical Model</b></p>\n  <p>It is an element with a field that is a list of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementFieldList-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.ElementFieldList"
       }
     ],
-    "name": "ElementFieldListModel",
-    "title": "FOOBAR ElementFieldList Logical Model",
+    "name": "ElementFieldList",
+    "title": "shr-test-ElementFieldList",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -134,7 +134,7 @@
     "id": "shr-test-ElementFieldListContainer-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementFieldListContainer Logical Model</b></p>\n  <p>It is an element with a field that contains an element with a field that is a list of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementFieldListContainer Logical Model</b></p>\n  <p>It is an element with a field that contains an element with a field that is a list of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementFieldListContainer-model",
     "identifier": [
@@ -143,8 +143,8 @@
         "value": "shr.test.ElementFieldListContainer"
       }
     ],
-    "name": "ElementFieldListContainerModel",
-    "title": "FOOBAR ElementFieldListContainer Logical Model",
+    "name": "ElementFieldListContainer",
+    "title": "shr-test-ElementFieldListContainer",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -250,7 +250,7 @@
     "id": "shr-test-SimpleChild2-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model",
     "identifier": [
@@ -259,8 +259,8 @@
         "value": "shr.test.SimpleChild2"
       }
     ],
-    "name": "SimpleChild2Model",
-    "title": "FOOBAR SimpleChild2 Logical Model",
+    "name": "SimpleChild2",
+    "title": "shr-test-SimpleChild2",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -366,7 +366,7 @@
     "id": "shr-test-NestedIncludesTypeConstraints-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR NestedIncludesTypeConstraints Logical Model</b></p>\n  <p>An entry with includes types constraints that are on a nested field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>NestedIncludesTypeConstraints Logical Model</b></p>\n  <p>An entry with includes types constraints that are on a nested field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-NestedIncludesTypeConstraints-model",
     "identifier": [
@@ -375,8 +375,8 @@
         "value": "shr.test.NestedIncludesTypeConstraints"
       }
     ],
-    "name": "NestedIncludesTypeConstraintsModel",
-    "title": "FOOBAR NestedIncludesTypeConstraints Logical Model",
+    "name": "NestedIncludesTypeConstraints",
+    "title": "shr-test-NestedIncludesTypeConstraints",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -654,7 +654,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -663,8 +663,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -777,7 +777,7 @@
     "id": "shr-test-SimpleChild-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model",
     "identifier": [
@@ -786,8 +786,8 @@
         "value": "shr.test.SimpleChild"
       }
     ],
-    "name": "SimpleChildModel",
-    "title": "FOOBAR SimpleChild Logical Model",
+    "name": "SimpleChild",
+    "title": "shr-test-SimpleChild",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/NestedListCardConstraints.json
+++ b/test/fixtures/NestedListCardConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-OptionalList-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR OptionalList Logical Model</b></p>\n  <p>An element with an optional list.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>OptionalList Logical Model</b></p>\n  <p>An element with an optional list.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-OptionalList-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.OptionalList"
       }
     ],
-    "name": "OptionalListModel",
-    "title": "FOOBAR OptionalList Logical Model",
+    "name": "OptionalList",
+    "title": "shr-test-OptionalList",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -120,7 +120,7 @@
     "id": "shr-test-ListField-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ListField Logical Model</b></p>\n  <p>An element with a list field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ListField Logical Model</b></p>\n  <p>An element with a list field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ListField-model",
     "identifier": [
@@ -129,8 +129,8 @@
         "value": "shr.test.ListField"
       }
     ],
-    "name": "ListFieldModel",
-    "title": "FOOBAR ListField Logical Model",
+    "name": "ListField",
+    "title": "shr-test-ListField",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -236,7 +236,7 @@
     "id": "shr-test-NestedListCardConstraints-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR NestedListCardConstraints Logical Model</b></p>\n  <p>It has a field with a nested card constraint on a list.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>NestedListCardConstraints Logical Model</b></p>\n  <p>It has a field with a nested card constraint on a list.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-NestedListCardConstraints-model",
     "identifier": [
@@ -245,8 +245,8 @@
         "value": "shr.test.NestedListCardConstraints"
       }
     ],
-    "name": "NestedListCardConstraintsModel",
-    "title": "FOOBAR NestedListCardConstraints Logical Model",
+    "name": "NestedListCardConstraints",
+    "title": "shr-test-NestedListCardConstraints",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/NestedValueSetConstraints.json
+++ b/test/fixtures/NestedValueSetConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -132,7 +132,7 @@
     "id": "shr-test-NestedValueSetConstraints-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR NestedValueSetConstraints Logical Model</b></p>\n  <p>It has valueset constraints on a field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>NestedValueSetConstraints Logical Model</b></p>\n  <p>It has valueset constraints on a field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-NestedValueSetConstraints-model",
     "identifier": [
@@ -141,8 +141,8 @@
         "value": "shr.test.NestedValueSetConstraints"
       }
     ],
-    "name": "NestedValueSetConstraintsModel",
-    "title": "FOOBAR NestedValueSetConstraints Logical Model",
+    "name": "NestedValueSetConstraints",
+    "title": "shr-test-NestedValueSetConstraints",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -260,7 +260,7 @@
     "id": "shr-test-Group-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Group-model",
     "identifier": [
@@ -269,8 +269,8 @@
         "value": "shr.test.Group"
       }
     ],
-    "name": "GroupModel",
-    "title": "FOOBAR Group Logical Model",
+    "name": "Group",
+    "title": "shr-test-Group",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -512,7 +512,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -521,8 +521,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -635,7 +635,7 @@
     "id": "shr-test-ForeignElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ForeignElementValue-model",
     "identifier": [
@@ -644,8 +644,8 @@
         "value": "shr.test.ForeignElementValue"
       }
     ],
-    "name": "ForeignElementValueModel",
-    "title": "FOOBAR ForeignElementValue Logical Model",
+    "name": "ForeignElementValue",
+    "title": "shr-test-ForeignElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -765,7 +765,7 @@
     "id": "shr-test-ElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model",
     "identifier": [
@@ -774,8 +774,8 @@
         "value": "shr.test.ElementValue"
       }
     ],
-    "name": "ElementValueModel",
-    "title": "FOOBAR ElementValue Logical Model",
+    "name": "ElementValue",
+    "title": "shr-test-ElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -895,7 +895,7 @@
     "id": "shr-other-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model",
     "identifier": [
@@ -904,8 +904,8 @@
         "value": "shr.other.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-other-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/NotDone.json
+++ b/test/fixtures/NotDone.json
@@ -4,7 +4,7 @@
     "id": "shr-test-NotDone-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR NotDone Logical Model</b></p>\n  <p>It is an unfinished element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>NotDone Logical Model</b></p>\n  <p>It is an unfinished element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-NotDone-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.NotDone"
       }
     ],
-    "name": "NotDoneModel",
-    "title": "FOOBAR NotDone Logical Model",
+    "name": "NotDone",
+    "title": "shr-test-NotDone",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/OnValueIncludesTypeConstraints.json
+++ b/test/fixtures/OnValueIncludesTypeConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-ElementValueList-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValueList Logical Model</b></p>\n  <p>It is an element with a value that is a list of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValueList Logical Model</b></p>\n  <p>It is an element with a value that is a list of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValueList-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.ElementValueList"
       }
     ],
-    "name": "ElementValueListModel",
-    "title": "FOOBAR ElementValueList Logical Model",
+    "name": "ElementValueList",
+    "title": "shr-test-ElementValueList",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -134,7 +134,7 @@
     "id": "shr-test-SimpleChild2-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild2 Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild2-model",
     "identifier": [
@@ -143,8 +143,8 @@
         "value": "shr.test.SimpleChild2"
       }
     ],
-    "name": "SimpleChild2Model",
-    "title": "FOOBAR SimpleChild2 Logical Model",
+    "name": "SimpleChild2",
+    "title": "shr-test-SimpleChild2",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -250,7 +250,7 @@
     "id": "shr-test-OnValueIncludesTypeConstraints-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR OnValueIncludesTypeConstraints Logical Model</b></p>\n  <p>An entry with includes types constraints that are on the value of the field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>OnValueIncludesTypeConstraints Logical Model</b></p>\n  <p>An entry with includes types constraints that are on the value of the field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-OnValueIncludesTypeConstraints-model",
     "identifier": [
@@ -259,8 +259,8 @@
         "value": "shr.test.OnValueIncludesTypeConstraints"
       }
     ],
-    "name": "OnValueIncludesTypeConstraintsModel",
-    "title": "FOOBAR OnValueIncludesTypeConstraints Logical Model",
+    "name": "OnValueIncludesTypeConstraints",
+    "title": "shr-test-OnValueIncludesTypeConstraints",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -454,7 +454,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -463,8 +463,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -577,7 +577,7 @@
     "id": "shr-test-SimpleChild-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model",
     "identifier": [
@@ -586,8 +586,8 @@
         "value": "shr.test.SimpleChild"
       }
     ],
-    "name": "SimpleChildModel",
-    "title": "FOOBAR SimpleChild Logical Model",
+    "name": "SimpleChild",
+    "title": "shr-test-SimpleChild",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/ReferenceChoice.json
+++ b/test/fixtures/ReferenceChoice.json
@@ -4,7 +4,7 @@
     "id": "shr-test-ReferenceChoice-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ReferenceChoice Logical Model</b></p>\n  <p>It is a reference to one of a few types</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ReferenceChoice Logical Model</b></p>\n  <p>It is a reference to one of a few types</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ReferenceChoice-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.ReferenceChoice"
       }
     ],
-    "name": "ReferenceChoiceModel",
-    "title": "FOOBAR ReferenceChoice Logical Model",
+    "name": "ReferenceChoice",
+    "title": "shr-test-ReferenceChoice",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/Simple.json
+++ b/test/fixtures/Simple.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/SimpleReference.json
+++ b/test/fixtures/SimpleReference.json
@@ -4,7 +4,7 @@
     "id": "shr-test-SimpleReference-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleReference Logical Model</b></p>\n  <p>It is a reference to a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleReference Logical Model</b></p>\n  <p>It is a reference to a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleReference-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.SimpleReference"
       }
     ],
-    "name": "SimpleReferenceModel",
-    "title": "FOOBAR SimpleReference Logical Model",
+    "name": "SimpleReference",
+    "title": "shr-test-SimpleReference",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/TwoDeepElementValue.json
+++ b/test/fixtures/TwoDeepElementValue.json
@@ -4,7 +4,7 @@
     "id": "shr-test-TwoDeepElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR TwoDeepElementValue Logical Model</b></p>\n  <p>It is an element with a two-deep element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>TwoDeepElementValue Logical Model</b></p>\n  <p>It is an element with a two-deep element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-TwoDeepElementValue-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.TwoDeepElementValue"
       }
     ],
-    "name": "TwoDeepElementValueModel",
-    "title": "FOOBAR TwoDeepElementValue Logical Model",
+    "name": "TwoDeepElementValue",
+    "title": "shr-test-TwoDeepElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -134,7 +134,7 @@
     "id": "shr-test-ElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model",
     "identifier": [
@@ -143,8 +143,8 @@
         "value": "shr.test.ElementValue"
       }
     ],
-    "name": "ElementValueModel",
-    "title": "FOOBAR ElementValue Logical Model",
+    "name": "ElementValue",
+    "title": "shr-test-ElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -264,7 +264,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -273,8 +273,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/TypeConstrainedChoices.json
+++ b/test/fixtures/TypeConstrainedChoices.json
@@ -4,7 +4,7 @@
     "id": "shr-test-Choice-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Choice Logical Model</b></p>\n  <p>It is an element with a choice</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Choice Logical Model</b></p>\n  <p>It is an element with a choice</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Choice-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.Choice"
       }
     ],
-    "name": "ChoiceModel",
-    "title": "FOOBAR Choice Logical Model",
+    "name": "Choice",
+    "title": "shr-test-Choice",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -208,7 +208,7 @@
     "id": "shr-test-TypeConstrainedChoice-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR TypeConstrainedChoice Logical Model</b></p>\n  <p>It is an element with a choice with a constraint.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>TypeConstrainedChoice Logical Model</b></p>\n  <p>It is an element with a choice with a constraint.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-TypeConstrainedChoice-model",
     "identifier": [
@@ -217,8 +217,8 @@
         "value": "shr.test.TypeConstrainedChoice"
       }
     ],
-    "name": "TypeConstrainedChoiceModel",
-    "title": "FOOBAR TypeConstrainedChoice Logical Model",
+    "name": "TypeConstrainedChoice",
+    "title": "shr-test-TypeConstrainedChoice",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -324,7 +324,7 @@
     "id": "shr-test-ChoiceValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ChoiceValue Logical Model</b></p>\n  <p>It is an element with a choice value.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ChoiceValue Logical Model</b></p>\n  <p>It is an element with a choice value.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ChoiceValue-model",
     "identifier": [
@@ -333,8 +333,8 @@
         "value": "shr.test.ChoiceValue"
       }
     ],
-    "name": "ChoiceValueModel",
-    "title": "FOOBAR ChoiceValue Logical Model",
+    "name": "ChoiceValue",
+    "title": "shr-test-ChoiceValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -528,7 +528,7 @@
     "id": "shr-test-TwoDeepChoiceField-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR TwoDeepChoiceField Logical Model</b></p>\n  <p>It is an element with a a field with a choice.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>TwoDeepChoiceField Logical Model</b></p>\n  <p>It is an element with a a field with a choice.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-TwoDeepChoiceField-model",
     "identifier": [
@@ -537,8 +537,8 @@
         "value": "shr.test.TwoDeepChoiceField"
       }
     ],
-    "name": "TwoDeepChoiceFieldModel",
-    "title": "FOOBAR TwoDeepChoiceField Logical Model",
+    "name": "TwoDeepChoiceField",
+    "title": "shr-test-TwoDeepChoiceField",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -732,7 +732,7 @@
     "id": "shr-test-TypeConstrainedChoiceWithPath-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR TypeConstrainedChoiceWithPath Logical Model</b></p>\n  <p>It is an element with a choice on a field with a constraint.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>TypeConstrainedChoiceWithPath Logical Model</b></p>\n  <p>It is an element with a choice on a field with a constraint.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-TypeConstrainedChoiceWithPath-model",
     "identifier": [
@@ -741,8 +741,8 @@
         "value": "shr.test.TypeConstrainedChoiceWithPath"
       }
     ],
-    "name": "TypeConstrainedChoiceWithPathModel",
-    "title": "FOOBAR TypeConstrainedChoiceWithPath Logical Model",
+    "name": "TypeConstrainedChoiceWithPath",
+    "title": "shr-test-TypeConstrainedChoiceWithPath",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -902,7 +902,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -911,8 +911,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/TypeConstrainedReference.json
+++ b/test/fixtures/TypeConstrainedReference.json
@@ -4,7 +4,7 @@
     "id": "shr-test-TypeConstrainedReference-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR TypeConstrainedReference Logical Model</b></p>\n  <p>It is an element a constraint on a reference.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>TypeConstrainedReference Logical Model</b></p>\n  <p>It is an element a constraint on a reference.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-TypeConstrainedReference-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.TypeConstrainedReference"
       }
     ],
-    "name": "TypeConstrainedReferenceModel",
-    "title": "FOOBAR TypeConstrainedReference Logical Model",
+    "name": "TypeConstrainedReference",
+    "title": "shr-test-TypeConstrainedReference",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -122,7 +122,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -131,8 +131,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -245,7 +245,7 @@
     "id": "shr-test-SimpleChild-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model",
     "identifier": [
@@ -254,8 +254,8 @@
         "value": "shr.test.SimpleChild"
       }
     ],
-    "name": "SimpleChildModel",
-    "title": "FOOBAR SimpleChild Logical Model",
+    "name": "SimpleChild",
+    "title": "shr-test-SimpleChild",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -361,7 +361,7 @@
     "id": "shr-test-SimpleReference-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleReference Logical Model</b></p>\n  <p>It is a reference to a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleReference Logical Model</b></p>\n  <p>It is a reference to a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleReference-model",
     "identifier": [
@@ -370,8 +370,8 @@
         "value": "shr.test.SimpleReference"
       }
     ],
-    "name": "SimpleReferenceModel",
-    "title": "FOOBAR SimpleReference Logical Model",
+    "name": "SimpleReference",
+    "title": "shr-test-SimpleReference",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/TypeConstraints.json
+++ b/test/fixtures/TypeConstraints.json
@@ -4,7 +4,7 @@
     "id": "shr-test-SimpleChild-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.SimpleChild"
       }
     ],
-    "name": "SimpleChildModel",
-    "title": "FOOBAR SimpleChild Logical Model",
+    "name": "SimpleChild",
+    "title": "shr-test-SimpleChild",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -120,7 +120,7 @@
     "id": "shr-test-ElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementValue Logical Model</b></p>\n  <p>It is an element with an element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementValue-model",
     "identifier": [
@@ -129,8 +129,8 @@
         "value": "shr.test.ElementValue"
       }
     ],
-    "name": "ElementValueModel",
-    "title": "FOOBAR ElementValue Logical Model",
+    "name": "ElementValue",
+    "title": "shr-test-ElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -250,7 +250,7 @@
     "id": "shr-test-GroupDerivative-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR GroupDerivative Logical Model</b></p>\n  <p>It is a derivative of a group of elements with type constraints.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>GroupDerivative Logical Model</b></p>\n  <p>It is a derivative of a group of elements with type constraints.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-GroupDerivative-model",
     "identifier": [
@@ -259,8 +259,8 @@
         "value": "shr.test.GroupDerivative"
       }
     ],
-    "name": "GroupDerivativeModel",
-    "title": "FOOBAR GroupDerivative Logical Model",
+    "name": "GroupDerivative",
+    "title": "shr-test-GroupDerivative",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -408,7 +408,7 @@
     "id": "shr-test-Group-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Group Logical Model</b></p>\n  <p>It is a group of elements</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Group-model",
     "identifier": [
@@ -417,8 +417,8 @@
         "value": "shr.test.Group"
       }
     ],
-    "name": "GroupModel",
-    "title": "FOOBAR Group Logical Model",
+    "name": "Group",
+    "title": "shr-test-Group",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -660,7 +660,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -669,8 +669,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -783,7 +783,7 @@
     "id": "shr-test-Coded-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Coded Logical Model</b></p>\n  <p>It is a coded element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Coded-model",
     "identifier": [
@@ -792,8 +792,8 @@
         "value": "shr.test.Coded"
       }
     ],
-    "name": "CodedModel",
-    "title": "FOOBAR Coded Logical Model",
+    "name": "Coded",
+    "title": "shr-test-Coded",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -911,7 +911,7 @@
     "id": "shr-test-ForeignElementValue-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ForeignElementValue Logical Model</b></p>\n  <p>It is an element with a foreign element value</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ForeignElementValue-model",
     "identifier": [
@@ -920,8 +920,8 @@
         "value": "shr.test.ForeignElementValue"
       }
     ],
-    "name": "ForeignElementValueModel",
-    "title": "FOOBAR ForeignElementValue Logical Model",
+    "name": "ForeignElementValue",
+    "title": "shr-test-ForeignElementValue",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -1041,7 +1041,7 @@
     "id": "shr-other-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-other-test-Simple-model",
     "identifier": [
@@ -1050,8 +1050,8 @@
         "value": "shr.other.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-other-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",

--- a/test/fixtures/TypeConstraintsWithPath.json
+++ b/test/fixtures/TypeConstraintsWithPath.json
@@ -4,7 +4,7 @@
     "id": "shr-test-ElementField-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ElementField Logical Model</b></p>\n  <p>It is an element with a field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ElementField Logical Model</b></p>\n  <p>It is an element with a field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ElementField-model",
     "identifier": [
@@ -13,8 +13,8 @@
         "value": "shr.test.ElementField"
       }
     ],
-    "name": "ElementFieldModel",
-    "title": "FOOBAR ElementField Logical Model",
+    "name": "ElementField",
+    "title": "shr-test-ElementField",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -134,7 +134,7 @@
     "id": "shr-test-TwoDeepElementField-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR TwoDeepElementField Logical Model</b></p>\n  <p>It is an element with a two-deep element field</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>TwoDeepElementField Logical Model</b></p>\n  <p>It is an element with a two-deep element field</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-TwoDeepElementField-model",
     "identifier": [
@@ -143,8 +143,8 @@
         "value": "shr.test.TwoDeepElementField"
       }
     ],
-    "name": "TwoDeepElementFieldModel",
-    "title": "FOOBAR TwoDeepElementField Logical Model",
+    "name": "TwoDeepElementField",
+    "title": "shr-test-TwoDeepElementField",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -250,7 +250,7 @@
     "id": "shr-test-NestedField-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR NestedField Logical Model</b></p>\n  <p>It is an element with a nested field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>NestedField Logical Model</b></p>\n  <p>It is an element with a nested field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-NestedField-model",
     "identifier": [
@@ -259,8 +259,8 @@
         "value": "shr.test.NestedField"
       }
     ],
-    "name": "NestedFieldModel",
-    "title": "FOOBAR NestedField Logical Model",
+    "name": "NestedField",
+    "title": "shr-test-NestedField",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -366,7 +366,7 @@
     "id": "shr-test-ConstrainedPath-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ConstrainedPath Logical Model</b></p>\n  <p>It derives an element with a nested field.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ConstrainedPath Logical Model</b></p>\n  <p>It derives an element with a nested field.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ConstrainedPath-model",
     "identifier": [
@@ -375,8 +375,8 @@
         "value": "shr.test.ConstrainedPath"
       }
     ],
-    "name": "ConstrainedPathModel",
-    "title": "FOOBAR ConstrainedPath Logical Model",
+    "name": "ConstrainedPath",
+    "title": "shr-test-ConstrainedPath",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -566,7 +566,7 @@
     "id": "shr-test-ConstrainedPathNoInheritance-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR ConstrainedPathNoInheritance Logical Model</b></p>\n  <p>It has a new field with a nested constraint.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>ConstrainedPathNoInheritance Logical Model</b></p>\n  <p>It has a new field with a nested constraint.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-ConstrainedPathNoInheritance-model",
     "identifier": [
@@ -575,8 +575,8 @@
         "value": "shr.test.ConstrainedPathNoInheritance"
       }
     ],
-    "name": "ConstrainedPathNoInheritanceModel",
-    "title": "FOOBAR ConstrainedPathNoInheritance Logical Model",
+    "name": "ConstrainedPathNoInheritance",
+    "title": "shr-test-ConstrainedPathNoInheritance",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -766,7 +766,7 @@
     "id": "shr-test-Simple-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>Simple Logical Model</b></p>\n  <p>It is a simple element</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-Simple-model",
     "identifier": [
@@ -775,8 +775,8 @@
         "value": "shr.test.Simple"
       }
     ],
-    "name": "SimpleModel",
-    "title": "FOOBAR Simple Logical Model",
+    "name": "Simple",
+    "title": "shr-test-Simple",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",
@@ -889,7 +889,7 @@
     "id": "shr-test-SimpleChild-model",
     "text": {
       "status": "generated",
-      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>FOOBAR SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
+      "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <p><b>SimpleChild Logical Model</b></p>\n  <p>A derivative of the simple type.</p>\n</div>"
     },
     "url": "http://foobar.com/fhir/StructureDefinition/shr-test-SimpleChild-model",
     "identifier": [
@@ -898,8 +898,8 @@
         "value": "shr.test.SimpleChild"
       }
     ],
-    "name": "SimpleChildModel",
-    "title": "FOOBAR SimpleChild Logical Model",
+    "name": "SimpleChild",
+    "title": "shr-test-SimpleChild",
     "status": "draft",
     "date": "2018-02-26",
     "publisher": "The Foo Bar Corporation",


### PR DESCRIPTION
This PR contains fixes/changes requested by the M-Code spec team.  They include:
* New mapping feature to indicate that certain elements should not produce profiles (e.g., Patient or Encounter)
* Simplified names and titles of profiles, extensions, logical models, value sets, and code systems
* Allow mappings of `Coding` to `code` or `CodeableConcept` (standardhealth/shr-cli#131)
* Properly handle cardinality when mapping to extensions (standardhealth/shr-cli#136)
* Remove redundant/invalid `targetProfile` property from DSTU2 type elements