### PR TITLE
Fix detection and handling of no-diff-profiles

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -453,10 +453,13 @@ class FHIRExporter {
 
       // Check if this is a "no-diff" profile. A profile is considered "no-diff"
       // If the "mapping" is different, as the mappings are only used internally by other SHR profiles
+      const allowedDiffKeys = ['id', 'path', 'short', 'definition', 'mapping'];
+      const allowedDiffKeysForRoot = [...allowedDiffKeys, 'mustSupport', 'isModifier', 'isSummary'];
       const isNoDiffProfile = profile.differential.element.length <= 1 || profile.differential.element.every(e => {
         const keys = Object.keys(e);
+        const allowedKeys = (e.path.indexOf('.') === -1) ? allowedDiffKeysForRoot : allowedDiffKeys;
         return keys.every(k => {
-          return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition' || k === 'mapping';
+          return e[k] == null || allowedKeys.indexOf(k) !== -1;
         });
       });
       if (isNoDiffProfile || targetItem.hasNoProfileCommand()) {
@@ -3023,6 +3026,10 @@ class FHIRExporter {
     } else if (warnIfProfileIsProcessing && this._processTracker.isActive(identifier)) {
       logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(identifier));
     }
+    // If this is really a no-diff profile, then return the base structuredef instead!
+    if (typeof p !== 'undefined' && !common.isCustomProfile(p)) {
+      return this.lookupStructureDefinition(MVH.sdBaseDefinition(p));
+    }
     return p;
   }
 
@@ -3032,6 +3039,10 @@ class FHIRExporter {
     if (typeof profile !== 'undefined') {
       if (warnIfStructureDefinitionIsProcessing && this._processTracker.isActive(id)) {
         logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(id));
+      }
+      // If this is really a no-diff profile, then return the base structuredef instead!
+      if (!common.isCustomProfile(profile)) {
+        return this.lookupStructureDefinition(MVH.sdBaseDefinition(profile));
       }
       return profile;
     }


### PR DESCRIPTION
Fixes detection of no-diff profile when root element has `isModifier`, `isSummary`, or `mustSupport` flags set.

Also updates lookupProfile and lookupStructureDefinition functions to return the *base* definition when a no-diff profile is requested.  This makes it work more like it did before no-diff profiles were stored in the profile hash.  This also fixes the issue with types and references referring to no-diff profile URLs that weren't valid anymore after export.