### PR TITLE
Add fixed value constraints for strings

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2198,6 +2198,7 @@ class FHIRExporter {
     }
     this.applyOwnIncludesCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnBooleanConstraints(sourceValue, profile, snapshotEl, differentialEl);
+    this.applyOwnFixedValueConstraints(sourceValue, profile, snapshotEl, differentialEl);
     if (isExtension) {
       this.applyOwnIncludesTypeConstraintsOnExtension(sourceValue, profile, snapshotEl, differentialEl);
     }
@@ -2259,6 +2260,7 @@ class FHIRExporter {
           this.applyOwnCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnIncludesCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnBooleanConstraints(childSourceValue, profile, element, diffElement);
+          this.applyOwnFixedValueConstraints(childSourceValue, profile, element, diffElement);
           if (childSourceValue.constraintsFilter.includesType.hasConstraints) {
             logger.warn('Nested include types are currently not supported when applied to extensions');
           }
@@ -3034,6 +3036,19 @@ class FHIRExporter {
       this.fixValueOnElement(profile, snapshotEl, differentialEl, boolValue, 'boolean');
       if (boolConstraints.length > 1) {
         logger.error('Found more than one boolean to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13036', snapshotEl.id);
+      }
+    }
+  }
+
+  applyOwnFixedValueConstraints(sourceValue, profile, snapshotEl, differentialEl) {
+    const fixedConstraints = sourceValue.constraintsFilter.own.fixedValue.constraints;
+    if (fixedConstraints.length > 0) {
+      [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
+      const value = fixedConstraints[0].value;
+      const type = fixedConstraints[0].type;
+      this.fixValueOnElement(profile, snapshotEl, differentialEl, value, type);
+      if (fixedConstraints.length > 1) {
+        logger.error('Found more than one value to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13036', snapshotEl.id);
       }
     }
   }


### PR DESCRIPTION
Added `applyOwnFixedValueConstraints` function to `export.js`, and calls to this function. Currently only works for strings.