### PR TITLE
Add link to download full specification

### DIFF
--- a/lib/ig_files/pages/downloads.html
+++ b/lib/ig_files/pages/downloads.html
@@ -23,6 +23,7 @@
 
 <h3>Downloads</h3>
 <ul>
+  <li><a href="full-ig.zip">Full Specification [ZIP]</a></li>
   <li><a href="definitions.json.zip">JSON Definitions [ZIP]</a></li>
   <li><a href="examples.json.zip">JSON Examples [ZIP]</a></li>
   <li><a href="definitions.xml.zip">XML Definitions [ZIP]</a></li>


### PR DESCRIPTION
The IG Publisher generates the `full-ig.zip` file already -- we just needed to link to it.

You can test this by running the CLI against any config and running the FHIR IG Publisher.  The "Full Specification [ZIP]" link on the downloads page should download a zip file.  Unzip it and open index.html inside -- and you have (another) local copy of the IG.