### PR TITLE
Remove support for Entry/_Entry keywords

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -12,7 +12,6 @@ const {ModelsExporter} = require('./logical/export');
 const {exportIG} = require('./ig');
 
 const TARGETS = ['FHIR_DSTU_2', 'FHIR_STU_3', 'FHIR_R4'];
-const ENTRY_ID = new mdls.Identifier('shr.base', 'Entry');
 const CONCEPT_ID = new mdls.PrimitiveIdentifier('concept');
 
 // The following two constants toggle advanced developer features, usually not needed
@@ -619,8 +618,8 @@ class FHIRExporter {
     let map = this._unmappedPaths.get(def.identifier.fqn);
     for (let i=0; i < sourcePath.length; i++) {
       const p = sourcePath[i];
-      // For now, don't deal with _Entry.* or _Concept.*
-      if (p.isEntryKeyWord || p.isConceptKeyWord) {
+      // For now, don't deal with _Concept.*
+      if (p.isConceptKeyWord) {
         return;
       } else if (i == sourcePath.length-1) {
         map.set('_has_mapped_children', true);
@@ -3945,17 +3944,8 @@ class FHIRExporter {
     // Find the value at the root of the path
     let value = this.findValueByIdentifier(path[0], fieldsToSearch);
 
-    // Some special case logic for '_Entry' or _Concept (implicit fields)
-    if (typeof value === 'undefined' && path[0].isEntryKeyWord) {
-      if (path.length == 1) {
-        // This is the end of the path, so just give them a 1..1 Entry
-        return new mdls.IdentifiableValue(ENTRY_ID).withMinMax(1, 1);
-      }
-      // Bump everything down a level, as if the search was on Entry (not the parent)
-      def = this._specs.dataElements.findByIdentifier(ENTRY_ID);
-      path = path.slice(1);
-      value = this.findValueByIdentifier(path[0], common.valueAndFields(def));
-    } else if (typeof value === 'undefined' && path[0].isConceptKeyWord) {
+    // Some special case logic for _Concept (implicit field)
+    if (typeof value === 'undefined' && path[0].isConceptKeyWord) {
       if (path.length == 1) {
         // This is the end of the path, so just give them a 1..1 CodeableConcept
         const conceptValue = new mdls.IdentifiableValue(CONCEPT_ID).withMinMax(1, 1);

--- a/lib/export.js
+++ b/lib/export.js
@@ -4119,12 +4119,12 @@ class FHIRExporter {
           parentProfile = this.lookupProfile(def.basedOn[0]);
         }
 
-          //Hide warning if the parent profile is also Basic (avoid duplicates through inheritance)
-          //Override and show warning anyway if the parent is abstract, as children of abstract should show message
-          //Also show warning if there is no warning
-          //a. No Parent
-          //b. The parent is abstract
-          //b. The parent type isn't also basic (avoid duplicate error message) AND the parent isn't abstract (show children of abstracts even if duplicate)
+        //Hide warning if the parent profile is also Basic (avoid duplicates through inheritance)
+        //Override and show warning anyway if the parent is abstract, as children of abstract should show message
+        //Also show warning if there is no warning
+        //a. No Parent
+        //b. The parent is abstract
+        //b. The parent type isn't also basic (avoid duplicate error message) AND the parent isn't abstract (show children of abstracts even if duplicate)
         if (!parentProfile || MVH.sdType(parentProfile) != 'Basic' || parent.isAbstract) {
           // 03004, 'Element profiled on Basic. Consider a more specific mapping.', 'The Basic profile should not be used in most cases. Consider a more specific profile mapping that categorizes the Element being mapped.', 'errorNumber'
           logger.warn('03004');


### PR DESCRIPTION
"Entryness" affects implementations of data elements, but should not automatically add special fields to the model itself.  As such, there is no longer any valid need for Entry/_Entry keywords.

This is PR 6 of 7 in the overall effort to remove the need for the shr.base.Entry element.

1. shr-models (standardhealth/shr-models#49)
2. shr-text-import (standardhealth/shr-text-import#110)
3. shr-expand (standardhealth/shr-expand#49)
4. shr-json-javadoc (standardhealth/shr-json-javadoc#28)
5. shr-json-schema-export (standardhealth/shr-json-schema-export#17)
6. shr-fhir-export
7. shr-es6-export (standardhealth/shr-es6-export#60)