### PR TITLE
Fix DSTU2 slice names

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -1,9 +1,9 @@
 const bunyan = require('bunyan');
 const mdls = require('shr-models');
-const escapeRegExp = require('lodash/escapeRegExp');
 const load = require('./load');
 const common = require('./common');
 const MVH = require('./multiVersionHelper');
+const {insertElementInSnapshot, insertElementInDifferential} = require ('./insertElement');
 const {CodeSystemExporter} = require('./codeSystems');
 const {ValueSetExporter} = require('./valueSets');
 const {ExtensionExporter} = require('./extensions');
@@ -2951,10 +2951,10 @@ class FHIRExporter {
       delete(ssEl.alias);
       delete(ssEl.mapping);
       delete(ssEl.slicing);
-      this.insertElementInSnapshot(ssEl, profile);
+      insertElementInSnapshot(ssEl, profile);
 
       dfEl = common.cloneJSON(ssEl);
-      this.insertElementInDifferential(dfEl, profile);
+      insertElementInDifferential(dfEl, profile);
     } else {
       // There is an existing snapshot element for this extension, so we'll modify that.
       // Grab the matching differential element before we change the snapshot id
@@ -2991,7 +2991,7 @@ class FHIRExporter {
       }
 
       if (dfIsNew) {
-        this.insertElementInDifferential(dfEl, profile);
+        insertElementInDifferential(dfEl, profile);
       }
     }
 
@@ -3015,54 +3015,6 @@ class FHIRExporter {
     this.applyConstraints(sourceValue, profile, ssEl, dfEl, true, rule.sourcePath);
 
     return;
-  }
-
-  /**
-   * Inserts an element into its proper place in a list of elements
-   */
-  insertElementInList(element, list) {
-    let i = 0;
-    let lastMatchId = '';
-    for (; i < list.length; i++) {
-      const currentId = list[i].id;
-      // If the item we're placing starts with the current item, it's a match
-      // so remember the match and go to the next element in the list
-      if ((new RegExp(`^${escapeRegExp(currentId)}([\\.:].+)?$`)).test(element.id)) {
-        lastMatchId = currentId;
-      // If it wasn't a match, but the current item is a choice (e.g., value[x]), call it
-      // a match if it starts with the same root (e.g., valueString), and then go to the next element
-      } else if (currentId.endsWith('[x]') && (new RegExp(`^${escapeRegExp(currentId.slice(0, -3))}[A-Z][^\\.]+(\\..+)?$`)).test(element.id)) {
-        lastMatchId = currentId;
-      } else {
-        let stop;
-        // If the next part of the item is a '.' (not a ':'), then we want to stop if the current item
-        // doesn't start with the last match or is a slice of the last match (as indicated by a ':')
-        if (element.id.length > lastMatchId.length && element.id[lastMatchId.length] === '.') {
-          stop = ! new RegExp(`^${escapeRegExp(lastMatchId)}(\\..+)?$`).test(currentId);
-        // else we want to stop if the current item doesn't start with the last match
-        } else {
-          stop = ! new RegExp(`^${escapeRegExp(lastMatchId)}([\\.:].+)?$`).test(currentId);
-        }
-        if (stop) {
-          break;
-        }
-      }
-    }
-    list.splice(i, 0, element);
-  }
-
-  /**
-   * Inserts an element into its proper place in the snapshot element
-   */
-  insertElementInSnapshot(element, profile) {
-    this.insertElementInList(element, profile.snapshot.element);
-  }
-
-  /**
-   * Inserts an element into its proper place in the differential elements
-   */
-  insertElementInDifferential(element, profile) {
-    this.insertElementInList(element, profile.differential.element);
   }
 
   lookupProfile(identifier, createIfNeeded=true, warnIfProfileIsProcessing=false) {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -258,7 +258,6 @@ class ExtensionExporter {
     const ssExt = {
       id: `${baseId}.extension:extension`,
       path: `${this.getExtensionPathFromExtensionID(baseId)}.extension`,
-      [MVH.nameOfEdSliceName(extension)]: 'extension',
       short: 'Extension',
       definition: 'An Extension',
       min: 0,
@@ -270,7 +269,6 @@ class ExtensionExporter {
     const dfExt = {
       id: ssExt.id,
       path: ssExt.path,
-      [MVH.nameOfEdSliceName(extension)]: MVH.edSliceName(extension, ssExt),
       max: ssExt.max
     };
     extension.differential.element.push(dfExt);

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -439,7 +439,7 @@ class ExtensionExporter {
     const dfExt = {
       id: ssExt.id,
       path: ssExt.path,
-      [MVH.nameOfEdSliceName(extension)]: MVH.edSliceName(extension, ssExt),
+      [MVH.nameOfEdSliceName(extension)]: common.shortID(field.identifier),
       short: ssExt.short,
       definition: ssExt.definition,
       min: ssExt.min,

--- a/lib/insertElement.js
+++ b/lib/insertElement.js
@@ -1,0 +1,59 @@
+const escapeRegExp = require('lodash/escapeRegExp');
+
+/**
+ * Finds the intended index in the list where the element should be inserted
+ */
+function intendedIndexInList(element, list) {
+  let i = 0;
+  let lastMatchId = '';
+  for (; i < list.length; i++) {
+    const currentId = list[i].id;
+    // If the item we're placing starts with the current item, it's a match
+    // so remember the match and go to the next element in the list
+    if ((new RegExp(`^${escapeRegExp(currentId)}([\\.:].+)?$`)).test(element.id)) {
+      lastMatchId = currentId;
+    // If it wasn't a match, but the current item is a choice (e.g., value[x]), call it
+    // a match if it starts with the same root (e.g., valueString), and then go to the next element
+    } else if (currentId.endsWith('[x]') && (new RegExp(`^${escapeRegExp(currentId.slice(0, -3))}[A-Z][^\\.]+(\\..+)?$`)).test(element.id)) {
+      lastMatchId = currentId;
+    } else {
+      let stop;
+      // If the next part of the item is a '.' (not a ':'), then we want to stop if the current item
+      // doesn't start with the last match or is a slice of the last match (as indicated by a ':')
+      if (element.id.length > lastMatchId.length && element.id[lastMatchId.length] === '.') {
+        stop = ! new RegExp(`^${escapeRegExp(lastMatchId)}(\\..+)?$`).test(currentId);
+      // else we want to stop if the current item doesn't start with the last match
+      } else {
+        stop = ! new RegExp(`^${escapeRegExp(lastMatchId)}([\\.:].+)?$`).test(currentId);
+      }
+      if (stop) {
+        break;
+      }
+    }
+  }
+  return i;
+}
+
+/**
+ * Inserts an element into its proper place in a list of elements
+ */
+function insertElementInList(element, list) {
+  const i = intendedIndexInList(element, list);
+  list.splice(i, 0, element);
+}
+
+/**
+ * Inserts an element into its proper place in the snapshot element
+ */
+function insertElementInSnapshot(element, profile) {
+  insertElementInList(element, profile.snapshot.element);
+}
+
+/**
+ * Inserts an element into its proper place in the differential elements
+ */
+function insertElementInDifferential(element, profile) {
+  insertElementInList(element, profile.differential.element);
+}
+
+module.exports = { insertElementInList, insertElementInSnapshot, insertElementInDifferential, intendedIndexInList };

--- a/lib/multiVersionHelper.js
+++ b/lib/multiVersionHelper.js
@@ -1,3 +1,4 @@
+const {intendedIndexInList} = require('./insertElement');
 /**
  * Gets the value of a property from a definition, looking at the fhir version to determine whether to get r2 or r3
  * @param {Object} rootDef - the definition to get the fhirVersion from
@@ -299,11 +300,26 @@ function edSliceName(structDef, elDef) {
     if (name == null) {
       return name;
     }
-    // To know if it is really a *slice* name, we need to see if there is another element with the same
-    // path that has a *slicing* defined.  If not, this is just an identifier name and we
-    // shouldn't return it as a slice name.
-    if (structDef.snapshot.element.some(e => e != elDef && e.path === elDef.path && e.slicing != null)) {
-      return name;
+    // To know if it is really a *slice* name, we need to see if there is a previous element with the same
+    // path -- and in the same subtree -- that has a *slicing* defined.  If not, this is just an identifier
+    // name and we shouldn't return it as a slice name.
+    let elDefIdx = structDef.snapshot.element.findIndex(e => e === elDef);
+    if (elDefIdx === -1) {
+      // element hasn't been inserted into the list, so find where it *should* be inserted
+      elDefIdx = intendedIndexInList(elDef, structDef.snapshot.element);
+    }
+    // Iterate the elements backward from the elDef, looking for one with a matching path & a slicing
+    for (let i = elDefIdx - 1; i >= 0; i--) {
+      const prevEl = structDef.snapshot.element[i];
+      // if the path is shorter than elDef's path, then any matching paths before this are in a different
+      // sub-tree, so they don't count.
+      if (!prevEl.path.startsWith(elDef.path)) {
+        return undefined;
+      }
+      // If it has a matching path and a slicing, it's a real slice -- return the name!
+      if (elDef.path === prevEl.path && prevEl.slicing != null) {
+        return name;
+      }
     }
     return undefined;
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This fixes a problem that can come up when classes are mapped to Argonaut profiles and slicing is used.  In DSTU2, the `name` attribute (on `element`) is used for two purposes -- _one_ of which can be as a slice name.  Our code needs to determine if it is a slice name or not.  Our previous logic to determine this was flawed -- in that it would incorrectly detect it as a slice name if the same path had been sliced _anywhere_ in the profile.  Now we only look in the same sub-tree for a slice root.

Without the fix, if you run the following against the `shr_spec` branch `dev_mlt_geneChanges`:
```
node . -c ig-oncocore-config.json -l error -s es6 ../shr_spec/spec/
```
... you'll get errors like this:
```
[03:00:54.086Z] ERROR shr: Invalid or unsupported target path. ERROR_CODE:13006 (module=shr-fhir-export, shrId=oncocore.TumorDimensions)
    target: http://fhir.org/guides/argonaut/StructureDefinition/argo-observationresults
    --
    mappingRule: Components.TumorDimension2.DataValue maps to component.value[x] (in slice = component:oncocore-TumorDimension2)
```

With the fix, the errors go away.  (Note -- we are skipping ES6 export because there are _known_ errors there).

This PR also removes a slicename that had been applied to sub-extensions of extensions when they were zeroed out.  It just never should have been there in the first place -- so I removed it.

To support some of the slicename detection, I had to refactor an algorithm out of `export.js` and I put it in `insertInElements.js`.  That code isn't really new -- it's just moved.