### PR TITLE
Add support for using extension ids in paths

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -3128,11 +3128,34 @@ class FHIRExporter {
     let elements = profile.snapshot.element;
     let parentEl = profile.snapshot.element[0];
     let cumulativePath = MVH.sdType(profile);
+    // Path parts can have multiple components -- the root part, an optional id or choice specifier, and a slice name
+    // e.g., foo, foo[bar], foo[x], foo:baz, foo[bar]:baz, or foo[x].baz
+    // This regex separates out those components so we can process based on them
+    const pathPartRegex = /^([^\[:]+)(\[([^\]]+)\])?(:(.*))?$/;
+    const extRegEx = /^(modifierE|e)xtension$/;
+    // Now iterate the path one part at a time
     for (let i=0; i < targetPathArray.length; i++) {
-      // First, find the element that matches the path and slice name.  This is the root of all elements at this path.
-      const [pathPart, sliceName] = targetPathArray[i].split(':', 2);
+      // Match on the part
+      const match = targetPathArray[i].match(pathPartRegex);
+      const isExt = extRegEx.test(match[1]); // test if match[1] (the root) is extension or modifierExtension
+      const pathPart = isExt ? match[1] : `${match[1]}${match[2] || ''}`; // In the case of value[x], match[2] is [x]
+      const extName = isExt ? match[3] : null; // match[3] is the bit inside the bracks (the extension id)
+      const sliceName = match[5]; // match[5] is the slicename (after the ':')
       cumulativePath += `.${pathPart}`;
-      let root = elements.find(e => MVH.edSliceName(profile, e) === sliceName && e.path === cumulativePath);
+      let root = elements.find(e => {
+        if (isExt && extName != null) {
+          // Lookup the extension by its ID, supporting cases where the profile is an id or URL w/ id at end
+          const extType = e.type ? e.type.find(t => t.code === 'Extension') : null;
+          const extProfile = MVH.typeProfile(extType);
+          return e.path === cumulativePath
+            && extProfile
+            && (extProfile === extName || extProfile.endsWith(`/${extName}`))
+            && (sliceName == null || MVH.edSliceName(profile, e) === sliceName);
+        } else {
+          // No extension name specified, so just search by path and slicename (if applicable)
+          return e.path === cumulativePath && MVH.edSliceName(profile, e) === sliceName;
+        }
+      });
       if (root != null) {
         // Re-set the parent and narrow elements to only those under this path/slice (including the root)
         parentEl = root;
@@ -3187,7 +3210,8 @@ class FHIRExporter {
           return;
         }
         // At this point, it looks like we may need to "unroll" the parent to get to this part of the path
-        const type = parentEl.type[0].code;
+        // If there is a profile, that's what we want to unroll, otherwise the type
+        const type = MVH.typeProfile(parentEl.type[0]) || MVH.typeTargetProfile(parentEl.type[0]) || parentEl.type[0].code;
         const sd = this.lookupStructureDefinition(type, true);
         // Before we unroll it, check to be sure the sub-element exists (otherwise we needlessly unroll it)
         const sdType = MVH.sdType(sd);

--- a/lib/multiVersionHelper.js
+++ b/lib/multiVersionHelper.js
@@ -371,7 +371,9 @@ function convertType(structDef, type) {
 }
 
 function typeProfile(type) {
-  if (Array.isArray(type.profile)) {
+  if (type == null) {
+    return type;
+  } else if (Array.isArray(type.profile)) {
     // It's DSTU2, so only return it if the code is not Reference (else it's really targetProfile).
     // Also drop anything after the first element in the array.
     return type.code !== 'Reference' && type.profile.length > 0 ? type.profile[0] : undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.11.2",
+  "version": "5.12.0-beta.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Adds support for mapping phrases with extension ids like:
```
constrain item.extension[cqif-calculatedValue] to 1..1
```
and
```
DTR-QuestionnaireItem.CalculatedValue maps to item.extension[cqif-calculatedValue].valueString
```