### PR TITLE
2019 ballot edition

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -2499,7 +2499,7 @@ class FHIRExporter {
           && e.type && e.type.some(t => MVH.typeHasProfile(t, url));
       });
     }
-    if (typeof el === undefined) {
+    if (el == null) {
       logger.error('Failed to resolve path from %s to %s. ERROR_CODE:13026', snapshotEl.id, shrPath);
       return;
     }

--- a/lib/export.js
+++ b/lib/export.js
@@ -2168,10 +2168,12 @@ class FHIRExporter {
     }
     // As a *very* special (and unfortunate) case, we must special-case quantity.  Essentially, the problem is that
     // Quantity maps Units[concept] onto itself, so the constraints on Units[concept] need to be applied to Quantity instead.
-    if (new mdls.Identifier('shr.core', 'Quantity').equals(sourceValue.identifier) || new mdls.Identifier('shr.core', 'Quantity').equals(common.choiceFriendlyEffectiveIdentifier(sourceValue))) {
+    const choiceFriendlyId = common.choiceFriendlyEffectiveIdentifier(sourceValue);
+    if ((sourceValue.identifier && sourceValue.identifier.isQuantity) || (choiceFriendlyId && choiceFriendlyId.isQuantity)) {
+      const quantityNS = (sourceValue.identifier && sourceValue.identifier.isQuantity) ? sourceValue.identifier.namespace : choiceFriendlyId.namespace;
       // Move all constraints from Units[concept] to the Quantity, but first -- clone!
       sourceValue = sourceValue.clone();
-      const unitsConceptCsts = sourceValue.constraintsFilter.withPath([new mdls.Identifier('shr.core', 'Units'), new mdls.PrimitiveIdentifier('concept')]).constraints;
+      const unitsConceptCsts = sourceValue.constraintsFilter.withPath([new mdls.Identifier(quantityNS, 'Units'), new mdls.PrimitiveIdentifier('concept')]).constraints;
       for (const cst of unitsConceptCsts) {
         cst.path = [];
       }
@@ -2436,9 +2438,9 @@ class FHIRExporter {
     // As a *very* special (and unfortunate) case, we must special-case quantity.  Essentially, the problem is that
     // Quantity maps Units[concept] onto itself, so the paths for Units[concept] need to be applied to Quantity instead.
     // E.g., system and code are actually at the *root* of Quantity
-    if (new mdls.Identifier('shr.core', 'Quantity').equals(rootIdentifier)) {
+    if (rootIdentifier && rootIdentifier.isQuantity) {
       // Change path from Units[concept] to empty...
-      if (shrPath.length >= 2 && new mdls.Identifier('shr.core', 'Units').equals(shrPath[0]) && new mdls.PrimitiveIdentifier('concept').equals(shrPath[1])) {
+      if (shrPath.length >= 2 && new mdls.Identifier(rootIdentifier.namespace, 'Units').equals(shrPath[0]) && new mdls.PrimitiveIdentifier('concept').equals(shrPath[1])) {
         return this.findTargetFHIRPath(rootIdentifier, shrPath.slice(2));
       }
     }

--- a/lib/export.js
+++ b/lib/export.js
@@ -4022,7 +4022,7 @@ class FHIRExporter {
       // Allow this for "base" classes
       if (!profile.id.endsWith(`-${MVH.sdType(profile)}`)) {
         if (!def._isAbstract) {
-          logger.warn('The \'%s\' property is not bound to a value set, fixed to a code, or fixed to a quantity unit. This property is core to the target resource and usually should be constrained. ERROR_CODE:03006', path);
+          logger.info('The \'%s\' property is not bound to a value set, fixed to a code, or fixed to a quantity unit. This property is core to the target resource and usually should be constrained. ERROR_CODE:03006', path);
         } else {
           logger.info('Abstract Class: The \'%s\' property is not bound to a value set or fixed to a code. This property is core to the target resource and usually should be constrained.', path);
         }

--- a/lib/export.js
+++ b/lib/export.js
@@ -159,9 +159,6 @@ class FHIRExporter {
         // First remove the namespaces from the slice names so the id is shorter
         // e.g., replace shr-core-SystolicBP with SystolicBP
         element.id = element.id.replace(/:([a-z][^\-.:]*-)+([A-Z][^\-.:]*)/g, ':$2');
-        // Then remove the profile name from the root element (again, keeping id shorter)
-        // e.g., replace Observation:BloodPressure with Observation
-        element.id = element.id.replace(/^([A-Z][a-z]+):([^.:]+)/m, '$1');
         // Remove all []() characters
         element.id = element.id.replace(/[[\]()]/g, '');
         // Replace all other unsupported characters with -
@@ -328,7 +325,6 @@ class FHIRExporter {
 
       // Modify the snapshot elements as appropriate
       for (const ssEl of profile.snapshot.element) {
-        ssEl.id = ssEl.id.replace(new RegExp(/^[^.]+/m), `${MVH.sdType(profile)}:${profileID}`);
         // Don't carry over the examples since they might be irrelevant to the specific profile use case.
         // (Also, some of the examples in STU 3.0.1 cause invariant violations!)
         delete(ssEl.example);
@@ -2583,7 +2579,7 @@ class FHIRExporter {
           }
         } else if (bind.strength == 'extensible') {
           if (!this.isValueSetSubsetOfOther(vsURI, bindVSURI)) {
-            if (this._config.showDuplicateErrors || !this.shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath)) {
+            if (this._config.showDuplicateErrors || !this.shouldConsiderSnapshotElementVSConstraintDuplicate(profile, snapshotEl, sourcePath)) {
               logger.warn('Overriding extensible value set constraint from %s to %s.  Only allowed when new codes do not overlap meaning of old codes. ERROR_CODE:03003', bindVSURI, vsURI);
               // this is technically allowed, so don't return yet -- just continue...
             }
@@ -2676,13 +2672,12 @@ class FHIRExporter {
     Inheritance is determined by matching sourcePath of the mapping with fields from
     the mapped element, and determining inheritance status at each level of depth
   */
-  shouldConsiderSnapshotElementVSConstraintDuplicate(snapshotEl, sourcePath) {
+  shouldConsiderSnapshotElementVSConstraintDuplicate(profile, snapshotEl, sourcePath) {
     var vscIsDuplicate = false;
 
-    const snapshotElFqn = snapshotEl.id.match(/\w*:((\w*-)+[A-za-z0-9-]*).*/)[1];
-    const snapshotElNameIndex = snapshotElFqn.search(/-[A-Z]/);
-    const snapshotElNamespace = snapshotElFqn.slice(0, snapshotElNameIndex).replace(/-/g, '.');
-    const snapshotElName = snapshotElFqn.slice(snapshotElNameIndex + 1);
+    const snapshotElNameIndex = profile.id.search(/-[A-Z]/);
+    const snapshotElNamespace = profile.id.slice(0, snapshotElNameIndex).replace(/-/g, '.');
+    const snapshotElName = profile.id.slice(snapshotElNameIndex + 1);
     const snapshotElID = { 'name': snapshotElName, 'namespace': snapshotElNamespace };
     const snapshotDataElement = this._specs.dataElements.findByIdentifier(snapshotElID);
 
@@ -2697,7 +2692,7 @@ class FHIRExporter {
         let matchedField;
         const combinedFieldsAndValue = (currEl.fields && currEl.value) ? [currEl.value, ...currEl.fields] : (currEl.fields) ? currEl.fields : [currEl.value]; //potentially more thorough than current implentation, although tests show no difference
 
-        if (snapshotEl.id.split(':').length == 2) { //This is used to determine whether or not this is an 'includesType' slice. Includes type slices have two ':' paths
+        if (snapshotEl.id.split(':').length > 0) { //This is used to determine whether or not this is an 'includesType' slice. Includes type slices have at least one ':' path
           //Handle normal slices
 
           //Find the field on the element

--- a/lib/export.js
+++ b/lib/export.js
@@ -2198,6 +2198,7 @@ class FHIRExporter {
     }
     this.applyOwnIncludesCodeConstraints(sourceValue, profile, snapshotEl, differentialEl);
     this.applyOwnBooleanConstraints(sourceValue, profile, snapshotEl, differentialEl);
+    this.applyOwnFixedValueConstraints(sourceValue, profile, snapshotEl, differentialEl);
     if (isExtension) {
       this.applyOwnIncludesTypeConstraintsOnExtension(sourceValue, profile, snapshotEl, differentialEl);
     }
@@ -2259,6 +2260,7 @@ class FHIRExporter {
           this.applyOwnCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnIncludesCodeConstraints(childSourceValue, profile, element, diffElement);
           this.applyOwnBooleanConstraints(childSourceValue, profile, element, diffElement);
+          this.applyOwnFixedValueConstraints(childSourceValue, profile, element, diffElement);
           if (childSourceValue.constraintsFilter.includesType.hasConstraints) {
             logger.warn('Nested include types are currently not supported when applied to extensions');
           }
@@ -3034,6 +3036,19 @@ class FHIRExporter {
       this.fixValueOnElement(profile, snapshotEl, differentialEl, boolValue, 'boolean');
       if (boolConstraints.length > 1) {
         logger.error('Found more than one boolean to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13036', snapshotEl.id);
+      }
+    }
+  }
+
+  applyOwnFixedValueConstraints(sourceValue, profile, snapshotEl, differentialEl) {
+    const fixedConstraints = sourceValue.constraintsFilter.own.fixedValue.constraints;
+    if (fixedConstraints.length > 0) {
+      [snapshotEl, differentialEl] = this.findConstrainableElement(sourceValue, profile, snapshotEl, differentialEl);
+      const value = fixedConstraints[0].value;
+      const type = fixedConstraints[0].type;
+      this.fixValueOnElement(profile, snapshotEl, differentialEl, value, type);
+      if (fixedConstraints.length > 1) {
+        logger.error('Found more than one value to fix on %s. This should never happen and is probably a bug in the tool. ERROR_CODE:13036', snapshotEl.id);
       }
     }
   }

--- a/lib/export.js
+++ b/lib/export.js
@@ -3469,7 +3469,7 @@ class FHIRExporter {
         p = this.mappingToProfile(basicMapping);
       }
     } else if (warnIfProfileIsProcessing && this._processTracker.isActive(identifier)) {
-      logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(identifier));
+      logger.debug('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(identifier));
     }
     // If this is really a no-diff profile, then return the base structuredef instead!
     if (typeof p !== 'undefined' && !common.isCustomProfile(p)) {
@@ -3483,7 +3483,7 @@ class FHIRExporter {
     const profile = this._profilesMap.get(id);
     if (typeof profile !== 'undefined') {
       if (warnIfStructureDefinitionIsProcessing && this._processTracker.isActive(id)) {
-        logger.warn('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(id));
+        logger.debug('Using profile that is currently in the middle of processing: %s. ERROR_CODE:13054', common.fhirID(id));
       }
       // If this is really a no-diff profile, then return the base structuredef instead!
       if (!common.isCustomProfile(profile)) {

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -102,9 +102,6 @@ class ExtensionExporter {
     } else {
       delete(ext.description);
     }
-    for (const ssEl of ext.snapshot.element) {
-      ssEl.id = ssEl.id.replace(new RegExp(/^[^.]+/m), `Extension:${common.shortID(def.identifier)}`);
-    }
 
     return ext;
   }

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -395,6 +395,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
       }
     }
 
+    // Create the CIMPL to FHIR Mapping Includes File
     const mapRegExp = /^.*<pre>([^]*)<\/pre>.*$/mg;
     const match = mapRegExp.exec(profile.text.div);
     const mapPath = path.join(outDir, 'pages', '_includes', `${profile.id}-cameo-mapping.xhtml`);
@@ -488,6 +489,56 @@ ${match[1]}
         </tr>
         `);
     }
+
+    // Create the Extension Usage Includes File
+    const usagePath = path.join(outDir, 'pages', '_includes', `${extension.id}-usage.xhtml`);
+    const getUsesInStructDefs = (structDefs) => {
+      const usages = [];
+      structDefs.forEach(profile => {
+        // Look through each of the snapshot elements for elements whose path ends with extension or modifierExtension
+        // and who list this extension as the extension type.
+        const usagePaths = new Set();
+        profile.snapshot.element.forEach(ssEl => {
+          // If it's an extension path and we haven't already recorded it (i.e., we don't want duplicates)...
+          if (/\.(modifierE|e)xtension$/.test(ssEl.path) && !usagePaths.has(ssEl.path)) {
+            if (ssEl.type && ssEl.type.some(t => t.code === 'Extension' && MVH.typeHasProfile(t, extension.url))) {
+              usagePaths.add(ssEl.path);
+              usages.push({
+                name: profile.name,
+                id: profile.id,
+                path: ssEl.path
+              })
+            }
+          }
+        });
+      });
+      return usages;
+    }
+    const profileUses = getUsesInStructDefs(fhirResults.profiles);
+    const extensionUses = getUsesInStructDefs(fhirResults.extensions);
+    let usageSnippet = '';
+    if (profileUses.length > 0) {
+      usageSnippet = '<h4>Usage</h4>\n\n' +
+      '<p>This extension is used in the following profiles:</p>' +
+      '<ul>\n' +
+      profileUses.map(u => {
+        const on = u.path.slice(u.path.indexOf('.')+1, u.path.lastIndexOf('.'));
+        return `  <li><a href="StructureDefinition-${u.id}.html">${u.name}</a>${on.length > 0 ? ` (on <tt>${on}</tt>)` : ''}</li>\n`;
+      }).join('') +
+      '</ul>\n';
+    }
+    if (extensionUses.length > 0) {
+      if (usageSnippet.length === 0) {
+        usageSnippet = '<h4>Usage</h4>\n\n';
+      } else {
+        usageSnippet += '\n';
+      }
+      usageSnippet += '<p>This extension is used in the following complex extensions:</p>' +
+      '<ul>\n' +
+      extensionUses.map(u => `  <li><a href="StructureDefinition-${u.id}.html">${u.name}</a></li>\n`).join('') +
+      '</ul>\n\n';
+    }
+    fs.writeFileSync(usagePath, usageSnippet, 'utf8');
   }
 
   fhirResults.valueSets.sort(byName);

--- a/lib/ig_files/sd-extension.html
+++ b/lib/ig_files/sd-extension.html
@@ -118,6 +118,11 @@ This extension was published on {{ site.data.structuredefinitions.{{[id]}}.date 
 <a name="inv"> </a>
 {%include {{[type]}}-{{[id]}}-inv.xhtml%}
 
+<p>&nbsp;</p>
+
+<a name="usg"> </a>
+{%include {{[id]}}-usage.xhtml%}
+
 <!-- ==============END CONTENT END CONTENT=================== -->
 
 {% include container-end.html %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-fhir-export",
-  "version": "6.1.3",
+  "version": "6.2.0",
   "description": "Exports SHR data elements from SHR models to FHIR profiles",
   "author": "",
   "license": "Apache-2.0",
@@ -26,12 +26,12 @@
     "chai": "^3.5.0",
     "eslint": "^6.0.1",
     "mocha": "^6.1.4",
-    "shr-models": "standardhealth/shr-models#cm_sprint_41",
+    "shr-models": "^6.2.0",
     "shr-test-helpers": "^6.0.0"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^6.0.0"
+    "shr-models": "^6.2.0"
   },
   "resolutions": {
     "brace-expansion": "^1.1.11"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^3.5.0",
     "eslint": "^6.0.1",
     "mocha": "^6.1.4",
-    "shr-models": "^6.0.0",
+    "shr-models": "standardhealth/shr-models#cm_sprint_41",
     "shr-test-helpers": "^6.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,10 +1171,9 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shr-models@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0.tgz#6ffe6a48ae6bcf6c20e25dbfcc5b2954fca7d661"
-  integrity sha512-k8tU/YghNoFdpHxzC1ZpfpHMEMAJPZyGGAMd9QfOcCqDsETUyK9u76GuXoSlhXHjDM5CXOCeq6LmxWCQhK95iw==
+shr-models@standardhealth/shr-models#cm_sprint_41:
+  version "6.1.0"
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/020a549c5b52f2c06a23d63a120a179c6510a381"
 
 shr-test-helpers@^6.0.0:
   version "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,9 +1171,10 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shr-models@standardhealth/shr-models#cm_sprint_41:
-  version "6.1.0"
-  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/020a549c5b52f2c06a23d63a120a179c6510a381"
+shr-models@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.2.0.tgz#1f66f3bc8a16c15328607e5b05a99cf7a3bc53fe"
+  integrity sha512-h7u7PpKuxd5epy+cMHzjnGAesPo/GmtQnUjeZHMuIfoNzJ82mrvMpZ8P3EdiKLD+y12nMzCX54wg8iAjDmzO5g==
 
 shr-test-helpers@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This PR adds the following features:
* support for fixed strings (from CIMPL models)
* support for `obf.datatype.Quantity` (w/ backwards compatibility for `shr.core.Quantity`)
* show extension usage on extension pages in the IG
* remove profile identifier from root snapshot/differential ids (addresses issue reported in standardhealth/shr-cli#221)
* demote a some errors to lower levels
* fix a crash due to trying to dereference a null pointer in some cases
* upgrade to the latest IG Publisher jar.