### PR TITLE
Map to extension field

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -47,11 +47,18 @@ function getFHIRElementByID(elements, id) {
 
 var sliceIDCounters = new Map();
 
+function hasSlicingOnBaseElement(structureDef, snapshotEl, discType, discPath) {
+  return typeof snapshotEl.slicing !== 'undefined'
+    && MVH.edSlicingDiscriminator(structureDef, snapshotEl).some(d => d.type == discType && d.path == discPath);
+}
+
 function addSlicingToBaseElement(structureDef, snapshotEl, differentialEl, discType, discPath) {
   if (typeof snapshotEl.slicing !== 'undefined') {
     // A slicing already exists, so just add the missing discriminator
-    if (!MVH.edSlicingDiscriminator(structureDef, snapshotEl).some(d => d.type == discType && d.path == discPath)) {
+    if (!hasSlicingOnBaseElement(structureDef, snapshotEl, discType, discPath)) {
       snapshotEl.slicing.discriminator.push(MVH.convertDiscriminator(structureDef, { type: discType, path: discPath }));
+    } else {
+      return; // nothing was changed, so return before we modify the differential
     }
   } else {
     snapshotEl.slicing = createSlicingObject(structureDef, discType, discPath);
@@ -320,4 +327,4 @@ class FHIRExportError extends Error {
   }
 }
 
-module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, valueName, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, lowerFirst, todayString, isCustomProfile, typeToString, trim, getTarget, ProcessTracker, TargetItem, MappingCommand};
+module.exports = {FHIRExportError, getSnapshotElement, getSnapshotElementById, getDifferentialElementById, hasSlicingOnBaseElement, addSlicingToBaseElement, createSlicingObject, elementTypeContainsTypeName, fhirID, fhirURL, shortID, valueAndFields, valueName, equalShrElementPaths, escapeHTML, cloneJSON, capitalize, lowerFirst, todayString, isCustomProfile, typeToString, trim, getTarget, ProcessTracker, TargetItem, MappingCommand};

--- a/lib/export.js
+++ b/lib/export.js
@@ -2891,11 +2891,7 @@ class FHIRExporter {
     }
 
     const isModifier = /modifierExtension$/.test(extPath);
-    let baseExtEl = common.getSnapshotElement(profile, extPath);
-    // TODO: Why does this infinitely loop if we always use getSnapshotElementForFieldTarget?
-    if (baseExtEl == null) {
-      baseExtEl = this.getSnapshotElementForFieldTarget(profile, new FieldTarget(extPath), sourceValue);
-    }
+    const baseExtEl = this.getSnapshotElementForFieldTarget(profile, new FieldTarget(extPath), sourceValue);
 
     // First, look to see if the extension is already there (in the case of profiling a profile)
     let ssEl = profile.snapshot.element.find(e => {

--- a/lib/export.js
+++ b/lib/export.js
@@ -856,8 +856,9 @@ class FHIRExporter {
         } else if (rule.sourcePath.some(p => p instanceof mdls.TBD)) {
           continue;
         } else if (rule instanceof mdls.FieldMappingRule) {
-          if (rule.target.startsWith('http://') || rule.target.startsWith('https://')) {
-            this.processFieldToURLMappingRule(map, rule, profile);
+          const ft = FieldTarget.parse(rule.target);
+          if (ft.isExtension()) {
+            this.processFieldToExtensionMappingRule(map, rule, profile);
           } else {
             this.processFieldToFieldMappingRule(map, rule, profile);
           }
@@ -877,7 +878,7 @@ class FHIRExporter {
     const unslicedMap = new Map();
     for (const rule of map.rulesFilter.field.rules) {
       const t = FieldTarget.parse(rule.target);
-      if (!t.hasInSliceCommand()) {
+      if (!t.hasInSliceCommand() && !t.isExtension()) {
         const count = unslicedMap.has(t.target) ? unslicedMap.get(t.target) + 1 : 1;
         unslicedMap.set(t.target, count);
       }
@@ -897,17 +898,12 @@ class FHIRExporter {
     }
   }
 
-  processFieldToURLMappingRule(map, rule, profile) {
+  processFieldToExtensionMappingRule(map, rule, profile) {
     const def = this._specs.dataElements.findByIdentifier(map.identifier);
-    if (rule.sourcePath.length > 1) {
-      // TODO: If part of the sourcepath points to a BackboneElement, should we put the extension there?  How does that
-      // affect cardinality? Do we need a way in the mapping grammar to place extensions at certain points?
-      logger.info('Deep path mapped to extension, but extension placed at root level.');
-    }
     if (TRACK_UNMAPPED_PATHS) {
       this.removeMappedPath(def, rule.sourcePath);
     }
-    this.addExtension(def, profile, rule.sourcePath, rule.target);
+    this.addExtension(def, profile, rule);
   }
 
   processFieldToFieldMappingRule(map, rule, profile) {
@@ -2855,9 +2851,13 @@ class FHIRExporter {
           logger = logger.child({ extension: field.effectiveIdentifier.fqn });
           logger.debug('Start mapping extension');
           try {
-            this.addExtension(def, profile, [field.effectiveIdentifier]);
+            // By convention (for now) modifiers have the word "Modifier" in their name
+            const isModifier = (/modifier/i).test(field.effectiveIdentifier.name);
+            const extPath = isModifier ? 'modifierExtension' : 'extension';
+            const rule = new mdls.FieldMappingRule([field.effectiveIdentifier], extPath);
+            this.addExtension(def, profile, rule);
             if (TRACK_UNMAPPED_PATHS) {
-              this.removeMappedPath(def, [field.effectiveIdentifier]);
+              this.removeMappedPath(def, rule.sourcePath);
             }
           } catch (e) {
             logger.error('Unexpected error adding extension. ERROR_CODE:13051', e);
@@ -2873,9 +2873,9 @@ class FHIRExporter {
     }
   }
 
-  addExtension(def, profile, sourcePath, extURL) {
-    const sourceValue = this.findValueByPath(sourcePath, def);
-    const aggSourceCard = this.getAggregateEffectiveCardinality(def.identifier, sourcePath);
+  addExtension(def, profile, rule) {
+    const sourceValue = this.findValueByPath(rule.sourcePath, def);
+    const aggSourceCard = this.getAggregateEffectiveCardinality(def.identifier, rule.sourcePath);
 
     const identifier = sourceValue.effectiveIdentifier;
 
@@ -2884,18 +2884,25 @@ class FHIRExporter {
       return;
     }
 
-    if (typeof extURL === 'undefined') {
+    const ft = FieldTarget.parse(rule.target);
+    let extURL, extPath;
+    if (ft.isExtensionURL()) {
+      if (rule.sourcePath.length > 1) {
+        logger.info('Deep path mapped to extension URL, but extension placed at root level.');
+      }
+      extURL = ft.target;
+      extPath = 'extension';
+    } else {
       extURL = this._extensionExporter.lookupExtension(identifier).url;
+      extPath = ft.target;
     }
 
-    // By convention (for now) modifiers have the word "Modifier" in their name
-    const isModifier = (/modifier/i).test(identifier.name);
-    const extType = isModifier ? 'modifierExtension' : 'extension';
-    const baseExtEl = common.getSnapshotElement(profile, extType);
+    const isModifier = /modifierExtension$/.test(extPath);
+    const baseExtEl = common.getSnapshotElement(profile, extPath);
 
     // First, look to see if the extension is already there (in the case of profiling a profile)
     let ssEl = profile.snapshot.element.find(e => {
-      return e.path === `${MVH.sdType(profile)}.${extType}` && e.type.length === 1 && MVH.typeProfile(e.type[0]) === extURL;
+      return e.path === `${MVH.sdType(profile)}.${extPath}` && e.type.length === 1 && MVH.typeProfile(e.type[0]) === extURL;
     });
 
     let dfEl; // To be assigned later
@@ -2974,18 +2981,18 @@ class FHIRExporter {
     // If there isn't already a base, add it.  It's always defined in the base resource and has 0..* cardinality.
     if (!ssEl.base) {
       ssEl.base = dfEl.base = {
-        path: `${MVH.sdType(profile)}.${extType}`,
+        path: `${MVH.sdType(profile)}.${extPath}`,
         min: 0,
         max: '*'
       };
     }
 
-    const shrMap = sourcePath.map((pathElem) => {
+    const shrMap = rule.sourcePath.map((pathElem) => {
       return `<${pathElem.fqn}>`;
     }).join('.');
     pushShrMapToElementMappings(shrMap, ssEl, dfEl);
 
-    this.applyConstraints(sourceValue, profile, ssEl, dfEl, true, sourcePath);
+    this.applyConstraints(sourceValue, profile, ssEl, dfEl, true, rule.sourcePath);
 
     return;
   }
@@ -3686,6 +3693,17 @@ class FieldTarget {
   get target() { return this._target; }
   get commands() { return this._commands; }
   get comments() { return this._comments; }
+
+  // Functions to check if the target is an extension and how its mapped (URL or element)
+  isExtensionURL() {
+    return /^https?:\/\//.test(this._target);
+  }
+  isExtensionPath() {
+    return /^(.+\.)?(extension|modifierExtension)$/.test(this._target);
+  }
+  isExtension() {
+    return this.isExtensionURL() || this.isExtensionPath();
+  }
 
   // The "slice at" command indicates the path where the slicing is rooted.  This is only needed when the target
   // path is *not* where the root of the slice should be (for example, if the target is not multiple cardinality).

--- a/lib/export.js
+++ b/lib/export.js
@@ -1,5 +1,6 @@
 const bunyan = require('bunyan');
 const mdls = require('shr-models');
+const escapeRegExp = require('lodash/escapeRegExp');
 const load = require('./load');
 const common = require('./common');
 const MVH = require('./multiVersionHelper');
@@ -396,15 +397,6 @@ class FHIRExporter {
       // Remove any temporary properties we used to help along the way
       for (const el of profile.differential.element) {
         delete(el._originalProperties);
-      }
-
-      // If there are extensions, update the base extension element(s)
-      for (const extType of ['extension', 'modifierExtension']) {
-        if (profile.differential.element.filter(e => e.path == `${MVH.sdType(profile)}.${extType}`).length > 0) {
-          // Apparently we only need to modify the snapshot (based on published IGs and examples)
-          const ssEl = common.getSnapshotElement(profile, extType);
-          common.addSlicingToBaseElement(profile, ssEl, null, 'value', 'url');
-        }
       }
 
       // Fix any minimum cardinalities that should be bumped up due to slicing.
@@ -903,7 +895,7 @@ class FHIRExporter {
     if (TRACK_UNMAPPED_PATHS) {
       this.removeMappedPath(def, rule.sourcePath);
     }
-    this.addExtension(def, profile, rule);
+    this.addExtension(map, profile, rule);
   }
 
   processFieldToFieldMappingRule(map, rule, profile) {
@@ -2855,7 +2847,7 @@ class FHIRExporter {
             const isModifier = (/modifier/i).test(field.effectiveIdentifier.name);
             const extPath = isModifier ? 'modifierExtension' : 'extension';
             const rule = new mdls.FieldMappingRule([field.effectiveIdentifier], extPath);
-            this.addExtension(def, profile, rule);
+            this.addExtension(map, profile, rule);
             if (TRACK_UNMAPPED_PATHS) {
               this.removeMappedPath(def, rule.sourcePath);
             }
@@ -2873,7 +2865,8 @@ class FHIRExporter {
     }
   }
 
-  addExtension(def, profile, rule) {
+  addExtension(map, profile, rule) {
+    const def = this._specs.dataElements.findByIdentifier(map.identifier);
     const sourceValue = this.findValueByPath(rule.sourcePath, def);
     const aggSourceCard = this.getAggregateEffectiveCardinality(def.identifier, rule.sourcePath);
 
@@ -2898,7 +2891,11 @@ class FHIRExporter {
     }
 
     const isModifier = /modifierExtension$/.test(extPath);
-    const baseExtEl = common.getSnapshotElement(profile, extPath);
+    let baseExtEl = common.getSnapshotElement(profile, extPath);
+    // TODO: Why does this infinitely loop if we always use getSnapshotElementForFieldTarget?
+    if (baseExtEl == null) {
+      baseExtEl = this.getSnapshotElementForFieldTarget(profile, new FieldTarget(extPath), sourceValue);
+    }
 
     // First, look to see if the extension is already there (in the case of profiling a profile)
     let ssEl = profile.snapshot.element.find(e => {
@@ -2911,12 +2908,19 @@ class FHIRExporter {
       if (aggSourceCard.max == 0) {
         return;
       }
+
+      // We'll be adding an extension, so ensure we have the base slicing defined
+      if (!common.hasSlicingOnBaseElement(profile, baseExtEl, 'value', 'url')) {
+        const baseExtDiffEl = common.getDifferentialElementById(profile, baseExtEl.id, true);
+        common.addSlicingToBaseElement(profile, baseExtEl, baseExtDiffEl, 'value', 'url');
+      }
+
       // Find the base extension element from which this extension will be derived
       ssEl = common.cloneJSON(baseExtEl);
       ssEl.id = `${ssEl.id}:${common.shortID(identifier)}`;
-      ssEl.path;
       MVH.setEdSliceName(profile, ssEl, common.shortID(identifier));
       ssEl.definition = this.getDescription(identifier, identifier.name);
+      // NOTE: Set initial cardinality in simple way, but will be re-processed later
       ssEl.min = aggSourceCard.min;
       ssEl.max = typeof aggSourceCard.max === 'undefined' ? '*' : aggSourceCard.max.toString();
       ssEl.type = [MVH.convertType(profile, { code : 'Extension', profile : extURL })];
@@ -2929,10 +2933,10 @@ class FHIRExporter {
       delete(ssEl.alias);
       delete(ssEl.mapping);
       delete(ssEl.slicing);
-      this.insertExtensionElementInList(ssEl, profile.snapshot.element);
+      this.insertElementInSnapshot(ssEl, profile);
 
       dfEl = common.cloneJSON(ssEl);
-      this.insertExtensionElementInList(dfEl, profile.differential.element);
+      this.insertElementInDifferential(dfEl, profile);
     } else {
       // There is an existing snapshot element for this extension, so we'll modify that.
       // Grab the matching differential element before we change the snapshot id
@@ -2953,12 +2957,7 @@ class FHIRExporter {
       if (typeof ssEl.definition === 'undefined') {
         dfEl.definition = ssEl.definition = this.getDescription(identifier, identifier.name);
       }
-      const targetCard = getFHIRElementCardinality(ssEl);
-      if (aggSourceCard.fitsWithinCardinalityOf(targetCard)) {
-        setCardinalityOnFHIRElements(aggSourceCard, ssEl, dfEl);
-      } else {
-        logger.error('Cannot constrain cardinality from %s to %s. ERROR_CODE:13014', targetCard.toString(), aggSourceCard.toString());
-      }
+      // NOTE: Cardinalities will be handled later
       if (isModifier && (typeof ssEl.mustSupport === 'undefined' || !ssEl.mustSupport)) {
         dfEl.mustSupport = ssEl.mustSupport = true;
       }
@@ -2974,9 +2973,12 @@ class FHIRExporter {
       }
 
       if (dfIsNew) {
-        this.insertExtensionElementInList(dfEl, profile.differential.element);
+        this.insertElementInDifferential(dfEl, profile);
       }
     }
+
+    // Set the cardinalities, using aggregates to ensure proper cardinality mapping
+    this.processFieldToFieldCardinality(map, rule, profile, ssEl, dfEl);
 
     // If there isn't already a base, add it.  It's always defined in the base resource and has 0..* cardinality.
     if (!ssEl.base) {
@@ -2997,24 +2999,52 @@ class FHIRExporter {
     return;
   }
 
-  insertExtensionElementInList(extElement, elements) {
-    let inserted = false;
-    const priorPaths = ['id', 'meta', 'implicitRules', 'language', 'text', 'contained', 'extension'];
-    if (extElement.isModifier) {
-      priorPaths.push('modifierExtension');
-    }
-    for (let i=0; i < elements.length; i++) {
-      const pathParts = elements[i].path.split('.');
-      if (pathParts.length > 1 && priorPaths.indexOf(pathParts[1]) == -1) {
-        elements.splice(i, 0, extElement);
-        inserted = true;
-        break;
+  /**
+   * Inserts an element into its proper place in a list of elements
+   */
+  insertElementInList(element, list) {
+    let i = 0;
+    let lastMatchId = '';
+    for (; i < list.length; i++) {
+      const currentId = list[i].id;
+      // If the item we're placing starts with the current item, it's a match
+      // so remember the match and go to the next element in the list
+      if ((new RegExp(`^${escapeRegExp(currentId)}([\\.:].+)?$`)).test(element.id)) {
+        lastMatchId = currentId;
+      // If it wasn't a match, but the current item is a choice (e.g., value[x]), call it
+      // a match if it starts with the same root (e.g., valueString), and then go to the next element
+      } else if (currentId.endsWith('[x]') && (new RegExp(`^${escapeRegExp(currentId.slice(0, -3))}[A-Z][^\\.]+(\\..+)?$`)).test(element.id)) {
+        lastMatchId = currentId;
+      } else {
+        let stop;
+        // If the next part of the item is a '.' (not a ':'), then we want to stop if the current item
+        // doesn't start with the last match or is a slice of the last match (as indicated by a ':')
+        if (element.id.length > lastMatchId.length && element.id[lastMatchId.length] === '.') {
+          stop = ! new RegExp(`^${escapeRegExp(lastMatchId)}(\\..+)?$`).test(currentId);
+        // else we want to stop if the current item doesn't start with the last match
+        } else {
+          stop = ! new RegExp(`^${escapeRegExp(lastMatchId)}([\\.:].+)?$`).test(currentId);
+        }
+        if (stop) {
+          break;
+        }
       }
     }
-    if (!inserted) {
-      // Just insert it at the end
-      elements.push(extElement);
-    }
+    list.splice(i, 0, element);
+  }
+
+  /**
+   * Inserts an element into its proper place in the snapshot element
+   */
+  insertElementInSnapshot(element, profile) {
+    this.insertElementInList(element, profile.snapshot.element);
+  }
+
+  /**
+   * Inserts an element into its proper place in the differential elements
+   */
+  insertElementInDifferential(element, profile) {
+    this.insertElementInList(element, profile.differential.element);
   }
 
   lookupProfile(identifier, createIfNeeded=true, warnIfProfileIsProcessing=false) {

--- a/lib/multiVersionHelper.js
+++ b/lib/multiVersionHelper.js
@@ -299,10 +299,10 @@ function edSliceName(structDef, elDef) {
     if (name == null) {
       return name;
     }
-    // To know if it is really a *slice* name, we need to see if there is an element with the same
+    // To know if it is really a *slice* name, we need to see if there is another element with the same
     // path that has a *slicing* defined.  If not, this is just an identifier name and we
     // shouldn't return it as a slice name.
-    if (structDef.snapshot.element.some(e => e.path === elDef.path && e.slicing != null)) {
+    if (structDef.snapshot.element.some(e => e != elDef && e.path === elDef.path && e.slicing != null)) {
       return name;
     }
     return undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.10.0",
+  "version": "5.11.0-beta.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.11.0-beta.1",
+  "version": "5.11.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
The 5.11.0 Beta release adds support for mapping fields directly to `extension` and `modifierExtension` paths.

For example, see the last two mappings in this DSTU2 mapping:
```
Observation maps to Observation:
  // ... field mappings here
  ReferenceRange maps to referenceRange
  ReferenceRange.Range.LowerBound maps to referenceRange.low
  ReferenceRange.Range.UpperBound maps to referenceRange.high
  ReferenceRange.Type maps to referenceRange.meaning 
  ReferenceRange.ApplicableSubpopulation maps to referenceRange.modifierExtension
  ReferenceRange.ApplicableAgeRange maps to referenceRange.modifierExtension
  // ... more field mappings
```

The above would create extensions for `ApplicableSubpupulation` and `ApplicableAgeRange` and then map them as modifierExtensions on `Observation.referenceRange`.