### PR TITLE
Fix issue constraining value[x] in extension elements of profiles

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2319,6 +2319,20 @@ class FHIRExporter {
   }
 
   findTargetFHIRPath(rootIdentifier, shrPath) {
+    if (shrPath.length === 0) {
+      return '';
+    }
+
+    // As a *very* special (and unfortunate) case, we must special-case quantity.  Essentially, the problem is that
+    // Quantity maps Units.Coding onto itself, so paths for Units.Coding need to be applied to Quantity instead.
+    // E.g., system and code are actually at the *root* of Quantity
+    if (new mdls.Identifier('shr.core', 'Quantity').equals(rootIdentifier)) {
+      // Change path from Units.Coding to empty...
+      if (shrPath.length >= 2 && new mdls.Identifier('shr.core', 'Units').equals(shrPath[0]) && new mdls.Identifier('shr.core', 'Coding').equals(shrPath[1])) {
+        return this.findTargetFHIRPath(rootIdentifier, shrPath.slice(2));
+      }
+    }
+
     // Lookup rootIdentifier mapping
     const map = this._specs.maps.findByTargetAndIdentifier(this._target, rootIdentifier);
     // Look for fieldmapping w/ shrPath
@@ -2379,7 +2393,15 @@ class FHIRExporter {
       logger.error('Failed to resolve path from %s to %s. ERROR_CODE:13026', snapshotEl.id, shrPath);
       return;
     }
-    return this.getElementInExtension(shrPath.slice(1), profile, el);
+    if (el.type.length == 1 && el.type[0].code == 'Extension') {
+      return this.getElementInExtension(shrPath.slice(1), profile, el);
+    } else {
+      // We hit a non-extension element, so do the standard element search from the parent extension down the rest of the path
+      const targetRootPath = el.path.substring(el.path.lastIndexOf('.')+1);
+      const targetSubPath = this.findTargetFHIRPath(shrPath[1], shrPath.slice(2));
+      const fieldTarget = targetSubPath.length === 0 ? new FieldTarget(targetRootPath) : new FieldTarget(`${targetRootPath}.${targetSubPath}`);
+      return this.getSnapshotElementFromParentToFieldTarget(profile, snapshotEl, fieldTarget);
+    }
   }
 
   // When applying constraints to an extension, we need actually apply it to the extension's value (if present)
@@ -2759,7 +2781,7 @@ class FHIRExporter {
       }
 
       // Now check for subpaths (system and code)
-      const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, snapshotEl, identifier);
+      const [systemEl, codeEl] = this.findSystemAndCodeElements(profile, snapshotEl, 'Quantity');
       if ((systemEl.fixedUri && systemEl.fixedUri != code.system) || (codeEl.fixedCode && codeEl.fixedCode != code.code)) {
         logger.error('Cannot override code constraint from %s|%s to %s|%s. ERROR_CODE:13048', systemEl.fixedUri, codeEl.fixedCode, code.system, code.code);
         return;
@@ -3339,6 +3361,11 @@ class FHIRExporter {
   }
 
   getSnapshotElementForFieldTarget(profile, fieldTarget, sourceValue, sliceCard) {
+    const parentEl = profile.snapshot.element[0];
+    return this.getSnapshotElementFromParentToFieldTarget(profile, parentEl, fieldTarget, sourceValue, sliceCard);
+  }
+
+  getSnapshotElementFromParentToFieldTarget(profile, parentEl, fieldTarget, sourceValue, sliceCard) {
     // Get the slice-aware path (by combining in-slice value with the target)
     const targetPathArray = fieldTarget.target.split('.');
     if (fieldTarget.hasInSliceCommand()) {
@@ -3351,10 +3378,11 @@ class FHIRExporter {
         targetPathArray[i] = slicePathArray[i];
       }
     }
+
     // Try to find the path one segment as a time, unrolling child elements and creating slices as necessary
-    let elements = profile.snapshot.element;
-    let parentEl = profile.snapshot.element[0];
-    let cumulativePath = MVH.sdType(profile);
+    let elements = profile.snapshot.element.filter(e => e.id === parentEl.id || e.id.startsWith(`${parentEl.id}.`));
+    let cumulativePath = parentEl.path;
+
     // Path parts can have multiple components -- the root part, an optional id or choice specifier, and a slice name
     // e.g., foo, foo[bar], foo[x], foo:baz, foo[bar]:baz, or foo[x].baz
     // This regex separates out those components so we can process based on them

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.13.1",
+  "version": "5.13.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This fixes an issue with applying constraints to `value[x]` elements in profile extensions.

To reproduce, run the currently released SHR CLI against `shr_spec` _dev_ branch without specifying a config:
```
node . -l error -s es6 ../shr_spec/spec/
```

You'll see two errors, both related to applying constraints on `bodySite` extensions.

If you yarn-link to the `shr-fhir-export` _fix-map-to-ext_ branch (this PR), and re-run the CLI, the errors go away.  In addition, you'll see that the constraints are properly applied to the `brca-BreastCancerCondition` and `brca-BreastSpeciment` profiles.  For example, these entries are added to the `differential` of `brca-BreastSpecimen.json`:

![image](https://user-images.githubusercontent.com/2278253/55995538-bee9ad80-5c82-11e9-8392-2209eb3bf195.png)
