### PR TITLE
No shr maps in ig

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -165,7 +165,9 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   const sdPath = path.join(outDir, 'resources');
   fs.ensureDirSync(sdPath);
   const fhirSpecURLBase = target === 'FHIR_DSTU_2' ? 'http://hl7.org/fhir/DSTU2/' : 'http://hl7.org/fhir/STU3/';
-  for (const profile of fhirResults.profiles) {
+  for (let profile of fhirResults.profiles) {
+    profile = removeSHRMappings(profile);
+
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${profile.id}.json`), JSON.stringify(profile, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${profile.id}`] = {
       'base': `StructureDefinition-${profile.id}.html`
@@ -272,7 +274,9 @@ ${match[1]}
   && config.implementationGuide.primarySelectionStrategy
   && (config.implementationGuide.primarySelectionStrategy.strategy === 'namespace');
 
-  for (const extension of fhirResults.extensions.sort(byName)) {
+  for (let extension of fhirResults.extensions.sort(byName)) {
+    extension = removeSHRMappings(extension);
+
     if (primaryExtensionUrls.has(extension.url)) {
       for (const element of extension.snapshot.element) {
         if (element.binding
@@ -688,6 +692,50 @@ function byName(a, b) {
     return 1;
   }
   return 0;
+}
+
+function removeSHRMappings(sd) {
+  sd = common.cloneJSON(sd);
+  // First go through and remove all the SHR mappings from the snapshot
+  sd.snapshot.element.forEach(el => {
+    if (el.mapping && el.mapping.length > 0) {
+      el.mapping = el.mapping.filter(m => m.identity != 'shr');
+      if (el.mapping.length === 0) {
+        delete el.mapping;
+      }
+    }
+  });
+  // Then remove all SHR mappings from the differential
+  sd.differential.element.forEach(el => {
+    if (el.mapping && el.mapping.length > 0) {
+      el.mapping = el.mapping.filter(m => m.identity != 'shr');
+      if (el.mapping.length === 0) {
+        delete el.mapping;
+      }
+    }
+  });
+  // Remove the differential elements that are now just id/path and don't have any non-trivial child differential elements
+  sd.differential.element = sd.differential.element.filter((el, i) => {
+    const keys = Object.keys(el);
+    if (keys.length <= 2 && keys.every(k => k === 'id' || k === 'path')) {
+      // We know that children will be directly after it and will start with the same path
+      for (let j=i+1; j < sd.differential.element.length && sd.differential.element[j].path.startsWith(`${el.path}.`); j++) {
+        const childEl = sd.differential.element[j];
+        const childKeys = Object.keys(childEl);
+        if (childKeys.length > 2 || childKeys.some(k => k !== 'id' && k !== 'path')) {
+          // It has a non trivial descendent, so keep it
+          return true;
+        }
+      }
+      // It has no meaningful child differentials so filter it out
+      return false;
+    }
+    // It's non-trivial so keep it
+    return true;
+  });
+  // TODO: Do we need to clean up the snapshot of any elements that were expanded just so we could put the mapping in?
+  // Finally return the new sd
+  return sd;
 }
 
 module.exports = {exportIG};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.11.1",
+  "version": "5.11.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR removes SHR mappings from the profiles and extensions in the IG source.  The mappings are needed by the shr-es6-export, but are not necessary in the IG source.  We want to remove them because they cause the IG to show elements in the diff that only differ by mapping (which isn't even displayed in the UI).  This is confusing to readers.