### PR TITLE
Carry over descriptions

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2360,7 +2360,9 @@ class FHIRExporter {
           logger.warn('Trying to map %s to %s, but %s was previously mapped to it. ERROR_CODE:03001', sourceProfile.url, matchedType.code, mappedProfiles.join(' | '));
         } else {
           // We successfully mapped the type, so we need to apply the definition and update the differential
-          snapshotEl.short = differentialEl.short = sourceIdentifier.name;
+          let short = this.getDescriptionAsShort(sourceIdentifier);
+          short = short ? `${sourceIdentifier.name}: ${short}` : sourceIdentifier.name;
+          snapshotEl.short = differentialEl.short = short;
           snapshotEl.definition = differentialEl.definition = this.getDescription(sourceIdentifier, sourceIdentifier.name);
           if (typeof mappedProfiles !== 'undefined' && !typesHaveSameCodesProfilesAndTargetProfiles(originalTargetTypes, snapshotEl.type)) {
             differentialEl.type = snapshotEl.type;
@@ -2401,7 +2403,9 @@ class FHIRExporter {
       fieldTarget.addSliceStrategyCommand('includes');
       const slice = this.createSliceFromBase(profile, snapshotEl, ictConstraint.isA.name, fieldTarget, sourceValue, ictConstraint.card);
       const sliceDf = common.getDifferentialElementById(profile, slice.id, true);
-      slice.short = sliceDf.short = ictConstraint.isA.name;
+      let short = this.getDescriptionAsShort(ictConstraint.isA);
+      short = short ? `${ictConstraint.isA.name}: ${short}` : ictConstraint.isA.name;
+      slice.short = sliceDf.short = short;
       slice.definition = sliceDf.definition = this.getDescription(ictConstraint.isA, ictConstraint.isA.name);
       let [valueSnapshotEl, valueDifferentialEl] = this.findConstrainableElement(sourceValue, profile, slice);
 
@@ -3706,7 +3710,9 @@ class FHIRExporter {
 
       // "Personalize" the base slice to this specific element
       if (typeof sourceValue !== 'undefined' && sourceValue instanceof mdls.IdentifiableValue) {
-        ssSliceSection[0].short = dfSliceSection[0].short = sourceValue.effectiveIdentifier.name;
+        let short = this.getDescriptionAsShort(sourceValue.effectiveIdentifier);
+        short = short ? `${sourceValue.effectiveIdentifier.name}: ${short}` : sourceValue.effectiveIdentifier.name;
+        ssSliceSection[0].short = dfSliceSection[0].short = short;
         ssSliceSection[0].definition = dfSliceSection[0].definition =
           this.getDescription(sourceValue.effectiveIdentifier, sourceValue.effectiveIdentifier.name);
       }

--- a/lib/export.js
+++ b/lib/export.js
@@ -710,6 +710,10 @@ class FHIRExporter {
     // don't want sentences shorter than that anyway.
     let i = 2;
     for (i=str.indexOf('.', i); i !== -1 && i < str.length; i = str.indexOf('.', i+1)) {
+      // If the '.' is part of 'e.g.', 'i.e.', or 'vs.', skip it -- it's not the end of the sentence.
+      // Otherwise if the '.' is followed by optional spaces and a newline, OR if it is followed by
+      // one or more spaces and a capital letter or number, consider the '.' as the end of the sentence.
+      // Also allow the " character to account for quoted sentences where the '.' is inside the quote.
       const surrounding = str.slice(i-1, i+3);
       if ( surrounding === 'e.g.' || surrounding === 'i.e.') {
         i += 2;
@@ -721,8 +725,11 @@ class FHIRExporter {
       }
     }
     if (i === -1) {
+      // Even though it was > 140 characters, it's all just one sentence, so keep the whole thing.
       return str;
     }
+    // Truncate after the '.', but then check for unbalanced " marks because we might have truncated
+    // inside a quoted phrase.  Balance the " marks by adding one at the end if necessary.
     const truncated = str.slice(0, i+1);
     const dqMatches = truncated.match(/"/g) || [];
     return dqMatches.length % 2 === 0 ? truncated : `${truncated}"`;

--- a/lib/export.js
+++ b/lib/export.js
@@ -680,6 +680,36 @@ class FHIRExporter {
     return description;
   }
 
+  getDescriptionAsShort(identifier, defaultText) {
+    let description = this.getDescription(identifier, defaultText);
+    // Play by twitter rules (maybe somewhat less than arbitrary?)
+    if (description == null || description.length <= 140) {
+      // If it's a single sentence, remove the last '.', per normal style in FHIR docs
+      if (description.indexOf('.') === description.lastIndexOf('.') && description.lastIndexOf('.') === (description.length-1)) {
+        description = description.slice(0, -1);
+      }
+      return description;
+    }
+    // Try to truncate it at the end of a sentence.
+    if (/\.\s/.test(description)) {
+      description = description.slice(0, description.search(/\.\s/));
+    }
+    // If it's still > 140 characters, truncate it at a newline, if applicable
+    if (description.length > 140 && description.indexOf('\n') > 0) {
+      description = description.slice(0, description.indexOf('\n'));
+    }
+    // If it's still > 140 characters, truncate it at the last word before 140 and add ...
+    if (description.length > 140) {
+      let i;
+      for (i = 137; i >= 0 && !(/\s/.test(description[i])); i--);
+      if (i === 0) {
+        i = 137; // just in case there are no spaces!
+      }
+      description = description.slice(0, i) + '...';
+    }
+    return description;
+  }
+
   /**
    * Returns an array of code objects representing the concepts associated with an SHR DataElement definition
    * @param {Object} identifier - the SHR Identifier representinf the data element defining its concepts
@@ -1681,6 +1711,9 @@ class FHIRExporter {
       return;
     }
 
+    const originalShort = snapshotEl.short;
+    const originalDefinition = snapshotEl.definition;
+
     // If this is mapped from the element's value, make the definition refer to the element's definition
     if (def.description && rule.sourcePath.length === 1 && def.value) {
       const id = rule.sourcePath[0];
@@ -1690,18 +1723,40 @@ class FHIRExporter {
         || (val.options && val.aggregateOptions.some(o => id.equals(o.identifier) || id.equals(o.effectiveIdentifier)));
       if (isElementValue) {
         const desc = `${common.capitalize(common.valueName(val))} representing ${common.lowerFirst(common.trim(def.description))}`;
-        snapshotEl.definition = differentialEl.definition = desc;
+        snapshotEl.short = differentialEl.short = this.getDescriptionAsShort(def.identifier, def.identifier.name);
+        if (originalDefinition !== desc) {
+          snapshotEl.definition = differentialEl.definition = desc;
+        }
       }
     }
 
     // If the original short definition was an enumeration, we should try to replace it if possible
-    if (snapshotEl.short && snapshotEl.short.indexOf('|') !== -1) {
+    if (originalShort && originalShort.indexOf('|') !== -1) {
       // Only replace it if we provide a value set constraint
       if (sourceValue.constraintsFilter.own.valueSet.hasConstraints) {
         const vsURL = sourceValue.constraintsFilter.own.valueSet.constraints[0].valueSet;
         const short = this.getShortFromValueSet(vsURL);
-        if (short) {
+        if (short && originalShort !== short) {
           snapshotEl.short = differentialEl.short = short;
+          // Note: Only change the definition if we've changed the short
+          const definition = this.getDefinitionFromValueSet(vsURL);
+          if (definition && originalDefinition !== definition) {
+            snapshotEl.definition = differentialEl.definition = definition;
+          }
+        }
+      }
+    } else if (sourceValue.constraintsFilter.own.type.hasConstraints) {
+      // If original short has not changed yet, and we have a single source identifier, update it
+      const sourceIdentifier = common.choiceFriendlyEffectiveIdentifier(sourceValue);
+      if (sourceIdentifier && snapshotEl.definition === originalDefinition) {
+        const description = this.getDescription(sourceIdentifier);
+        if (description != null && description !== originalDefinition) {
+          snapshotEl.short = this.getDescriptionAsShort(sourceIdentifier);
+          if (snapshotEl.short !== originalShort) {
+            differentialEl.short = snapshotEl.short;
+          }
+          // Update definition last to maintain order of short, definition
+          snapshotEl.definition = differentialEl.definition = description;
         }
       }
     }
@@ -1713,32 +1768,52 @@ class FHIRExporter {
     let short;
     if (vsURL.startsWith('http://hl7.org/fhir/ValueSet' || vsURL.startsWith('urn:tbd'))) {
       // It's an HL7 or TBD VS.  Just leave what's there in place...
-    } else if (vsURL.startsWith('http://standardhealthrecord.org')) {
-      // It's an SHR value set, so we can be smart about constructing a short
-      const items = [];
-      const vs = this._specs.valueSets.findByURL(vsURL);
-      for (const r of vs.rules) {
-        if (r instanceof mdls.ValueSetIncludesCodeRule) {
-          items.push(r.code.code);
-        } else if (r instanceof mdls.ValueSetIncludesDescendentsRule) {
-          items.push(`descendents of ${r.code.code}`);
-        } else if (r instanceof mdls.ValueSetExcludesDescendentsRule) {
-          items.push(`not descendents of ${r.code.code}`);
-        } else if (r instanceof mdls.ValueSetIncludesFromCodeRule) {
-          items.push(`codes from ${r.code.code}`);
-        } else if (r instanceof mdls.ValueSetIncludesFromCodeSystemRule) {
-          items.push(`codes from ${r.system}`);
+    } else {
+      if (vsURL.startsWith(this._config.projectURL)) {
+        // It's an CIMPL-defined value set, so we can be smart about constructing a short
+        const items = [];
+        const vs = this._specs.valueSets.findByURL(vsURL);
+        if (vs) {
+          for (const r of vs.rules) {
+            if (r instanceof mdls.ValueSetIncludesCodeRule) {
+              items.push(r.code.code);
+            } else if (r instanceof mdls.ValueSetIncludesDescendentsRule) {
+              items.push(`descendents of ${r.code.code}`);
+            } else if (r instanceof mdls.ValueSetExcludesDescendentsRule) {
+              items.push(`not descendents of ${r.code.code}`);
+            } else if (r instanceof mdls.ValueSetIncludesFromCodeRule) {
+              items.push(`codes from ${r.code.code}`);
+            } else if (r instanceof mdls.ValueSetIncludesFromCodeSystemRule) {
+              items.push(`codes from ${r.system}`);
+            }
+          }
+          short = items.slice(0, 5).join(' | ');
+          if (items.length > 5) {
+            short += ' | ...';
+          }
         }
       }
-      short = items.slice(0, 5).join(' | ');
-      if (items.length > 5) {
-        short += ' | ...';
+
+      if (short == null) {
+        // It's an external value set, so just reference it
+        short = `codes from ${vsURL}`;
       }
-    } else {
-      // It's an external value set, so just reference it
-      short = `codes from ${vsURL}`;
     }
     return common.trim(short);
+  }
+
+  getDefinitionFromValueSet(vsURL) {
+    let definition;
+    if (vsURL.startsWith('http://hl7.org/fhir/ValueSet' || vsURL.startsWith('urn:tbd'))) {
+      // It's an HL7 or TBD VS.  Just leave what's there in place...
+    } else if (vsURL.startsWith(this._config.projectURL)) {
+      // It's a CIMPL-defined value set, so we can be smart about constructing a short
+      const vs = this._specs.valueSets.findByURL(vsURL);
+      if (vs && vs.description && vs.description.length > 0) {
+        definition = vs.description;
+      }
+    }
+    return common.trim(definition);
   }
 
   knownMappingIssue(lhs, rhs, sourcePath, value, types) {
@@ -2874,7 +2949,7 @@ class FHIRExporter {
         id: `${baseCoding.id}:${sliceName}`,
         path: baseCoding.path,
         [MVH.nameOfEdSliceName(profile)]: sliceName,
-        short: common.trim(code.display),
+        short: code.display ? common.trim(code.display) : baseCoding.short,
         definition: code.display ? common.trim(code.display) : common.trim(baseCoding.definition),
         min: 1, // We're fixing the coding, so make it 1..1
         max: '1', // We're fixing the coding, so make it 1..1
@@ -3131,7 +3206,7 @@ class FHIRExporter {
         MVH.setEdSliceName(profile, ssEl, common.shortID(identifier));
         MVH.setEdSliceName(profile, dfEl, common.shortID(identifier));
       }
-      // If it already has a definition, just keep it as is since we shouldn't be chaning semantic meaning
+      // If it already has a definition, just keep it as is since we shouldn't be changing semantic meaning
       if (typeof ssEl.definition === 'undefined') {
         dfEl.definition = ssEl.definition = this.getDescription(identifier, identifier.name);
       }

--- a/lib/export.js
+++ b/lib/export.js
@@ -682,32 +682,50 @@ class FHIRExporter {
 
   getDescriptionAsShort(identifier, defaultText) {
     let description = this.getDescription(identifier, defaultText);
+    if (description == null) {
+      return description;
+    }
+
+    const firstSentence = this.getFirstSentence(description);
+
     // Play by twitter rules (maybe somewhat less than arbitrary?)
-    if (description == null || description.length <= 140) {
-      // If it's a single sentence, remove the last '.', per normal style in FHIR docs
-      if (description.indexOf('.') === description.lastIndexOf('.') && description.lastIndexOf('.') === (description.length-1)) {
-        description = description.slice(0, -1);
+    if (description.length <= 140) {
+      if (description === firstSentence && description.slice(-1) === '.') {
+        // Remove the trailing '.' if it's only one sentence, as that seems to be how FHIR does shorts
+        return description.slice(0, description.length-1);
       }
       return description;
     }
-    // Try to truncate it at the end of a sentence.
-    if (/\.\s/.test(description)) {
-      description = description.slice(0, description.search(/\.\s/));
+
+    // If we got here, then the description is > 140 chars, so use first sentence
+    if (firstSentence.slice(-1) === '.') {
+      // Remove the trailing '.' if it's only one sentence, as that seems to be how FHIR does shorts
+      return firstSentence.slice(0, firstSentence.length-1);
     }
-    // If it's still > 140 characters, truncate it at a newline, if applicable
-    if (description.length > 140 && description.indexOf('\n') > 0) {
-      description = description.slice(0, description.indexOf('\n'));
-    }
-    // If it's still > 140 characters, truncate it at the last word before 140 and add ...
-    if (description.length > 140) {
-      let i;
-      for (i = 137; i >= 0 && !(/\s/.test(description[i])); i--);
-      if (i === 0) {
-        i = 137; // just in case there are no spaces!
+    return firstSentence;
+  }
+
+  getFirstSentence(str) {
+    // Start at index 2.  This allows us to skip some index checks in the logic, and we
+    // don't want sentences shorter than that anyway.
+    let i = 2;
+    for (i=str.indexOf('.', i); i !== -1 && i < str.length; i = str.indexOf('.', i+1)) {
+      const surrounding = str.slice(i-1, i+3);
+      if ( surrounding === 'e.g.' || surrounding === 'i.e.') {
+        i += 2;
+        continue;
+      } else if (str.slice(i-2, i+1) === 'vs.') {
+        continue;
+      } else if (/^\.(([\s"]*\n)|([\s"]+[A-Z0-9]))/.test(str.slice(i))) {
+        break;
       }
-      description = description.slice(0, i) + '...';
     }
-    return description;
+    if (i === -1) {
+      return str;
+    }
+    const truncated = str.slice(0, i+1);
+    const dqMatches = truncated.match(/"/g) || [];
+    return dqMatches.length % 2 === 0 ? truncated : `${truncated}"`;
   }
 
   /**


### PR DESCRIPTION
This PR introduces changes that carry over descriptions for elements with substitutions to FHIR's `short` and `definition` fields.  It also includes changes that add description data to the `short` field for slices.

To test it, ensure all branches are on `master` except this one (`descriptions2`), and that they are yarn linked.  Then run the shr-cli:
```
node . -c ig-odh-config.json ../shr_spec/spec/
```

Publish the FHIR IG (`yarn ig:publish` on a network w/out proxy) and inspect the results.  A few expected results are shown below with old IG on the left and new IG on the right.

**CombatZonePeriod Profile**
Note that `valuePeriod` now shows a specific description in the differential view.
![image](https://user-images.githubusercontent.com/2278253/59806177-7c1b0600-92c1-11e9-8e2a-28801d910c98.png)

**UsualWork Profile**
Note that the component slices no longer just say the name of the element but also provide a description.
![image](https://user-images.githubusercontent.com/2278253/59806297-e2078d80-92c1-11e9-8f6e-d519b7b69f2f.png)

