### PR TITLE
Add Examples tab

### DIFF
--- a/lib/ig.js
+++ b/lib/ig.js
@@ -834,22 +834,21 @@ ${match[1]}
     if (examplesList.length > 0) {
       // Add the example to the HTML
       examplesList.sort((a, b) => a.resourceType.localeCompare(b.resourceType));
+      // Get a list of profiles for testing links
+      const linkableProfiles = fhirResults.profiles.map(p => p.url);
       for (const example of examplesList) {
-        let trimmedProfiles = [];
+        let profileStrings = [];
         if (example.meta != null) {
-          // Get profile names trimmed down to just namespace-name
-          trimmedProfiles = example.meta.profile.map(profile => profile.slice(profile.lastIndexOf('/') + 1));
+          profileStrings = example.meta.profile.map(profile => {
+            // Get a human readable version of the profile
+            const trimmedProfile = profile.slice(profile.lastIndexOf('/') + 1);
+            if (linkableProfiles.indexOf(profile) > -1) {
+              return `<a href="StructureDefinition-${trimmedProfile}.html">${trimmedProfile}</a>`;
+            } else {
+              return `${trimmedProfile}`;
+            }
+          });
         }
-        // Build up a set of links to profiles
-        const profileStrings = trimmedProfiles.map(profile => {
-          // If profile is internal to the IG, link to it. Otherwise, do not give a link
-          const linkableProfiles = fhirResults.profiles.map(p => p.id);
-          if (linkableProfiles.indexOf(profile) > -1) {
-            return `<a href="StructureDefinition-${profile}.html">${profile}</a>`;
-          } else {
-            return `${profile}`;
-          }
-        });
         const profileString = profileStrings.join(', ');
         htmlExamples.push(
           `

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -52,6 +52,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   const htmlOperationDefinitions = [];
   const htmlCapabilityStatements = [];
   const htmlConformances = [];
+  const htmlExamples = [];
 
   const isHL7IG = config.fhirURL && /^https?:\/\/([^/]+\.)?(hl7|fhir)\.org\//.test(config.fhirURL);
 
@@ -800,6 +801,7 @@ ${match[1]}
     igExamplesPath = path.join(specPath, 'fhir_examples');
   }
   if (igExamplesPath) {
+    const examplesList = [];
     igControl.paths.resources.push('examples');
     const outExamplesFolder = path.join(outDir, 'examples');
     fs.ensureDirSync(outExamplesFolder);
@@ -824,8 +826,40 @@ ${match[1]}
         };
         // Add the resource to the XML
         pushXmlResource(`${example.resourceType}/${example.id}`, `Example: ${example.id}`, 'example');
+        examplesList.push(example);
       } catch (e) {
         console.warn('Invalid example.  Example must be valid JSON:', exFilePath, e);
+      }
+    }
+    if (examplesList.length > 0) {
+      // Add the example to the HTML
+      examplesList.sort((a, b) => a.resourceType.localeCompare(b.resourceType));
+      for (const example of examplesList) {
+        let trimmedProfiles = [];
+        if (example.meta != null) {
+          // Get profile names trimmed down to just namespace-name
+          trimmedProfiles = example.meta.profile.map(profile => profile.slice(profile.lastIndexOf('/') + 1));
+        }
+        // Build up a set of links to profiles
+        const profileStrings = trimmedProfiles.map(profile => {
+          // If profile is internal to the IG, link to it. Otherwise, do not give a link
+          const linkableProfiles = fhirResults.profiles.map(p => p.id);
+          if (linkableProfiles.indexOf(profile) > -1) {
+            return `<a href="StructureDefinition-${profile}.html">${profile}</a>`;
+          } else {
+            return `${profile}`;
+          }
+        });
+        const profileString = profileStrings.join(', ');
+        htmlExamples.push(
+          `
+          <tr>
+            <td><a href="${example.resourceType}-${example.id}.html">${example.resourceType}-${example.id}</a></td>
+            <td><a href="${fhirSpecURLBase}${example.resourceType.toLowerCase()}.html">${example.resourceType}</a></td>
+            <td>${profileString}</td>
+          </tr>
+          `
+        );
       }
     }
   }
@@ -1013,6 +1047,12 @@ ${match[1]}
   let updatedConformancesHtml = conformancesHtml.replace('<conformances-go-here/>', htmlConformances.join(''));
   fs.writeFileSync(conformancesHtmlPath, updatedConformancesHtml, 'utf8');
 
+  // Rewrite the update Examples HTML file
+  const examplesHtmlPath = path.join(outDir, 'pages', 'examples.html');
+  const examplesHtml = fs.readFileSync(examplesHtmlPath, 'utf8');
+  let updatedExamplesHtml = examplesHtml.replace('<examples-go-here/>', htmlExamples.join(''));
+  fs.writeFileSync(examplesHtmlPath, updatedExamplesHtml, 'utf8');
+
   const navbarPath = path.join(outDir, 'pages', '_includes', 'navbar.html');
   let navbarHtml = fs.readFileSync(navbarPath, 'utf8');
   if (!config.implementationGuide.includeLogicalModels) {
@@ -1048,6 +1088,10 @@ ${match[1]}
     navbarHtml = navbarHtml.replace(historyItem, `<li><a href="${config.implementationGuide.historyLink.trim()}">History</a></li>`);
   } else {
     navbarHtml = navbarHtml.replace(historyItem, '');
+  }
+  if (htmlExamples.length === 0) {
+    const examplesItem = '<li><a href="examples.html">Examples</a></li>';
+    navbarHtml = navbarHtml.replace(examplesItem, '<!-- no examples -->')
   }
   fs.writeFileSync(navbarPath, navbarHtml);
 }

--- a/lib/ig_files/pages/_includes/navbar.html
+++ b/lib/ig_files/pages/_includes/navbar.html
@@ -49,6 +49,7 @@
             <li><a href="capabilitystatements.html">Capability Statements</a></li>
             <li><a href="downloads.html">Downloads</a></li>
             <li><a href="modeldoc.html">Reference Model</a></li>
+            <li><a href="examples.html">Examples</a></li>
             <history-link-goes-here/>
           </ul>
 

--- a/lib/ig_files/pages/examples.html
+++ b/lib/ig_files/pages/examples.html
@@ -1,0 +1,49 @@
+---
+# jekyll header
+---
+{% include header.html %}
+
+<!-- ============BreadCrumb=============== -->
+<div id="segment-breadcrumb" class="segmnt">
+  <!-- segment-breadcrumb -->
+  <div class="container">
+    <!-- container -->
+    <ul class="breadcrumb">
+      <li title="home"><a href="index.html"><b>Home</b></a></li>
+      <li><b>Examples</b></li>
+    </ul>
+  </div>
+  <!-- /container -->
+</div>
+<!-- /segment-breadcrumb -->
+
+{% include container-start.html %}
+
+<!-- ============CONTENT CONTENT=============== -->
+
+<h2>
+    Examples defined as part of this Implementation Guide
+</h2>
+<table class="codes">
+  <thead>
+    <tr>
+      <td>
+        <b>Example</b>
+      </td>
+      <td>
+        <b>ResourceType</b>
+      </td>
+      <td>
+        <b>Profiles</b>
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <examples-go-here/>
+  </tbody>
+</table>
+
+<!-- ==============END CONTENT END CONTENT=================== -->
+
+{% include container-end.html %}
+{% include footer.html %}


### PR DESCRIPTION
This adds an "Examples" tab to the IG that gives a global list of all examples in the IG. They are listed by the filename of the example, the resourceType, and the profiles that are listed in `meta.profile`, as shown below. This addresses CIMPL-60: https://standardhealthrecord.atlassian.net/projects/CIMPL/issues/CIMPL-60?filter=allopenissues&orderby=priority%20DESC.
![Capture](https://user-images.githubusercontent.com/52747882/65162332-109f1c80-da07-11e9-813f-1b365fc6ff87.PNG)
