### PR TITLE
Es6 fromfhir support

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -128,8 +128,14 @@ class FHIRExporter {
 
     // Delete intermediate variables
     const profiles = Array.from(this._profilesMap.values()).filter(p => common.isCustomProfile(p));
+    // For use in shr-es6-export, create a noDiffProfiles array as well, so profiles that only
+    // Contain mapping differences can be exported
+    const noDiffProfiles = Array.from(this._profilesMap.values()).filter(p => !common.isCustomProfile(p));
     for (const p of profiles) {
       delete(p._shr);
+    }
+    for (const p of noDiffProfiles) {
+      delete (p._shr);
     }
 
     const extensions = this._extensionExporter.extensions;
@@ -146,6 +152,7 @@ class FHIRExporter {
     return {
       profiles,
       extensions,
+      _noDiffProfiles: noDiffProfiles,
       valueSets: this._valueSetExporter.valueSets,
       codeSystems: this._codeSystemExporter.codeSystems,
       models: this._modelsExporter.models,
@@ -188,6 +195,7 @@ class FHIRExporter {
           ssEl.mapping.forEach(fixURI);
         }
       }
+
       // (2) Fix incorrect display text for US jurisdiction
       if (profile.jurisdiction) {
         profile.jurisdiction.forEach(j => {
@@ -195,6 +203,22 @@ class FHIRExporter {
             j.coding.forEach(c => { if (c.code === 'US') c.display = 'United States of America'; });
           }
         });
+      }
+
+      // Insert mapping rules into the FHIR mapping element
+      for (let r of map.rules) {
+        if (r.sourcePath == undefined) {
+          break;
+        }
+        const rulePath = `${map.targetItem}.${r.target}`;
+        // Find the profile snapshot element that corresponds to the mapping rule
+        const elem = profile.snapshot.element.find(e => e.id == rulePath);
+        // If the snapshot element was found, add the mapping in as an 'shr' identity
+        // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
+        if (elem && !r.sourcePath[0].isPrimitive) {
+          elem.mapping = elem.mapping || [];
+          elem.mapping.push({ 'identity': 'shr', 'map': `<${r.sourcePath[0].fqn}>` });
+        }
       }
 
       // There are some bugs in Argonauth resources that cause errors in the IG publisher.
@@ -442,20 +466,19 @@ class FHIRExporter {
       }
       profile.differential.element = fixedDifferentials;
 
-      // Check if this is a "no-diff" profile.
+      // Check if this is a "no-diff" profile. A profile is considered "no-diff"
+      // If the "mapping" is different, as the mappings are only used internally by other SHR profiles
       const isNoDiffProfile = profile.differential.element.length <= 1 || profile.differential.element.every(e => {
         const keys = Object.keys(e);
         return keys.every(k => {
-          return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition';
+          return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition' || k === 'mapping';
         });
       });
       if (isNoDiffProfile || targetItem.hasNoProfileCommand()) {
-        // Substitute it with the original resource!
-        // First, remember the original id
-        const originalId = profile.id;
-        // Now re-set the profile to the original resource
-        profile = common.cloneJSON(def);
-        this._profilesMap.set(originalId, profile);
+        // Now flag the profile as "not an SHR profile", so it doesn't get included in the
+        // Profiles list displayed to the user
+        profile._shr = false;
+        this._profilesMap.set(profile.id, profile);
       } else {
         // Perform additional QA
         this.additionalQA(profile);
@@ -949,6 +972,31 @@ class FHIRExporter {
         id: ss.id,
         path: ss.path
       };
+    }
+
+    // Make sure the mapping arrays in the FHIR object and the differential exist; create if not
+    ss.mapping = ss.mapping || [];
+    df.mapping = df.mapping || [];
+
+    // Check if the field being mapped is the definition's 'Value' element
+    // TODO: If def.value is a ChoiceValue, test that at least one ID equals the sourceValue (using .some())
+    const isValue = def.value !== undefined && sourceValue.effectiveIdentifier == def.value.identifier;
+    const shrMapping = { 'identity': 'shr' };
+    if (isValue) {
+      // If it is the 'Value' element, just map it through to the SHR 'Value'
+      shrMapping['map'] = '<Value>';
+      ss.mapping.push(shrMapping);
+      df.mapping.push(shrMapping);
+    } else {
+      // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
+      if (!sourceValue.identifier.isPrimitive && !sourceValue._derivedFromIncludesTypeConstraint) {
+        // Build the mapping based on the sourcePath for the rule, to handle nested elements
+        shrMapping['map'] = rule.sourcePath.map((pathElem) => {
+          return `<${pathElem.fqn}>`;
+        }).join('.');
+        ss.mapping.push(shrMapping);
+        df.mapping.push(shrMapping);
+      }
     }
 
     if (typeof ss.type === 'undefined' && typeof MVH.edContentReference(profile, ss) !== 'undefined') {

--- a/lib/export.js
+++ b/lib/export.js
@@ -965,8 +965,9 @@ class FHIRExporter {
       // If it is the 'Value' element, just map it through to the SHR 'Value'
       pushShrMapToElementMappings('<Value>', ss, df);
     } else {
-      // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
-      if (!sourceValue.identifier.isPrimitive && !sourceValue._derivedFromIncludesTypeConstraint) {
+      // If it isn't; and it's not derived from includes type constraints, map it to the fqn of the field being mapped
+      // TODO: Determine why we're excluding derivedFromIncludesTypeConstraints
+      if (!sourceValue._derivedFromIncludesTypeConstraint) {
         // Build the mapping based on the sourcePath for the rule, to handle nested elements
         const shrMap = rule.sourcePath.map((pathElem) => {
           return `<${pathElem.fqn}>`;
@@ -1112,6 +1113,10 @@ class FHIRExporter {
       const ss = common.cloneJSON(sdToUnroll.snapshot.element[i]);
       ss.id = `${baseId}${ss.id.slice(baseEl.id.length)}`;
       ss.path = `${basePath}${ss.path.slice(baseEl.path.length)}`;
+      // Remove the SHR mappings since they are relative to the unrolled object (not to the path they're unrolled to)
+      if (ss.mapping) {
+        ss.mapping = ss.mapping.filter(m => m.identity !== 'shr');
+      }
       // Only unroll this element if it's not unrolled already -- this check may not actually be necessary
       if (!profile.snapshot.element.some(e => e.id == ss.id)) {
         unrolled.push(ss);
@@ -2908,7 +2913,6 @@ class FHIRExporter {
       if (isModifier) {
         ssEl.mustSupport = ssEl.isModifier = true;
       }
-      delete(ssEl.base);
       delete(ssEl.short);
       MVH.deleteEdComment(profile, ssEl);
       delete(ssEl.alias);
@@ -2961,6 +2965,15 @@ class FHIRExporter {
       if (dfIsNew) {
         this.insertExtensionElementInList(dfEl, profile.differential.element);
       }
+    }
+
+    // If there isn't already a base, add it.  It's always defined in the base resource and has 0..* cardinality.
+    if (!ssEl.base) {
+      ssEl.base = dfEl.base = {
+        path: `${MVH.sdType(profile)}.${extType}`,
+        min: 0,
+        max: '*'
+      };
     }
 
     const shrMap = sourcePath.map((pathElem) => {
@@ -3207,6 +3220,15 @@ class FHIRExporter {
       // Set the slice name
       MVH.setEdSliceName(profile, ssSliceSection[0], sliceName);
       MVH.setEdSliceName(profile, dfSliceSection[0], sliceName);
+
+      // Set the base
+      if (!ssSliceSection[0].base) {
+        ssSliceSection[0].base = dfSliceSection[0].base = {
+          path: baseElement.path,
+          min: baseElement.min,
+          max: baseElement.max
+        };
+      }
 
       // The base slice section element has slicing (from the copy), but we don't need to repeat that
       delete(ssSliceSection[0].slicing);
@@ -3799,6 +3821,16 @@ function setCardinalityOnFHIRElements(card, snapshotEl, differentialEl, skipIfEq
       } else {
         delete(differentialEl.min);
         delete(differentialEl.max);
+      }
+    }
+    if (!snapshotEl.base) {
+      snapshotEl.base = {
+        path: snapshotEl.path,
+        min: originalProperties.min,
+        max: originalProperties.max
+      };
+      if (differentialEl != null) {
+        differentialEl.base = snapshotEl.base;
       }
     }
   }

--- a/lib/export.js
+++ b/lib/export.js
@@ -205,22 +205,6 @@ class FHIRExporter {
         });
       }
 
-      // Insert mapping rules into the FHIR mapping element
-      for (let r of map.rules) {
-        if (r.sourcePath == undefined) {
-          break;
-        }
-        const rulePath = `${map.targetItem}.${r.target}`;
-        // Find the profile snapshot element that corresponds to the mapping rule
-        const elem = profile.snapshot.element.find(e => e.id == rulePath);
-        // If the snapshot element was found, add the mapping in as an 'shr' identity
-        // NOTE: For the time being, this only adds the mapping for the toFHIR test cases, to simplify code
-        if (elem && !r.sourcePath[0].isPrimitive) {
-          elem.mapping = elem.mapping || [];
-          elem.mapping.push({ 'identity': 'shr', 'map': `<${r.sourcePath[0].fqn}>` });
-        }
-      }
-
       // There are some bugs in Argonauth resources that cause errors in the IG publisher.
       // Fix invalid ids in mappings (e.g., "us-core-(stu3)")
       if (this._target === 'FHIR_DSTU_2' && targetItem.target.startsWith('http://fhir.org/guides/argonaut/')) {
@@ -974,28 +958,20 @@ class FHIRExporter {
       };
     }
 
-    // Make sure the mapping arrays in the FHIR object and the differential exist; create if not
-    ss.mapping = ss.mapping || [];
-    df.mapping = df.mapping || [];
-
     // Check if the field being mapped is the definition's 'Value' element
     // TODO: If def.value is a ChoiceValue, test that at least one ID equals the sourceValue (using .some())
     const isValue = def.value !== undefined && sourceValue.effectiveIdentifier == def.value.identifier;
-    const shrMapping = { 'identity': 'shr' };
     if (isValue) {
       // If it is the 'Value' element, just map it through to the SHR 'Value'
-      shrMapping['map'] = '<Value>';
-      ss.mapping.push(shrMapping);
-      df.mapping.push(shrMapping);
+      pushShrMapToElementMappings('<Value>', ss, df);
     } else {
       // If it isn't; and it's not a primitive type, map it to the fqn of the field being mapped
       if (!sourceValue.identifier.isPrimitive && !sourceValue._derivedFromIncludesTypeConstraint) {
         // Build the mapping based on the sourcePath for the rule, to handle nested elements
-        shrMapping['map'] = rule.sourcePath.map((pathElem) => {
+        const shrMap = rule.sourcePath.map((pathElem) => {
           return `<${pathElem.fqn}>`;
         }).join('.');
-        ss.mapping.push(shrMapping);
-        df.mapping.push(shrMapping);
+        pushShrMapToElementMappings(shrMap, ss, df);
       }
     }
 
@@ -3954,6 +3930,23 @@ function typesHaveSameCodesProfilesAndTargetProfiles(t1, t2) {
     }
   }
   return true;
+}
+
+/**
+ * Pushes an SHR mapping value (used for toFHIR/fromFHIR serialization) to the mapping property of one or more elements
+ * @param {string} shrMap - the string to store in the `map` value of the mapping object
+ * @param  {...Object} elements - the elements containing mappings to push the SHR maps onto
+ */
+function pushShrMapToElementMappings(shrMap, ...elements) {
+  for (const element of elements) {
+    if (element.mapping == null) {
+      element.mapping = [{ identity: 'shr', map: shrMap }];
+    }
+    // Else if mapping array exists, only add SHR map if it doesn't already exist (no duplicates allowed)
+    else if (element.mapping.every(em => em.identity !== 'shr' || em.map !== shrMap)) {
+      element.mapping.push({ identity: 'shr', map: shrMap });
+    }
+  }
 }
 
 // NOTE: This class only used if REPORT_PROFILE_INDICATORS is set to true

--- a/lib/export.js
+++ b/lib/export.js
@@ -2963,6 +2963,11 @@ class FHIRExporter {
       }
     }
 
+    const shrMap = sourcePath.map((pathElem) => {
+      return `<${pathElem.fqn}>`;
+    }).join('.');
+    pushShrMapToElementMappings(shrMap, ssEl, dfEl);
+
     this.applyConstraints(sourceValue, profile, ssEl, dfEl, true, sourcePath);
 
     return;

--- a/lib/export.js
+++ b/lib/export.js
@@ -156,6 +156,7 @@ class FHIRExporter {
       valueSets: this._valueSetExporter.valueSets,
       codeSystems: this._codeSystemExporter.codeSystems,
       models: this._modelsExporter.models,
+      base: this._fhir,
     };
   }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -629,7 +629,7 @@ class FHIRExporter {
   enhanceMap(map) {
     // We're going to mess with things, so let's just clone the mapping now!
     map = map.clone();
-    const targetItem = common.TargetItem.parse(map.target);
+    const targetItem = common.TargetItem.parse(map.targetItem);
 
     // Some mapping rules indicate to slice using an "includes" strategy.  This means to slice on the
     // IncludesTypeConstraints.  To implement this, we expand the one mapping rule to many (one per IncludesType).

--- a/lib/export.js
+++ b/lib/export.js
@@ -453,10 +453,13 @@ class FHIRExporter {
 
       // Check if this is a "no-diff" profile. A profile is considered "no-diff"
       // If the "mapping" is different, as the mappings are only used internally by other SHR profiles
+      const allowedDiffKeys = ['id', 'path', 'short', 'definition', 'mapping'];
+      const allowedDiffKeysForRoot = [...allowedDiffKeys, 'mustSupport', 'isModifier', 'isSummary'];
       const isNoDiffProfile = profile.differential.element.length <= 1 || profile.differential.element.every(e => {
         const keys = Object.keys(e);
+        const allowedKeys = (e.path.indexOf('.') === -1) ? allowedDiffKeysForRoot : allowedDiffKeys;
         return keys.every(k => {
-          return e[k] == null || k === 'id' || k === 'path' || k === 'short' || k === 'definition' || k === 'mapping';
+          return e[k] == null || allowedKeys.indexOf(k) !== -1;
         });
       });
       if (isNoDiffProfile || targetItem.hasNoProfileCommand()) {
@@ -3023,6 +3026,10 @@ class FHIRExporter {
     } else if (warnIfProfileIsProcessing && this._processTracker.isActive(identifier)) {
       logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(identifier));
     }
+    // If this is really a no-diff profile, then return the base structuredef instead!
+    if (typeof p !== 'undefined' && !common.isCustomProfile(p)) {
+      return this.lookupStructureDefinition(MVH.sdBaseDefinition(p));
+    }
     return p;
   }
 
@@ -3032,6 +3039,10 @@ class FHIRExporter {
     if (typeof profile !== 'undefined') {
       if (warnIfStructureDefinitionIsProcessing && this._processTracker.isActive(id)) {
         logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(id));
+      }
+      // If this is really a no-diff profile, then return the base structuredef instead!
+      if (!common.isCustomProfile(profile)) {
+        return this.lookupStructureDefinition(MVH.sdBaseDefinition(profile));
       }
       return profile;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.10.0-beta.2",
+  "version": "5.10.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.10.0-beta.1",
+  "version": "5.10.0-beta.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR replaces #114 and #116:

Finalizes the SHR field mappings in ElementDefinitions, to be used by from- and toFHIR function definition in the shr-es6-exporter.