### PR TITLE
v5.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Only bumps the version number so we can re-publish to NPM as 5.14.2.  The 5.14.1 publish to NPM mistakenly included two versions of the FHIR Publisher jar due to a local unchecked-in version on my system.