### PR TITLE
Add non-boolean fixed values in logical models

### DIFF
--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -641,6 +641,37 @@ class ElementDefinition {
   }
 
   /**
+   * Fixes a fixed value to the element or a child of the element indicated by the path.  If the target element is
+   * in a deeper path than currently represented in the structure definition, parent level elements will be "expanded"
+   * (or "unrolled") based on their definition.  This means that calling this function may result in increasing the
+   * number of elements in the structure definition.
+   * @param {boolean} value - the fixed value to fix
+   * @param {string} [path] - if the fixed should be fixed to a child element, the dot-separated path of that element
+   * @param {function({code: string, profile?: string[], targetProfile?: string[], aggregation?: string[], versioning?: string}):StructureDefinition} [resolve] - a function that can resolve a type to a StructureDefinition instance
+   * @returns {ElementDefinition} the element to which the value was fixed (may be a child of the current element)
+   */
+  fixFixedValue(value, path, resolve) {
+    if (path && path.length > 0) {
+      const child = this.findChild(path, resolve);
+      if (child) {
+        return child.fixFixedValue(value, null, resolve);
+      }
+      return;
+    }
+
+    // This is the element to fix it to
+    // Get the type that we are fixing and capitalize the first letter
+    const lowercaseType = this.type[0].code;
+    const uppercaseType = lowercaseType.charAt(0).toUpperCase() + lowercaseType.slice(1);
+    this[`fixed${uppercaseType}`] = value;
+    if (this.min === 0 && this.max !== '0') {
+      this.min = 1;
+    }
+
+    return this;
+  }
+
+  /**
    * Modifies the cardinality of the element or a child of the element indicated by the path.  If the target element is
    * in a deeper path than currently represented in the structure definition, parent level elements will be "expanded"
    * (or "unrolled") based on their definition.  This means that calling this function may result in increasing the

--- a/lib/logical/ElementDefinition.js
+++ b/lib/logical/ElementDefinition.js
@@ -650,11 +650,11 @@ class ElementDefinition {
    * @param {function({code: string, profile?: string[], targetProfile?: string[], aggregation?: string[], versioning?: string}):StructureDefinition} [resolve] - a function that can resolve a type to a StructureDefinition instance
    * @returns {ElementDefinition} the element to which the value was fixed (may be a child of the current element)
    */
-  fixFixedValue(value, path, resolve) {
+  fixValue(value, path, resolve) {
     if (path && path.length > 0) {
       const child = this.findChild(path, resolve);
       if (child) {
-        return child.fixFixedValue(value, null, resolve);
+        return child.fixValue(value, null, resolve);
       }
       return;
     }

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -245,6 +245,9 @@ class ModelsExporter {
     for (const c of value.constraintsFilter.boolean.constraints) {
       this.applyBooleanConstraint(model, value, el, c);
     }
+    for (const c of value.constraintsFilter.fixedValue.constraints) {
+      this.applyFixedValueConstraint(model, value, el, c);
+    }
 
     // If the value is a choice, then there may be constraints on the individual options
     if (value instanceof mdls.ChoiceValue) {
@@ -345,6 +348,18 @@ class ModelsExporter {
    */
   applyBooleanConstraint(model, value, el, constraint) {
     el.fixBoolean(constraint.value, this.shrPathToFhirPath(value, constraint.path), this.resolve.bind(this));
+  }
+
+  /**
+   * Applies a fixed constraint to the given element or to a child of the element when the constraint specifies
+   * a sub-path.
+   * @param {StructureDefinition} model - the StructureDefinition to which this constraint should be applied
+   * @param {Object} value - the SHR Value object that defined this constraint
+   * @param {ElementDefinition} el - the ElementDefinition corresponding to the SHR Value Object
+   * @param {Object} constraint - the constraint to apply
+   */
+  applyFixedValueConstraint(model, value, el, constraint) {
+    el.fixFixedValue(constraint.value, this.shrPathToFhirPath(value, constraint.path), this.resolve.bind(this));
   }
 
   /**

--- a/lib/logical/export.js
+++ b/lib/logical/export.js
@@ -359,7 +359,7 @@ class ModelsExporter {
    * @param {Object} constraint - the constraint to apply
    */
   applyFixedValueConstraint(model, value, el, constraint) {
-    el.fixFixedValue(constraint.value, this.shrPathToFhirPath(value, constraint.path), this.resolve.bind(this));
+    el.fixValue(constraint.value, this.shrPathToFhirPath(value, constraint.path), this.resolve.bind(this));
   }
 
   /**


### PR DESCRIPTION
This adds support for showing fixed values in the logical models. Currently only booleans can be fixed. This PR is related to https://github.com/standardhealth/shr-expand/pull/47, where the need for it is discussed.