### PR TITLE
Extending search parameters page

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -774,10 +774,7 @@ ${match[1]}
         pushXmlResource(`${exResource.resourceType}/${exResource.id}`, name, 'example');
 
         if (exResource.resourceType === 'SearchParameter') {
-          let baseTypes = exResource.base;
-          if (exResource.base.constructor === Array) {
-            baseTypes = exResource.base.join(', ');
-          }
+          const baseTypes = Array.isArray(exResource.base) ? exResource.base.join(', ') : exResource.base;
           htmlRows.push(
             `<tr>
               <td><a href="${exResource.resourceType}-${exResource.id}.html">${exResource.code}</a></td>

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -774,7 +774,10 @@ ${match[1]}
         pushXmlResource(`${exResource.resourceType}/${exResource.id}`, name, 'example');
 
         if (exResource.resourceType === 'SearchParameter') {
-          const baseTypes = exResource.base.join(", ");
+          let baseTypes = exResource.base;
+          if (exResource.base.constructor === Array) {
+            baseTypes = exResource.base.join(', ');
+          }
           htmlRows.push(
             `<tr>
               <td><a href="${exResource.resourceType}-${exResource.id}.html">${exResource.code}</a></td>

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -773,12 +773,24 @@ ${match[1]}
         // See: https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/DSTU.20ig.2Exml.20package.2Eresource.2Epurpose.20for.20SearchParameters/near/168272354
         pushXmlResource(`${exResource.resourceType}/${exResource.id}`, name, 'example');
 
-        htmlRows.push(
-          `<tr>
-            <td><a href="${exResource.resourceType}-${exResource.id}.html">${name}</a></td>
-            <td>${markdownifiedText(exResource.description)}</td>
-          </tr>
-        `);
+        if (exResource.resourceType === 'SearchParameter') {
+          const baseTypes = exResource.base.join(", ");
+          htmlRows.push(
+            `<tr>
+              <td><a href="${exResource.resourceType}-${exResource.id}.html">${exResource.code}</a></td>
+              <td>${baseTypes}</td>
+              <td>${exResource.type}</td>
+              <td>${markdownifiedText(exResource.description)}</td>
+            </tr>`
+          );
+        } else {
+          htmlRows.push(
+            `<tr>
+              <td><a href="${exResource.resourceType}-${exResource.id}.html">${name}</a></td>
+              <td>${markdownifiedText(exResource.description)}</td>
+            </tr>
+          `);
+        }
       } catch (e) {
         // 13127, 'Invalid extra resource.  Resource must be valid JSON: ${resourcePath}.', 'Remove invalid JSON resource.', 'errorNumber'
         logger.error({ resourcePath: rscFilePath }, '13127');

--- a/lib/ig_files/pages/searchparameters.html
+++ b/lib/ig_files/pages/searchparameters.html
@@ -31,7 +31,13 @@
         <b>Name</b>
       </td>
       <td>
-        <b>Definition</b>
+        <b>Base Resources</b>
+      </td>
+      <td>
+        <b>Type</b>
+      </td>
+      <td>
+        <b>Description</b>
       </td>
     </tr>
   </thead>


### PR DESCRIPTION
This updates the search parameter page to have fields for "Name", "Base Resources", "Type", and "Description". This addresses CIMPL-58: https://standardhealthrecord.atlassian.net/projects/CIMPL/issues/CIMPL-58?filter=allopenissues&orderby=priority%20DESC. 
The new search parameters page has the format below.
![Capture (1)](https://user-images.githubusercontent.com/52747882/64959075-6d130800-d85e-11e9-902d-65be606a251e.PNG).
