### PR TITLE
Move selecting primary profiles to content profile

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -3385,6 +3385,10 @@ class FHIRExporter {
     // Iterate the rules one at a time
     for (const cpr of cp.rules) {
 
+      if (cpr.primaryProfile || cpr.noProfiles) {
+        continue;
+      }
+
       // Each rule has a path of SHR element identifiers.  Use these to try to find the corresponding
       // FHIR element in the profile.  To do this, we'll re-use the SHR mappings that are stored for
       // the ES6 exporter (since they map SHR paths to FHIR elements). This may not get us all the way,

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -269,6 +269,23 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
       logger.error('Hybrid strategy requires config.implementationGuide.primarySelectionStrategy.primary to be an array');
     }
   }
+  else if (specifications.contentProfiles.all.length > 0) {
+    let primary = []
+     for (const cp of specifications.contentProfiles.all) {
+       for (const cpr of cp.rules) {
+         // Proces element as primaryProfile if it is in ContentProfile
+         if (cpr.primaryProfile) {
+            primary.push(cp.identifier.fqn);
+         }
+       }
+     }
+    if (Array.isArray(primary)) {
+      isPrimaryFn = (id) => {
+        const element = idToElementMap.get(id);
+        return element && (/-extension$/.test(id) || element.isEntry) && ((primary.indexOf(element.identifier.name) != -1) || (primary.indexOf(element.identifier.namespace) != -1) || (primary.indexOf(element.identifier.fqn) != -1));
+      };
+    }
+  }
   if (isPrimaryFn == null) {
     // If strategy is "entry" or default, set every entry as primary
     // But... don't ever return true for extensions when this strategy is used;
@@ -428,8 +445,9 @@ ${match[1]}
   };
   fs.copySync(patchPath, sdPath, { filter: filterFunc });
 
-  const hideSupporting = config.implementationGuide.primarySelectionStrategy
-  && config.implementationGuide.primarySelectionStrategy.hideSupporting;
+  const hideSupporting = (config.implementationGuide.primarySelectionStrategy
+  && config.implementationGuide.primarySelectionStrategy.hideSupporting)
+  || config.implementationGuide.hideSupporting;
 
   const usingNamespaceStrategy = config.implementationGuide.primarySelectionStrategy
   && (config.implementationGuide.primarySelectionStrategy.strategy === 'namespace');

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -270,16 +270,16 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
     }
   }
   else if (specifications.contentProfiles.all.length > 0) {
-    let primary = []
-     for (const cp of specifications.contentProfiles.all) {
-       for (const cpr of cp.rules) {
-         // Proces element as primaryProfile if it is in ContentProfile
-         if (cpr.primaryProfile) {
-            primary.push(cp.identifier.fqn);
-         }
-       }
-     }
-    if (Array.isArray(primary)) {
+    const primary = [];
+    for (const cp of specifications.contentProfiles.all) {
+      for (const cpr of cp.rules) {
+        // Process element as primaryProfile if it is in ContentProfile
+        if (cpr.primaryProfile) {
+          primary.push(cp.identifier.fqn);
+        }
+      }
+    }
+    if (primary.length > 0) {
       isPrimaryFn = (id) => {
         const element = idToElementMap.get(id);
         return element && (/-extension$/.test(id) || element.isEntry) && ((primary.indexOf(element.identifier.name) != -1) || (primary.indexOf(element.identifier.namespace) != -1) || (primary.indexOf(element.identifier.fqn) != -1));
@@ -447,7 +447,7 @@ ${match[1]}
 
   const hideSupporting = (config.implementationGuide.primarySelectionStrategy
   && config.implementationGuide.primarySelectionStrategy.hideSupporting)
-  || config.implementationGuide.hideSupporting;
+  || config.implementationGuide.showPrimaryOnly;
 
   const usingNamespaceStrategy = config.implementationGuide.primarySelectionStrategy
   && (config.implementationGuide.primarySelectionStrategy.strategy === 'namespace');


### PR DESCRIPTION
Selecting primary profiles in the configuration file is still supported and will override content profile selections, but a warning will be issued.
PR 4/5