### PR TITLE
Fix potential null pointer exception in ig.js

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -217,7 +217,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     if (Array.isArray(primary)) {
       isPrimaryFn = (id) => {
         const element = idToElementMap.get(id);
-        return (/-extension$/.test(id) || element.isEntry) && (primary.indexOf(element.identifier.namespace) != -1);
+        return element && (/-extension$/.test(id) || element.isEntry) && (primary.indexOf(element.identifier.namespace) != -1);
       };
     } else {
       logger.error('Namespace strategy requires config.implementationGuide.primarySelectionStrategy.primary to be an array');
@@ -228,7 +228,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     if (Array.isArray(primary)) {
       isPrimaryFn = (id) => {
         const element = idToElementMap.get(id);
-        return (/-extension$/.test(id) || element.isEntry) && ((primary.indexOf(element.identifier.name) != -1) || (primary.indexOf(element.identifier.namespace) != -1) || (primary.indexOf(element.identifier.fqn) != -1));
+        return element && (/-extension$/.test(id) || element.isEntry) && ((primary.indexOf(element.identifier.name) != -1) || (primary.indexOf(element.identifier.namespace) != -1) || (primary.indexOf(element.identifier.fqn) != -1));
       };
     } else {
       // TODO: Get a logger!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "5.14.2",
+  "version": "5.14.3",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fix potential null pointer exception when checking if a primitive extension is primary.

We sometimes use primitive extensions (e.g., `primitive-string-extension`), but these won't have associated Elements.  The isPrimaryFn was trying to get and operate on the element associated with these -- which didn't work (since there is none).  A null check fixes the problem.