### PR TITLE
Workaround for bug in shr-expand

### DIFF
--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -481,6 +481,22 @@ class ModelsExporter {
       // TODO: Log this
     }
 
+    // This lenientFindChild function is a temporary stop-gap while a bug in shr-expand allows (and even requires)
+    // constraint paths to reference original element names instead of substituted ones. It tries to find a child
+    // by name, but if it can't find it, and if there is only one child -- then it assumes that one child is the
+    // one you are looking for (since it couldn't be any other).  This stop-gap should be removed once the shr-expand
+    // bug is fixed.  See: https://standardhealthrecord.atlassian.net/browse/CIMPL-72
+    const lenientFindChild = (el, path, resolver) => {
+      let child = el.findChild(path, resolver);
+      if (child == null) {
+        const directChildren = el.children().filter(c => c.id.split('.').slice(0, -1).join('.') === el.id);
+        if (directChildren.length === 1) {
+          child = directChildren[0];
+        }
+      }
+      return child;
+    };
+
     if (!constraint.onValue && (constraint.path == null || constraint.path.length == 0)) {
       // It is a direct constraint, make the type null (indicating it is a "section header")
       el.type = undefined;
@@ -509,7 +525,7 @@ class ModelsExporter {
       // Walk the path, making each part a backbone element until we get to the "section header"
       for (let i=0; i < elPath.length; i++) {
         // NOTE: this also unfolds all of the child elements
-        const child = currentEl.findChild(elPath[i], this.resolve.bind(this));
+        const child = lenientFindChild(currentEl, elPath[i], this.resolve.bind(this));
         currentEl.type = [{ code: 'BackboneElement' }];
         // Since we're now inlining this element anonymously, we need to reset all the `base` properties
         currentEl.resetBase();
@@ -541,7 +557,7 @@ class ModelsExporter {
     }
     if (constraint.path.length > 0) {
       const fhirPath = this.shrPathToFhirPath(value, constraint.path);
-      const valueChildEl = el.findChild(fhirPath, this.resolve.bind(this));
+      const valueChildEl = lenientFindChild(el, fhirPath, this.resolve.bind(this));
       const valueConstraint = new mdls.IncludesTypeConstraint(constraint.isA.clone(), constraint.card.clone());
       let listValue;
       if (constraint.path.length == 0) {


### PR DESCRIPTION
Implements a temporary work-around for a bug in shr-expand (that cannot be easily fixed at the moment).  See: https://standardhealthrecord.atlassian.net/browse/CIMPL-72

To test:
* First run the CLI without this fix against the `ig-all-r4-config.json` and note 1 error
    * Also note that `out/logical/vital-VitalSignsPanel-model.json` does NOT exist
* Then run it with this fix and note the error went away
    * Also note that `out/logical/vital-VitalSignsPanel-model.json` DOES exist