### PR TITLE
Fix processing on slice by number rules

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -954,10 +954,10 @@ class FHIRExporter {
       let isDuplicate = false;
       // Iterate the rules looking for ones with the same root sourcePath but a different "in slice" vsalue
       for (const rule of map.rules) {
-        if (rule.sourcePath.length >= sliceNumRule.sourcePath.length && pathsAreEqual(sliceNumRule.sourcePath, rule.sourcePath.slice(0, sliceNumRule.sourcePath.length))) {
+        if (rule.sourcePath && rule.sourcePath.length >= sliceNumRule.sourcePath.length && pathsAreEqual(sliceNumRule.sourcePath, rule.sourcePath.slice(0, sliceNumRule.sourcePath.length))) {
           const ft = FieldTarget.parse(rule.target);
           if (ft.hasInSliceCommand() && ft.findInSliceCommand() !== sliceNumSliceName) {
-            isDuplicate = true;
+            isDuplicate = rule.sourcePath.length === sliceNumRule.sourcePath.length;
             // Create a new FieldTarget with the updated "in slice"
             const newFT = new FieldTarget(ft.target, ft.commands.filter(c => c.key !== 'in slice'), ft.comments);
             newFT.addInSliceCommand(sliceNumSliceName);


### PR DESCRIPTION
This fixes a few minor issues w/ slice by number rules that only showed up in shr-es6-export tests. This did not affect the generation of *any* of the current CIMPL definitions.