### PR TITLE
Reduce publication errors

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -3435,9 +3435,13 @@ class FHIRExporter {
   }
 
   lookupProfile(identifier, createIfNeeded=true, warnIfProfileIsProcessing=false) {
+    const mapping = this._specs.maps.findByTargetAndIdentifier(this._target, identifier);
+    const targetItem = common.TargetItem.parse(mapping.targetItem);
+    if (targetItem.hasNoProfileCommand()) {
+      return this.lookupStructureDefinition(targetItem.target);
+    }
     let p = this._profilesMap.get(common.fhirID(identifier));
     if (typeof p === 'undefined' && createIfNeeded) {
-      const mapping = this._specs.maps.findByTargetAndIdentifier(this._target, identifier);
       if (typeof mapping !== 'undefined') {
         // Warning -- there CAN be a circular dependency here -- so watch out!  I warned you...
         p = this.mappingToProfile(mapping);

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -5,7 +5,7 @@ const common = require('./common');
 const load = require('./load');
 const MVH = require('./multiVersionHelper');
 
-let logger = bunyan.createLogger({name: 'shr-fhir-export'});;
+let logger = bunyan.createLogger({name: 'shr-fhir-export'});
 function setLogger(bunyanLogger) {
   logger = bunyanLogger;
 }

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -325,7 +325,12 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   default:            fhirSpecURLBase = 'http://hl7.org/fhir/R4/'; break;
   }
   for (let profile of fhirResults.profiles) {
+    // Identifiers and mappings are needed for ES6 class generation, but we don't want them in the
+    // IG profiles because:
+    // (a) the IG publisher reports errors when we use the canonical URL as the identifier system
+    // (b) the mappings create tons of diffs where nothing meaningful has actually changed
     profile = removeSHRMappings(profile);
+    delete profile.identifier;
 
     fs.writeFileSync(path.join(sdPath, `structuredefinition-${profile.id}.json`), JSON.stringify(profile, null, 2), 'utf8');
     igControl.resources[`StructureDefinition/${profile.id}`] = {
@@ -428,7 +433,12 @@ ${match[1]}
   && (config.implementationGuide.primarySelectionStrategy.strategy === 'namespace');
 
   for (let extension of fhirResults.extensions.sort(byName)) {
+    // Identifiers and mappings are needed for ES6 class generation, but we don't want them in the
+    // IG profiles because:
+    // (a) the IG publisher reports errors when we use the canonical URL as the identifier system
+    // (b) the mappings create tons of diffs where nothing meaningful has actually changed
     extension = removeSHRMappings(extension);
+    delete extension.identifier;
 
     // We added extensions by their use in primary profiles, but now check if
     // it is eligible due to its namespace or fully qualifier name (based on strategy)
@@ -483,7 +493,7 @@ ${match[1]}
   fhirResults.valueSets.sort(byName);
   const vsPath = path.join(outDir, 'resources');
   fs.ensureDirSync(vsPath);
-  for (const valueSet of fhirResults.valueSets) {
+  for (let valueSet of fhirResults.valueSets) {
     if (usingNamespaceStrategy) {
       const inNamespace = config.implementationGuide.primarySelectionStrategy.primary.some((p) => {
         return MVH.vsIdentifier(valueSet).some((i) => {
@@ -507,6 +517,12 @@ ${match[1]}
         }
       }
     }
+
+    // Identifiers are needed for filtering (above) and ES6 class generation, but we don't want
+    // them in the IG profiles because the IG publisher reports errors when we use the canonical
+    // URL as the identifier system
+    valueSet = common.cloneJSON(valueSet);
+    delete valueSet.identifier;
 
     fs.writeFileSync(path.join(vsPath, `valueset-${valueSet.id}.json`), JSON.stringify(valueSet, null, 2), 'utf8');
     igControl.resources[`ValueSet/${valueSet.id}`] = {
@@ -551,7 +567,7 @@ ${match[1]}
     fhirResults.codeSystems.sort(byName);
     const csPath = path.join(outDir, 'resources');
     fs.ensureDirSync(csPath);
-    for (const codeSystem of fhirResults.codeSystems) {
+    for (let codeSystem of fhirResults.codeSystems) {
       if (usingNamespaceStrategy) {
         const inNamespace = config.implementationGuide.primarySelectionStrategy.primary.some((p) => {
           return MVH.csIdentifier(codeSystem).some((i) => {
@@ -562,6 +578,12 @@ ${match[1]}
           primaryCodeSystemUrls.add(codeSystem.url);
         }
       }
+
+      // Identifiers are needed for filtering (above) and ES6 class generation, but we don't want
+      // them in the IG profiles because the IG publisher reports errors when we use the canonical
+      // URL as the identifier system
+      codeSystem = common.cloneJSON(codeSystem);
+      delete codeSystem.identifier;
 
       fs.writeFileSync(path.join(csPath, `codesystem-${codeSystem.id}.json`), JSON.stringify(codeSystem, null, 2), 'utf8');
       igControl.resources[`CodeSystem/${codeSystem.id}`] = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This contains two primary changes:
* Remove `identifier` from profiles and extensions when creating the IG resources
    * These are not required and the IG Publisher didn't like them
* Fix broken references to non-existent profiles
    * When we map using `(no profile)`, then no profile is created -- but references were still being made to them.  Now the references go to the base resources instead.

This was primarily tested against the `ig-mcode-r4-config.json` config in the `dev6-mCODE-noprofile` branch of shr_spec.

Making this a DRAFT PR so that I can bump the version number after its approval.