### PR TITLE
Handling FHIR deps

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -48,7 +48,7 @@ class FHIRExporter {
   constructor(specifications, configuration = {}) {
     this._specs = specifications;
     this._target = common.getTarget(configuration, this._specs);
-    this._fhir = load(this._target);
+    this._fhir = load(this._target, configuration);
     this._codeSystemExporter = new CodeSystemExporter(this._specs, this._fhir, configuration);
     this._valueSetExporter = new ValueSetExporter(this._specs, this._fhir, configuration);
     this._extensionExporter = new ExtensionExporter(this, this._specs, this._fhir, this._target, configuration);
@@ -4466,7 +4466,7 @@ function allowedBindingStrengthChange(originalStrength, newStrength) {
 //
 // NOTE: This function is used by shr-expand to properly allow inheritance of mappings.  For example, if
 // A is based on B, and A maps to X and B maps to Y -- then A inherits B's mappings IFF X has Y as a parent
-function isTargetBasedOn(target, baseTarget, targetSpec) {
+function isTargetBasedOn(target, baseTarget, targetSpec, configuration) {
   if (typeof target === 'undefined' || typeof baseTarget === 'undefined') {
     return false;
   } else if (target === baseTarget) {
@@ -4474,7 +4474,7 @@ function isTargetBasedOn(target, baseTarget, targetSpec) {
     return true;
   }
 
-  const defs = load(targetSpec);
+  const defs = load(targetSpec, configuration);
 
   // The target has two possible identifiers: the id and the url -- so we need to test against them both.
   // It also has two possible fields identifying its based on: type and baseDefinition, so we need those too.

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -56,6 +56,15 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
 
   const isHL7IG = config.fhirURL && /^https?:\/\/([^/]+\.)?(hl7|fhir)\.org\//.test(config.fhirURL);
 
+  // Load in external dependencies
+  if (config.implementationGuide.dependencies != null) {
+    for (const dep of config.implementationGuide.dependencies) {
+      // File location does not need to go into ig.json
+      const {fileLocation, ...igJSONDep} = dep;
+      igControl.dependencyList.push(igJSONDep);
+    }
+  }
+
   // Update igControl version and dependency list if applicable
   if (target === 'FHIR_DSTU_2') {
     igControl.version = '1.0.2';
@@ -77,21 +86,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
       location: 'http://hl7.org/fhir/us/core',
       version: '1.0.1'
     }];
-    if (config.implementationGuide.dependencies != null) {
-      for (const dep of config.implementationGuide.dependencies) {
-        // File location does not need to go into ig.json
-        const {fileLocation, ...igJSONDep} = dep;
-        igControl.dependencyList.push(igJSONDep);
-      }
-    }
   } else if (target === 'FHIR_R4') {
-    if (config.implementationGuide.dependencies != null) {
-      for (const dep of config.implementationGuide.dependencies) {
-        // File location does not need to go into ig.json
-        const {fileLocation, ...igJSONDep} = dep;
-        igControl.dependencyList.push(igJSONDep);
-      }
-    }
     // Use the US Core 4.0.0 "current" version already specified in ig.json
   }
 

--- a/lib/ig.js
+++ b/lib/ig.js
@@ -26,7 +26,7 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
   }
 
   // Load the FHIR definitions
-  const fhir = load(target);
+  const fhir = load(target, config);
 
   // Copy the static parts of the IG
   fs.copySync(path.join(__dirname, 'ig_files'), outDir);
@@ -77,7 +77,21 @@ function exportIG(specifications, fhirResults, outDir, configuration = {}, specP
       location: 'http://hl7.org/fhir/us/core',
       version: '1.0.1'
     }];
+    if (config.implementationGuide.dependencies != null) {
+      for (const dep of config.implementationGuide.dependencies) {
+        // File location does not need to go into ig.json
+        const {fileLocation, ...igJSONDep} = dep;
+        igControl.dependencyList.push(igJSONDep);
+      }
+    }
   } else if (target === 'FHIR_R4') {
+    if (config.implementationGuide.dependencies != null) {
+      for (const dep of config.implementationGuide.dependencies) {
+        // File location does not need to go into ig.json
+        const {fileLocation, ...igJSONDep} = dep;
+        igControl.dependencyList.push(igJSONDep);
+      }
+    }
     // Use the US Core 4.0.0 "current" version already specified in ig.json
   }
 

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,6 +1,6 @@
 const common = require('./common');
 const MVH = require('./multiVersionHelper');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 
 const _cache = new Map();
@@ -27,8 +27,9 @@ function load(target, configuration = {}) {
     // Load any other external IGs that have been specified in config
     if (configuration.implementationGuide != null && configuration.implementationGuide.dependencies != null) {
       for (const dep of configuration.implementationGuide.dependencies) {
-        if (fs.existsSync(dep.fileLocation)) {
-          recursiveLoadIGPath(path.normalize(dep.fileLocation), result);
+        const depPath = path.join(configuration.specPath, dep.fileLocation);
+        if (fs.existsSync(depPath)) {
+          recursiveLoadIGPath(depPath, result);
         }
       }
     }
@@ -53,7 +54,7 @@ function recursiveLoadIGPath(filePath, fhirDefinitions) {
       recursiveLoadIGPath(path.join(filePath,file), fhirDefinitions);
     });
   } else if (stat.isFile() && filePath.endsWith('.json')) {
-    fhirDefinitions.add(require(filePath));
+    fhirDefinitions.add(fs.readJsonSync(filePath));
   }
 }
 

--- a/lib/load.js
+++ b/lib/load.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const _cache = new Map();
 
-function load(target, configuration) {
+function load(target, configuration = {}) {
   if (!_cache.has(target)) {
     const result = new FHIRDefinitions(target);
     // Load the base FHIR definitions

--- a/lib/load.js
+++ b/lib/load.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const _cache = new Map();
 
-function load(target) {
+function load(target, configuration) {
   if (!_cache.has(target)) {
     const result = new FHIRDefinitions(target);
     // Load the base FHIR definitions
@@ -24,6 +24,14 @@ function load(target) {
     }
     // Load external IGs (e.g., US Core)
     recursiveLoadIGPath(`${__dirname}/definitions/${target}/IGs`, result);
+    // Load any other external IGs that have been specified in config
+    if (configuration.implementationGuide != null && configuration.implementationGuide.dependencies != null) {
+      for (const dep of configuration.implementationGuide.dependencies) {
+        if (fs.existsSync(dep.fileLocation)) {
+          recursiveLoadIGPath(path.normalize(dep.fileLocation), result);
+        }
+      }
+    }
     // Load our templates
     result.implementationGuideTemplate = fs.readFileSync(`${__dirname}/definitions/${target}/shr-implementationGuide-template.xml`, 'utf8');
     result.extensionTemplate = require(`${__dirname}/definitions/${target}/shr-extension-template.json`);


### PR DESCRIPTION
This is 3 of 3 PRs that add functionality to handle FHIR dependencies specified by the user. The other PRs are:
shr-cli: standardhealth/shr-cli#228
shr-expand: https://github.com/standardhealth/shr-expand/pull/50

The user is required to add the dependencies to the `implementationGuide` object on the configuration file in the following way:
```
"dependencies": [
            {
            "package": "hl7.fhir.uv.vhdir",
            "version": "current",
            "name": "VhDir",
            "location": "http://build.fhir.org/ig/HL7/Vhhir/",
            "fileLocation": "C:/Users/nfreiter/Desktop/VhDir"
            }
        ]
```
The files at the given `fileLocation` will then be loaded, and can be used in the same way as USCore. A reference to the dependency is also added to `ig.json`. 