### PR TITLE
More allowed conversions

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -30,6 +30,10 @@ function setLogger(bunyanLogger) {
 const allowedConversions = {
   'boolean': ['code'],
   'dateTime': ['date', 'instant'],
+  'positiveInt': ['unsignedInt', 'integer', 'Quantity'],
+  'unsignedInt': ['integer', 'Quantity'],
+  'integer': ['Quantity'],
+  'markdown': ['string'],
   'shr.core.CodeableConcept': ['Coding', 'code'],
   'shr.core.Coding': ['CodeableConcept', 'code']
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.13.2",
+  "version": "5.13.3",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Allow additional conversions for FHIR primitives:

* positiveInt can map to unsignedInt or integer or Quantity
* unsignedInt can map to integer or Quantity
* integer can map to Quantity
* markdown can map to string

You can test this by changing fields that are defined as these primitives in the SHR spec.  For example, you should be able to change `string` fields to `markdown` fields now and the FHIR exporter will still work.  Similar, you should be able to change `integer` fields to `positiveInt` or `unsignedInt`.